### PR TITLE
Fix logger error call order

### DIFF
--- a/backend/src/logger.js
+++ b/backend/src/logger.js
@@ -206,11 +206,11 @@ async function setup(state) {
 function logError(state, obj, msg) {
     // Call the original error method with proper typing
     if (state.logger !== null) {
-        state.logger.error(msg, { obj });
+        state.logger.error(obj, msg);
     } else {
         // Fallback to console if logger is not initialized
         console.error("Logger not initialized");
-        console.error(msg, { obj });
+        console.error(obj, msg);
     }
 
     // Send notification


### PR DESCRIPTION
## Summary
- fix logError so object/context is passed before message

## Testing
- `npm test`
- `npm run static-analysis`


------
https://chatgpt.com/codex/tasks/task_e_684224eb367c832ea2a238a5fdb4669f