### PR TITLE
Fix CLI error handling

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -54,7 +54,10 @@ async function entry() {
 
 // Set up the command line interface with commander
 if (require.main === module) {
-    entry();
+    entry().catch((err) => {
+        console.error(err);
+        process.exit(1);
+    });
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary
- exit on CLI failures to avoid unhandled Promise rejections

## Testing
- `npm test`
- `npm run static-analysis`


------
https://chatgpt.com/codex/tasks/task_e_68422c0748dc832eb610d086d7155c82