### PR TITLE
Fix diary.js JSDoc asset description

### DIFF
--- a/backend/src/diary.js
+++ b/backend/src/diary.js
@@ -162,7 +162,7 @@ async function processDiaryAudios(capabilities) {
  * Writes changes to the event log by appending entries for successfully
  * transcribed diary audio files.
  * @param {Capabilities} capabilities - An object containing the capabilities.
- * @param {Asset} ass - An array of TranscriptionSuccess objects.
+ * @param {Asset} ass - The processed diary audio asset to record.
  * @returns {Promise<void>} - A promise that resolves when the changes are written.
  */
 async function writeAsset(capabilities, ass) {


### PR DESCRIPTION
## Summary
- update `writeAsset` JSDoc in `backend/src/diary.js` to correctly describe the `ass` parameter

## Testing
- `npm install`
- `npm test`
- `npm run static-analysis`


------
https://chatgpt.com/codex/tasks/task_e_68422c0c0474832e8a38cb4b37189529