### PR TITLE
Fix JSDoc imports for ExistingFile

### DIFF
--- a/backend/src/config/storage.js
+++ b/backend/src/config/storage.js
@@ -24,7 +24,7 @@ const { fromExisting } = require("../filesystem/file");
 /**
  * Reads and deserializes a config.json file
  * @param {Capabilities} capabilities - The capabilities object
- * @param {import("../event_log_storage").ExistingFile} file - Path to the config.json file to read
+ * @param {import("../filesystem/file").ExistingFile} file - Path to the config.json file to read
  * @returns {Promise<import('./structure').Config | null>} The parsed config or null if invalid/missing
  */
 async function readConfig(capabilities, file) {

--- a/backend/src/json_stream_file/index.js
+++ b/backend/src/json_stream_file/index.js
@@ -9,7 +9,7 @@ const { streamValues } = require("stream-json/streamers/StreamValues");
 /**
  * Reads JSON objects from a file using streaming
  * @param {Capabilities} capabilities - The capabilities object
- * @param {import('../event_log_storage').ExistingFile} file - Path to the JSON file to read
+ * @param {import('../filesystem/file').ExistingFile} file - Path to the JSON file to read
  * @returns {Promise<Array<unknown>>} Array of parsed JSON objects
  */
 async function readObjects(capabilities, file) {


### PR DESCRIPTION
## Summary
- fix import paths in JSDoc for `ExistingFile`

## Testing
- `npm test`
- `npm run static-analysis`


------
https://chatgpt.com/codex/tasks/task_e_68422e8c0914832e9c2fde8d0580d219