### PR TITLE
Fix comment typo in Asset class

### DIFF
--- a/backend/src/event/asset.js
+++ b/backend/src/event/asset.js
@@ -19,7 +19,7 @@ class AssetClass {
 
     /**
      * This is a value that is never actually assigned.
-     * Its purpose is to make `RequestIdentifier` a nominal type.
+     * Its purpose is to make `Asset` a nominal type.
      * @type {undefined}
      * @private
      */


### PR DESCRIPTION
## Summary
- fix copy-pasted comment about nominal typing

## Testing
- `npm test`
- `npm run static-analysis`


------
https://chatgpt.com/codex/tasks/task_e_68422c08b940832ebb5aa02f36232367