### PR TITLE
Fix async route handlers

### DIFF
--- a/backend/src/routes/transcribe.js
+++ b/backend/src/routes/transcribe.js
@@ -141,8 +141,8 @@ function makeRouter(capabilities) {
      *    ?input=/absolute/path/to/file.wav
      *    &request_identifier=0x123
      */
-    router.get("/transcribe", (req, res) =>
-        handleTranscribeRequest(capabilities, req, res)
+    router.get("/transcribe", async (req, res) =>
+        await handleTranscribeRequest(capabilities, req, res)
     );
 
     return router;

--- a/backend/src/routes/transcribe_all.js
+++ b/backend/src/routes/transcribe_all.js
@@ -152,8 +152,8 @@ function makeRouter(capabilities) {
      *    ?input_dir=/absolute/path/to/directory
      *    &request_identifier=0x123
      */
-    router.get("/transcribe_all", (req, res) =>
-        handleTranscribeAllRequest(capabilities, req, res)
+    router.get("/transcribe_all", async (req, res) =>
+        await handleTranscribeAllRequest(capabilities, req, res)
     );
 
     return router;


### PR DESCRIPTION
## Summary
- await async handlers in `transcribe` and `transcribe_all` routes

## Testing
- `npm test`
- `npm run static-analysis`


------
https://chatgpt.com/codex/tasks/task_e_68422bfe9cd4832e84495035feee3c73