### PR TITLE
Fix run-tests script to include static analysis

### DIFF
--- a/scripts/run-tests
+++ b/scripts/run-tests
@@ -7,3 +7,4 @@ cd -- "${0%/*}"/..
 set -xe
 
 npm test
+npm run static-analysis


### PR DESCRIPTION
## Summary
- ensure run-tests performs linting & type checking

## Testing
- `npm install`
- `npm test`
- `npm run static-analysis`


------
https://chatgpt.com/codex/tasks/task_e_68422e92f0b8832e9407c8fc9e68010a