### PR TITLE
Fix docs on Termux PWA build step

### DIFF
--- a/docs/PWA_TERMUX_CONFIGURATION.md
+++ b/docs/PWA_TERMUX_CONFIGURATION.md
@@ -4,7 +4,7 @@ This project targets Android devices running [Termux](https://termux.dev/). The 
 
 Key points:
 
-- **injectManifest strategy** – see `frontend/vite.config.js`. The service worker source lives in `frontend/src/sw.js` and is copied as-is during the build.
+- **injectManifest strategy** – see `frontend/vite.config.js`. The service worker source lives in `frontend/src/sw.js` and the precache manifest is injected during the build.
 - **esbuild minify** – the Vite build step uses `esbuild` instead of `terser`.
 
 These adjustments allow the PWA build to complete inside Termux without additional native dependencies.


### PR DESCRIPTION
## Summary
- clarify that the PWA service worker has the precache manifest injected during the build

## Testing
- `npm test`
- `npm run static-analysis`


------
https://chatgpt.com/codex/tasks/task_e_68422e976ec8832e8da5597a8b887e01