### PR TITLE
Fix incorrect console levels in logger fallback

### DIFF
--- a/backend/src/logger.js
+++ b/backend/src/logger.js
@@ -238,7 +238,7 @@ function logWarning(state, obj, msg) {
         state.logger.warn(obj, msg);
     } else {
         // Fallback to console if logger is not initialized
-        console.error("Logger not initialized");
+        console.warn("Logger not initialized");
         console.warn(msg, { obj });
     }
 }
@@ -254,7 +254,7 @@ function logInfo(state, obj, msg) {
         state.logger.info(obj, msg);
     } else {
         // Fallback to console if logger is not initialized
-        console.error("Logger not initialized");
+        console.info("Logger not initialized");
         console.info(msg, { obj });
     }
 }
@@ -270,7 +270,7 @@ function logDebug(state, obj, msg) {
         state.logger.debug(obj, msg);
     } else {
         // Fallback to console if logger is not initialized
-        console.error("Logger not initialized");
+        console.debug("Logger not initialized");
         console.debug(msg, { obj });
     }
 }


### PR DESCRIPTION
## Summary
- ensure fallback messages use the matching console level in `logWarning`, `logInfo`, and `logDebug`

## Testing
- `npm test`
- `npm run static-analysis`

------
https://chatgpt.com/codex/tasks/task_e_68422e9cebc4832e837e7b1976fb4c46