### PR TITLE
Fix random string docs

### DIFF
--- a/backend/src/random/string.js
+++ b/backend/src/random/string.js
@@ -1,4 +1,4 @@
-// Generates a random alphanumeric string with cryptographic quality
+// Generates a random alphanumeric string using a seeded RNG
 
 const { defaultGenerator } = require('./default');
 
@@ -17,7 +17,7 @@ const ALPHANUMERIC_CHARS = '0123456789abcdefghijklmnopqrstuvwxyz';
  * @param {Capabilities} capabilities - An object containing a random number generator.
  * @param {number} [length=16] - The length of the generated string. Must be a positive integer.
  * @returns {string} A random alphanumeric string of specified length.
- * @throws {TypeError} If the length is not a positive integer or rng is invalid.
+ * @throws {TypeError} If the length is not a positive integer.
  */
 function string(capabilities, length = 16) {
     if (!Number.isInteger(length) || length < 1) {


### PR DESCRIPTION
## Summary
- clarify `random.string` docstring to remove mention of cryptographic quality and unused rng parameter

## Testing
- `npm install`
- `npm test`
- `npm run static-analysis`


------
https://chatgpt.com/codex/tasks/task_e_68422ea116c4832e8e479df9986bfad9