### PR TITLE
Fix async pre-check for git availability

### DIFF
--- a/backend/src/runtime_identifier.js
+++ b/backend/src/runtime_identifier.js
@@ -20,7 +20,7 @@ const random = require("./random");
  * @returns {Promise<string>}
  */
 async function getVersion(capabilities) {
-    capabilities.git.ensureAvailable();
+    await capabilities.git.ensureAvailable();
     try {
         const repositoryPath = __dirname;
         const { stdout } = await capabilities.git.call(


### PR DESCRIPTION
## Summary
- await `git.ensureAvailable()` when determining runtime version

## Testing
- `npm test`
- `npm run static-analysis`


------
https://chatgpt.com/codex/tasks/task_e_68423b16d0fc832e8652e797ae1072cb