### PR TITLE
Fix missing await when verifying Git

### DIFF
--- a/backend/src/runtime_identifier.js
+++ b/backend/src/runtime_identifier.js
@@ -20,7 +20,7 @@ const random = require("./random");
  * @returns {Promise<string>}
  */
 async function getVersion(capabilities) {
-    capabilities.git.ensureAvailable();
+    await capabilities.git.ensureAvailable();
     try {
         const repositoryPath = __dirname;
         const { stdout } = await capabilities.git.call(


### PR DESCRIPTION
## Summary
- ensure `getVersion` awaits `git.ensureAvailable`

## Testing
- `npm install`
- `npm test`
- `npm run static-analysis`


------
https://chatgpt.com/codex/tasks/task_e_68423b20842c832e9bc4d2f8866de7b4