### PR TITLE
Fix redundant null check in event deserialization

### DIFF
--- a/backend/src/event/structure.js
+++ b/backend/src/event/structure.js
@@ -188,9 +188,6 @@ function tryDeserialize(obj) {
         if (!eventIdObj || !eventIdObj.identifier) {
             return null;
         }
-        if (!eventIdObj || !eventIdObj.identifier) {
-            return null;
-        }
 
         // Create and return the Event object
         return {


### PR DESCRIPTION
## Summary
- remove duplicate `eventIdObj` check in `tryDeserialize`

## Testing
- `npm test`
- `npm run static-analysis`


------
https://chatgpt.com/codex/tasks/task_e_68423b2afa18832ea3a4bc6bbf6fdf9b