### PR TITLE
Fix FileReader streaming behaviour

### DIFF
--- a/backend/src/filesystem/reader.js
+++ b/backend/src/filesystem/reader.js
@@ -78,9 +78,9 @@ async function readFileAsBuffer(filePath) {
 function createReadStream(file) {
     const fsModule = require("fs");
     try {
-        return fsModule.createReadStream(file.path, {
-            encoding: "utf8",
-        });
+        // Leave encoding undefined so consumers can decide how to interpret the
+        // data. This keeps the reader suitable for both text and binary files.
+        return fsModule.createReadStream(file.path);
     } catch (err) {
         throw new ReaderError(
             `Failed to create read stream: ${file.path}`,


### PR DESCRIPTION
## Summary
- don't force UTF-8 encoding when creating read streams

## Testing
- `npm install`
- `npm test`
- `npm run static-analysis`


------
https://chatgpt.com/codex/tasks/task_e_68423b32b0f8832e8a61840dbce76c93