### PR TITLE
Fix EntryData description docs

### DIFF
--- a/backend/src/entry.js
+++ b/backend/src/entry.js
@@ -37,7 +37,7 @@ const creatorMake = require("./creator");
  * @property {string} original - The original, raw input for the event
  * @property {string} input - The processed input for the event
  * @property {string} type - The type of entry (e.g., "note", "diary", "todo")
- * @property {string} description - The content/description of the entry
+ * @property {string} [description] - The content/description of the entry
  * @property {Record<string, string>} [modifiers] - Additional key-value modifiers
  */
 

--- a/backend/src/event/structure.js
+++ b/backend/src/event/structure.js
@@ -17,7 +17,7 @@ const eventId = require("./id");
  * @property {string} input - The processed input of the event.
  * @property {Modifiers} modifiers - Modifiers applied to the event.
  * @property {string} type - The type of the event.
- * @property {string} description - A description of the event.
+ * @property {string} [description] - A description of the event.
  * @property {Creator} creator - Who created the event.
  */
 
@@ -30,7 +30,7 @@ const eventId = require("./id");
  * @property {string} input - The processed input of the event.
  * @property {Modifiers} modifiers - Modifiers applied to the event.
  * @property {string} type - The type of the event.
- * @property {string} description - A description of the event.
+ * @property {string} [description] - A description of the event.
  * @property {Creator} creator - Who created the event.
  */
 


### PR DESCRIPTION
## Summary
- mark `description` field optional in `EntryData`
- adjust event structure docs

## Testing
- `npm install`
- `npm test`
- `npm run static-analysis`


------
https://chatgpt.com/codex/tasks/task_e_684240605044832e98327b6680a3e90b