### PR TITLE
Fix missing await in /entries route

### DIFF
--- a/backend/src/routes/entries.js
+++ b/backend/src/routes/entries.js
@@ -53,9 +53,13 @@ function makeRouter(capabilities) {
         req.query["request_identifier"] = reqId.identifier;
 
         // Call multer upload middleware for multiple files
-        uploadMiddleware.array("files")(req, res, (err) => {
+        uploadMiddleware.array("files")(req, res, async (err) => {
             if (err) return next(err);
-            handleEntryPost(req, res, capabilities);
+            try {
+                await handleEntryPost(req, res, capabilities);
+            } catch (error) {
+                next(error);
+            }
         });
     });
 


### PR DESCRIPTION
## Summary
- await async entry creation to handle errors properly

## Testing
- `npm test`
- `npm run static-analysis`


------
https://chatgpt.com/codex/tasks/task_e_6842405d1f30832eba08190630fa648d