### PR TITLE
Fix docs comment in event log storage commit logic

### DIFF
--- a/backend/src/event_log_storage.js
+++ b/backend/src/event_log_storage.js
@@ -330,7 +330,7 @@ async function performGitTransaction(
         // Track if we need to commit
         let needsCommit = false;
 
-        // Only persist and commit if there are new entries
+        // Persist and commit when we have new entries or configuration changes
         if (newEntries.length > 0) {
             // Persist queued entries
             await appendEntriesToFile(capabilities, dataFile, newEntries);


### PR DESCRIPTION
## Summary
- clarify when event log storage commits changes

## Testing
- `npm install`
- `npm test`
- `npm run static-analysis`


------
https://chatgpt.com/codex/tasks/task_e_6843152246cc832e82437d99b95a1aef