### PR TITLE
Fix async error handling in upload storage

### DIFF
--- a/backend/src/storage.js
+++ b/backend/src/storage.js
@@ -26,10 +26,11 @@ function makeStorage(capabilities) {
          * @param {Express.Multer.File} _file
          * @param {(error: Error|null, destination: string) => void} cb
          */
-        destination: async (req, _file, cb) => {
+        destination: (req, _file, cb) => {
             const reqId = fromRequest(req);
-            const targetDir = await makeDirectory(capabilities, reqId);
-            cb(null, targetDir);
+            makeDirectory(capabilities, reqId)
+                .then((targetDir) => cb(null, targetDir))
+                .catch((err) => cb(err, ""));
         },
 
         /**


### PR DESCRIPTION
## Summary
- handle errors when creating upload destination directory

## Testing
- `npm test`
- `npm run static-analysis`


------
https://chatgpt.com/codex/tasks/task_e_68431529f320832ea8962aecfd80b8e5