### PR TITLE
Validate pagination parameters

### DIFF
--- a/backend/src/entry.js
+++ b/backend/src/entry.js
@@ -109,6 +109,13 @@ async function createEntry(capabilities, entryData, files = []) {
 async function getEntries(capabilities, pagination) {
     const { page, limit } = pagination;
 
+    if (!Number.isInteger(page) || page < 1) {
+        throw new Error('page must be a positive integer');
+    }
+    if (!Number.isInteger(limit) || limit < 1) {
+        throw new Error('limit must be a positive integer');
+    }
+
     // Fetch all entries from storage
     const entries = await transaction(capabilities, async (storage) => {
         return await storage.getExistingEntries();

--- a/backend/tests/entry.test.js
+++ b/backend/tests/entry.test.js
@@ -1,4 +1,4 @@
-const { createEntry } = require("../src/entry");
+const { createEntry, getEntries } = require("../src/entry");
 const { getMockedRootCapabilities } = require("./spies");
 const { stubEnvironment, stubEventLogRepository } = require("./stubs");
 
@@ -180,5 +180,24 @@ describe("createEntry (integration, with real capabilities)", () => {
         };
         const event = await createEntry(capabilities, entryData);
         expect(event.date).toEqual(new Date(futureDate));
+    });
+});
+
+describe("getEntries pagination validation", () => {
+    it("throws for non-positive page or limit", async () => {
+        const capabilities = await getTestCapabilities();
+        const entryData = {
+            original: "orig",
+            input: "inp",
+            type: "t",
+            description: "d",
+        };
+        await createEntry(capabilities, entryData);
+        await expect(
+            getEntries(capabilities, { page: 0, limit: 5 })
+        ).rejects.toThrow();
+        await expect(
+            getEntries(capabilities, { page: 1, limit: 0 })
+        ).rejects.toThrow();
     });
 });


### PR DESCRIPTION
## Summary
- validate page & limit in getEntries
- test invalid pagination

## Testing
- `npm test`
- `npm run static-analysis`


------
https://chatgpt.com/codex/tasks/task_e_68424077a474832e9c7b5f349a52c63c