### PR TITLE
Fix random string length validation test

### DIFF
--- a/backend/tests/random_string.test.js
+++ b/backend/tests/random_string.test.js
@@ -24,7 +24,8 @@ describe("random.string", () => {
         expect(() => random.string(capabilities, 0)).toThrow(TypeError);
         expect(() => random.string(capabilities, -5)).toThrow(TypeError);
         expect(() => random.string(capabilities, 1.5)).toThrow(TypeError);
-        expect(() => random.string("16")).toThrow(TypeError);
+        // Length must be numeric; passing a string should throw
+        expect(() => random.string(capabilities, "16")).toThrow(TypeError);
     });
 });
 


### PR DESCRIPTION
## Summary
- correct test case for invalid length

## Testing
- `npm test`
- `npm run static-analysis`


------
https://chatgpt.com/codex/tasks/task_e_6842406a2408832e99631afd188e3bac