### PR TITLE
Fix transcribeRequest cleanup

### DIFF
--- a/backend/src/transcribe.js
+++ b/backend/src/transcribe.js
@@ -113,19 +113,20 @@ async function transcribeFile(capabilities, inputFile, outputPath) {
  * @returns {Promise<void>}
  */
 async function transcribeRequest(capabilities, inputPath, reqId) {
-    const outputFile = path.basename("transcription.json");
+    const outputFile = "transcription.json";
     const targetDir = await makeDirectory(capabilities, reqId);
     const outputPath = path.join(targetDir, outputFile);
-    const inputFile = await capabilities.checker
-        .instantiate(inputPath)
-        .catch(() => {
-            throw new InputNotFound(
-                `Input file ${inputPath} not found.`,
-                inputPath
-            );
-        });
 
     try {
+        const inputFile = await capabilities.checker
+            .instantiate(inputPath)
+            .catch(() => {
+                throw new InputNotFound(
+                    `Input file ${inputPath} not found.`,
+                    inputPath
+                );
+            });
+
         await transcribeFile(capabilities, inputFile, outputPath);
     } finally {
         await markDone(capabilities, reqId);


### PR DESCRIPTION
## Summary
- ensure `transcribeRequest` always marks request as done

## Testing
- `npm test`
- `npm run static-analysis`


------
https://chatgpt.com/codex/tasks/task_e_68433b5aeb74832e815ff786f93d31c9