### PR TITLE
Fix service worker output path

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -43,7 +43,11 @@ export default defineConfig({
             },
             injectManifest: {
                 swSrc: "src/sw.js",
-                swDest: "dist/sw.js",
+                // swDest should be relative to the build outDir.
+                // Using "dist/sw.js" here would nest the output as
+                // "dist/dist/sw.js". Keep just the filename to place the
+                // service worker directly in the outDir.
+                swDest: "sw.js",
                 minify: false,
                 rollupFormat: "es",
             },


### PR DESCRIPTION
## Summary
- fix incorrect Vite PWA `swDest` config comment and value so service worker is built to `dist/sw.js`

## Testing
- `npm test`
- `npm run static-analysis`


------
https://chatgpt.com/codex/tasks/task_e_68433b5d6bf8832e9327127384ea7bdb