### PR TITLE
Fix empty request_identifier handling

### DIFF
--- a/backend/src/request_identifier.js
+++ b/backend/src/request_identifier.js
@@ -48,10 +48,10 @@ function fromRequest(req) {
     /** @type {any} */
     const query = req.query;
     const reqId = query['request_identifier'];
-    if (reqId === null || reqId === undefined) {
+    if (reqId === null || reqId === undefined || String(reqId).trim() === '') {
         throw new Error("Missing request_identifier field");
     }
-    return new RequestIdentifierClass(reqId.toString());
+    return new RequestIdentifierClass(String(reqId));
 }
 
 /**

--- a/backend/tests/request_identifier.test.js
+++ b/backend/tests/request_identifier.test.js
@@ -32,11 +32,11 @@ describe("Request Identifier", () => {
             );
         });
 
-        it("handles empty request_identifier", () => {
+        it("throws error when request_identifier is empty", () => {
             const req = { query: { request_identifier: "" } };
-            expect(() => fromRequest(req)).not.toThrow();
-            const reqId = fromRequest(req);
-            expect(reqId.identifier).toBe("");
+            expect(() => fromRequest(req)).toThrow(
+                "Missing request_identifier field"
+            );
         });
     });
 


### PR DESCRIPTION
## Summary
- validate that request_identifier is non-empty
- update tests to expect an error when request_identifier is empty

## Testing
- `npm test`
- `npm run static-analysis`


------
https://chatgpt.com/codex/tasks/task_e_68433b6bbf24832e9162657304ffe94f