### PR TITLE
Fix logging of request identifier

### DIFF
--- a/backend/src/routes/transcribe.js
+++ b/backend/src/routes/transcribe.js
@@ -59,7 +59,7 @@ async function handleTranscribeRequest(capabilities, req, res) {
     // Log the transcription request
     capabilities.logger.logInfo(
         {
-            request_identifier: reqId,
+            request_identifier: reqId.identifier,
             input: rawIn,
             client_ip: req.ip,
             user_agent: req.get("user-agent"),
@@ -70,7 +70,7 @@ async function handleTranscribeRequest(capabilities, req, res) {
     if (!rawIn) {
         capabilities.logger.logError(
             {
-                request_identifier: reqId,
+                request_identifier: reqId.identifier,
                 error: "Missing input parameter",
                 query: req.query,
             },
@@ -94,7 +94,7 @@ async function handleTranscribeRequest(capabilities, req, res) {
         if (isInputNotFound(error)) {
             capabilities.logger.logError(
                 {
-                    request_identifier: reqId,
+                    request_identifier: reqId.identifier,
                     error: "Input file not found",
                     input_path: inputPath,
                     error_details: error.message,
@@ -107,7 +107,7 @@ async function handleTranscribeRequest(capabilities, req, res) {
         } else {
             capabilities.logger.logError(
                 {
-                    request_identifier: reqId,
+                    request_identifier: reqId.identifier,
                     error:
                         error instanceof Object && "message" in error
                             ? String(error.message)

--- a/backend/src/routes/transcribe_all.js
+++ b/backend/src/routes/transcribe_all.js
@@ -56,7 +56,7 @@ async function handleTranscribeAllRequest(capabilities, req, res) {
     const rawDir = query["input_dir"];
     capabilities.logger.logInfo(
         {
-            request_identifier: reqId,
+            request_identifier: reqId.identifier,
             input_dir: rawDir,
             client_ip: req.ip,
             user_agent: req.get("user-agent"),
@@ -66,7 +66,7 @@ async function handleTranscribeAllRequest(capabilities, req, res) {
     if (!rawDir) {
         capabilities.logger.logError(
             {
-                request_identifier: reqId,
+                request_identifier: reqId.identifier,
                 error: "Missing input_dir parameter",
                 query: req.query,
             },
@@ -88,7 +88,7 @@ async function handleTranscribeAllRequest(capabilities, req, res) {
         if (result.failures.length > 0) {
             capabilities.logger.logError(
                 {
-                    request_identifier: reqId,
+                    request_identifier: reqId.identifier,
                     result,
                     input_dir: inputDir,
                 },
@@ -99,7 +99,7 @@ async function handleTranscribeAllRequest(capabilities, req, res) {
                 .json({ success: false, result });
         }
         capabilities.logger.logInfo(
-            { request_identifier: reqId, result, input_dir: inputDir },
+            { request_identifier: reqId.identifier, result, input_dir: inputDir },
             "Batch transcription successful"
         );
         return res.json({ success: true, result });
@@ -107,7 +107,7 @@ async function handleTranscribeAllRequest(capabilities, req, res) {
         if (error instanceof InputDirectoryAccess) {
             capabilities.logger.logError(
                 {
-                    request_identifier: reqId,
+                    request_identifier: reqId.identifier,
                     error: error.message,
                     input_dir: inputDir,
                     error_stack: error.stack,
@@ -121,7 +121,7 @@ async function handleTranscribeAllRequest(capabilities, req, res) {
         // Catch-all for other errors
         capabilities.logger.logError(
             {
-                request_identifier: reqId,
+                request_identifier: reqId.identifier,
                 error:
                     error instanceof Object && "message" in error
                         ? String(error.message)

--- a/backend/src/routes/upload.js
+++ b/backend/src/routes/upload.js
@@ -47,7 +47,7 @@ function makeRouter(capabilities) {
         const files = /** @type {Express.Multer.File[]} */ (req.files || []);
         const uploaded = files.map((f) => f.filename);
         capabilities.logger.logInfo(
-            { files: uploaded, request_identifier: reqId },
+            { files: uploaded, request_identifier: reqId.identifier },
             'Files uploaded'
         );
         await markDone(capabilities, reqId);


### PR DESCRIPTION
## Summary
- use `reqId.identifier` when logging in upload and transcription routes

## Testing
- `npm test`
- `npm run static-analysis`


------
https://chatgpt.com/codex/tasks/task_e_68433b737504832e9f2d5d4d9381811f