### PR TITLE
Fix default port for vite proxy

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -2,7 +2,8 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import { VitePWA } from "vite-plugin-pwa";
 
-const port = parseInt(process.env.VOLODYSLAV_SERVER_PORT);
+// Default to 3000 if the env variable is unset
+const port = parseInt(process.env.VOLODYSLAV_SERVER_PORT || "3000", 10);
 
 export default defineConfig({
     plugins: [


### PR DESCRIPTION
## Summary
- avoid NaN when `VOLODYSLAV_SERVER_PORT` is missing

## Testing
- `npm test`
- `npm run static-analysis`


------
https://chatgpt.com/codex/tasks/task_e_68433b71b780832ea7b49ed20306b6eb