### PR TITLE
Fix upload request id error handling

### DIFF
--- a/backend/src/storage.js
+++ b/backend/src/storage.js
@@ -27,7 +27,15 @@ function makeStorage(capabilities) {
          * @param {(error: Error|null, destination: string) => void} cb
          */
         destination: (req, _file, cb) => {
-            const reqId = fromRequest(req);
+            let reqId;
+            try {
+                reqId = fromRequest(req);
+            } catch (err) {
+                const error = err instanceof Error ? err : new Error(String(err));
+                cb(error, "");
+                return;
+            }
+
             makeDirectory(capabilities, reqId)
                 .then((targetDir) => cb(null, targetDir))
                 .catch((err) => cb(err, ""));


### PR DESCRIPTION
## Summary
- fix upload route storage to gracefully handle missing request identifier

## Testing
- `npm test`
- `npm run static-analysis`


------
https://chatgpt.com/codex/tasks/task_e_68435b98424c832ea0c437dd03af882e