### PR TITLE
Fix update script symlink path

### DIFF
--- a/scripts/update-and-install
+++ b/scripts/update-and-install
@@ -16,4 +16,4 @@ npm test
 npm run build
 
 mkdir -p "$PREFIX"/bin
-ln -srfT -- "scripts/run-main" "$PREFIX"/bin/volodyslav
+ln -srfT -- "$PWD/scripts/run-main" "$PREFIX"/bin/volodyslav


### PR DESCRIPTION
## Summary
- fix `update-and-install` to use `$PWD` when creating the executable symlink

## Testing
- `npm install`
- `npm test`
- `npm run static-analysis`


------
https://chatgpt.com/codex/tasks/task_e_68435b9afa7c832eace007a67497b07d