### PR TITLE
Fix invalid date parsing in format_time_stamp

### DIFF
--- a/backend/src/format_time_stamp.js
+++ b/backend/src/format_time_stamp.js
@@ -74,8 +74,18 @@ function format_time_stamp(basic) {
         return undefined;
     }
 
+    const match = isoUTC.match(/(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})Z/);
     const d = new Date(isoUTC);
-    if (isNaN(d.getTime())) {
+    if (
+        !match ||
+        isNaN(d.getTime()) ||
+        d.getUTCFullYear() !== Number(match[1]) ||
+        d.getUTCMonth() + 1 !== Number(match[2]) ||
+        d.getUTCDate() !== Number(match[3]) ||
+        d.getUTCHours() !== Number(match[4]) ||
+        d.getUTCMinutes() !== Number(match[5]) ||
+        d.getUTCSeconds() !== Number(match[6])
+    ) {
         return undefined;
     }
 

--- a/backend/tests/format_time_stamp.test.js
+++ b/backend/tests/format_time_stamp.test.js
@@ -19,4 +19,10 @@ describe('formatFileTimestamp', () => {
       'Filename "invalidfile.txt" does not start with YYYYMMDDThhmmssZ'
     );
   });
+
+  it('throws an error for invalid calendar date', async () => {
+    await expect(async () =>
+      formatFileTimestamp('20250230T000000Z.txt')
+    ).rejects.toThrow('Failed to parse valid Date from timestamp string: 20250230T000000Z');
+  });
 });


### PR DESCRIPTION
## Summary
- improve `format_time_stamp` to reject invalid calendar dates
- test invalid date handling

## Testing
- `npm test`
- `npm run static-analysis`


------
https://chatgpt.com/codex/tasks/task_e_6843652d83f4832e8832e060f40e4043