### PR TITLE
Fix server port validation

### DIFF
--- a/backend/src/environment.js
+++ b/backend/src/environment.js
@@ -49,7 +49,10 @@ function workingDirectory() {
 
 function myServerPort() {
     const raw = getEnv("VOLODYSLAV_SERVER_PORT");
-    const port = parseInt(raw, 10);
+    if (!/^\d+$/.test(raw)) {
+        throw new EnvironmentError("VOLODYSLAV_SERVER_PORT");
+    }
+    const port = Number(raw);
     if (!Number.isInteger(port) || port < 0 || port > 65535) {
         throw new EnvironmentError("VOLODYSLAV_SERVER_PORT");
     }

--- a/backend/tests/environment.test.js
+++ b/backend/tests/environment.test.js
@@ -1,0 +1,18 @@
+const { make } = require('../src/environment');
+
+describe('myServerPort', () => {
+  const original = process.env.VOLODYSLAV_SERVER_PORT;
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.VOLODYSLAV_SERVER_PORT;
+    } else {
+      process.env.VOLODYSLAV_SERVER_PORT = original;
+    }
+  });
+
+  it('throws on non-numeric characters', () => {
+    process.env.VOLODYSLAV_SERVER_PORT = '123abc';
+    const env = make();
+    expect(() => env.myServerPort()).toThrow('VOLODYSLAV_SERVER_PORT');
+  });
+});


### PR DESCRIPTION
## Summary
- validate `VOLODYSLAV_SERVER_PORT` strictly before parsing
- test that invalid port strings throw

## Testing
- `npm test`
- `npm run static-analysis`

------
https://chatgpt.com/codex/tasks/task_e_68436534822c832ea76af8a5121e3a2a