### PR TITLE
Fix invalid modifier handling in createEntry

### DIFF
--- a/backend/src/entry.js
+++ b/backend/src/entry.js
@@ -64,6 +64,14 @@ async function createEntry(capabilities, entryData, files = []) {
         throw new Error("description field is required");
     }
 
+    if (entryData.modifiers !== undefined) {
+        for (const [, v] of Object.entries(entryData.modifiers)) {
+            if (typeof v !== "string") {
+                throw new Error("modifiers must be key-value strings");
+            }
+        }
+    }
+
     /** @type {import('./event/structure').Event} */
     const event = {
         id,

--- a/backend/tests/entry.test.js
+++ b/backend/tests/entry.test.js
@@ -182,6 +182,21 @@ describe("createEntry (integration, with real capabilities)", () => {
         const event = await createEntry(capabilities, entryData);
         expect(event.date).toEqual(new Date(futureDate));
     });
+
+    it("throws if modifiers contain non-string values", async () => {
+        const capabilities = await getTestCapabilities();
+        const entryData = {
+            original: "Invalid modifiers original",
+            input: "Invalid modifiers input",
+            type: "invalid-modifiers-type",
+            description: "Entry with invalid modifiers.",
+            modifiers: { foo: 123 },
+        };
+
+        await expect(createEntry(capabilities, entryData)).rejects.toThrow(
+            /modifiers must be key-value strings/
+        );
+    });
 });
 
 describe("getEntries pagination validation", () => {


### PR DESCRIPTION
## Summary
- validate modifier values in `createEntry`
- test that non-string modifier values throw an error

## Testing
- `npm test`
- `npm run static-analysis`


------
https://chatgpt.com/codex/tasks/task_e_68436b4b7d6c832eb61a794027bd1bcb