### PR TITLE
Fix event modifiers validation

### DIFF
--- a/backend/src/event/structure.js
+++ b/backend/src/event/structure.js
@@ -116,12 +116,22 @@ function tryDeserialize(obj) {
             return null;
         }
 
-        // Handle modifiers - defaults to {} if missing, must be a non-array object if present
-        const rawModifiers = "modifiers" in obj ? obj.modifiers : {};
-        const modifiers = rawModifiers || {};
-        if (typeof modifiers !== "object" || Array.isArray(modifiers)) {
+        // Handle modifiers - defaults to {} if missing. When provided it must
+        // be an object and not an array. Falsy values like 0 should be
+        // considered invalid rather than treated as an empty object.
+        const hasModifiers = "modifiers" in obj;
+        /** @type {unknown} */
+        const rawModifiers = hasModifiers ? obj.modifiers : {};
+        if (
+            hasModifiers &&
+            (rawModifiers === null ||
+                typeof rawModifiers !== "object" ||
+                Array.isArray(rawModifiers))
+        ) {
             return null;
         }
+        /** @type {Record<string, unknown>} */
+        const modifiers = hasModifiers ? /** @type {Record<string, unknown>} */ (rawModifiers) : {};
 
         // Manually validate and parse the date
         const dateObj = new Date(date);

--- a/backend/tests/event_structure.test.js
+++ b/backend/tests/event_structure.test.js
@@ -1,0 +1,17 @@
+const event = require('../src/event/structure');
+
+describe('event.tryDeserialize', () => {
+  it('returns null when modifiers is not an object', () => {
+    const obj = {
+      id: 'abc',
+      date: '2025-01-01T00:00:00.000Z',
+      original: 'o',
+      input: 'i',
+      type: 't',
+      description: 'd',
+      creator: { name: 'n', uuid: 'u', version: 'v' },
+      modifiers: 0
+    };
+    expect(event.tryDeserialize(obj)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- fix validation for `modifiers` when deserializing events
- add regression test for invalid `modifiers` type

## Testing
- `npm test`
- `npm run static-analysis`


------
https://chatgpt.com/codex/tasks/task_e_68436b4d8e2c832eb4f15e35bccc0ca2