### PR TITLE
Fix modifiers parsing to validate JSON object

### DIFF
--- a/backend/src/routes/entries.js
+++ b/backend/src/routes/entries.js
@@ -113,7 +113,16 @@ function parseModifiers(modifiers) {
     }
 
     try {
-        return JSON.parse(modifiers);
+        const parsed = JSON.parse(modifiers);
+        if (
+            parsed &&
+            typeof parsed === "object" &&
+            !Array.isArray(parsed) &&
+            Object.values(parsed).every((v) => typeof v === "string")
+        ) {
+            return parsed;
+        }
+        return undefined;
     } catch {
         return undefined;
     }

--- a/backend/tests/entries.test.js
+++ b/backend/tests/entries.test.js
@@ -70,6 +70,23 @@ describe("POST /api/entries", () => {
         expect(res.body.error).toMatch(/Missing required fields/);
     });
 
+    it("ignores modifiers field when it is not an object", async () => {
+        const { app } = await makeTestApp();
+        const entry = {
+            original: "Bad mods original",
+            input: "Bad mods input",
+            type: "bad-mods",
+            description: "bad",
+            modifiers: "true",
+        };
+        const res = await request(app)
+            .post("/api/entries")
+            .send(entry)
+            .set("Content-Type", "application/json");
+        expect(res.statusCode).toBe(201);
+        expect(res.body.entry.modifiers).toEqual({});
+    });
+
     it("creates an entry with an asset when a file is uploaded", async () => {
         const { app, capabilities } = await makeTestApp();
         const tmpDir = fs.mkdtempSync(


### PR DESCRIPTION
## Summary
- ensure parsed modifiers are plain objects with string values
- test modifiers parsing via /api/entries

## Testing
- `npm test`
- `npm run static-analysis`


------
https://chatgpt.com/codex/tasks/task_e_68436b52d324832ebc65b18252d875e8