### PR TITLE
Fix FileDeleter error when removing missing directory

### DIFF
--- a/backend/src/filesystem/deleter.js
+++ b/backend/src/filesystem/deleter.js
@@ -85,7 +85,7 @@ async function deleteFile(filePath) {
  */
 async function deleteDirectory(directoryPath) {
     try {
-        await fs.rm(directoryPath, { recursive: true, force: true });
+        await fs.rm(directoryPath, { recursive: true });
     } catch (err) {
         if (err instanceof Object && "code" in err && err.code === "ENOENT") {
             throw new FileNotFoundError(directoryPath);

--- a/backend/tests/deleter.test.js
+++ b/backend/tests/deleter.test.js
@@ -1,0 +1,11 @@
+const os = require('os');
+const path = require('path');
+const deleter = require('../src/filesystem/deleter');
+
+describe('deleteDirectory', () => {
+  it('throws FileNotFoundError when directory does not exist', async () => {
+    const dir = path.join(os.tmpdir(), 'nonexistent-' + Date.now());
+    const d = deleter.make();
+    await expect(d.deleteDirectory(dir)).rejects.toMatchObject({ filePath: dir });
+  });
+});


### PR DESCRIPTION
## Summary
- add test for deleting non-existent directory
- remove `force: true` flag so `deleteDirectory` throws `FileNotFoundError`

## Testing
- `npm test`
- `npm run static-analysis`


------
https://chatgpt.com/codex/tasks/task_e_68436b63730c832eb9ff2095d42ef45c