### PR TITLE
Fix environment variable check

### DIFF
--- a/backend/src/environment.js
+++ b/backend/src/environment.js
@@ -33,7 +33,7 @@ function isEnvironmentError(object) {
  */
 function getEnv(key) {
     const ret = process.env[key];
-    if (!ret) {
+    if (ret === undefined) {
         throw new EnvironmentError(key);
     }
     return ret;

--- a/backend/tests/environment.test.js
+++ b/backend/tests/environment.test.js
@@ -15,4 +15,10 @@ describe('myServerPort', () => {
     const env = make();
     expect(() => env.myServerPort()).toThrow('VOLODYSLAV_SERVER_PORT');
   });
+
+  it('allows "0" as a valid port', () => {
+    process.env.VOLODYSLAV_SERVER_PORT = '0';
+    const env = make();
+    expect(env.myServerPort()).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary
- allow undefined check only when validating environment variables
- keep server port `"0"` test

## Testing
- `npm test`
- `npm run static-analysis`


------
https://chatgpt.com/codex/tasks/task_e_68436b614db8832e97bac9e5f02b1625