### PR TITLE
Fix environment variable check

### DIFF
--- a/backend/src/environment.js
+++ b/backend/src/environment.js
@@ -33,7 +33,7 @@ function isEnvironmentError(object) {
  */
 function getEnv(key) {
     const ret = process.env[key];
-    if (!ret) {
+    if (ret === undefined) {
         throw new EnvironmentError(key);
     }
     return ret;

--- a/backend/tests/environment.test.js
+++ b/backend/tests/environment.test.js
@@ -15,4 +15,33 @@ describe('myServerPort', () => {
     const env = make();
     expect(() => env.myServerPort()).toThrow('VOLODYSLAV_SERVER_PORT');
   });
+
+  it('allows "0" as a valid port', () => {
+    process.env.VOLODYSLAV_SERVER_PORT = '0';
+    const env = make();
+    expect(env.myServerPort()).toBe(0);
+  });
+
+  it('throws on empty string', () => {
+    process.env.VOLODYSLAV_SERVER_PORT = '';
+    const env = make();
+    expect(() => env.myServerPort()).toThrow('VOLODYSLAV_SERVER_PORT');
+  });
+});
+
+describe('logFile', () => {
+  const original = process.env.VOLODYSLAV_LOG_FILE;
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.VOLODYSLAV_LOG_FILE;
+    } else {
+      process.env.VOLODYSLAV_LOG_FILE = original;
+    }
+  });
+
+  it('returns empty string without throwing', () => {
+    process.env.VOLODYSLAV_LOG_FILE = '';
+    const env = make();
+    expect(env.logFile()).toBe('');
+  });
 });


### PR DESCRIPTION
## Summary
- allow undefined check only when validating environment variables
- keep server port "0" test
- add test verifying empty string port is invalid
- add test for empty log file path being accepted

## Testing
- `npm test`
- `npm run static-analysis`


------
https://chatgpt.com/codex/tasks/task_e_68436b614db8832e97bac9e5f02b1625