### PR TITLE
Introduce datetime capability and mocks

### DIFF
--- a/backend/src/capabilities/root.js
+++ b/backend/src/capabilities/root.js
@@ -18,6 +18,7 @@
 /** @typedef {import('../notifications').Notifier} Notifier */
 /** @typedef {import('../schedule').Scheduler} Scheduler */
 /** @typedef {import('../ai/transcription').AITranscription} AITranscription */
+/** @typedef {import('../datetime').Datetime} Datetime */
 
 
 /**
@@ -37,6 +38,7 @@
  * @property {Notifier} notifier - A notifier instance.
  * @property {Scheduler} scheduler - A scheduler instance.
  * @property {AITranscription} aiTranscription - An AI transcription instance.
+ * @property {Datetime} datetime - Datetime utilities.
  */
 
 const memconst = require("../memconst");
@@ -56,6 +58,7 @@ const loggingCapability = require("../logger");
 const notifierCapability = require("../notifications");
 const schedulerCapability = require("../schedule");
 const aiTranscriptionCapability = require("../ai/transcription");
+const datetimeCapability = require("../datetime");
 
 /**
  * This structure collects maximum capabilities that any part of Volodyslav can access.
@@ -65,9 +68,11 @@ const aiTranscriptionCapability = require("../ai/transcription");
  */
 const make = memconst(() => {
     const environment = environmentCapability.make();
+    const datetime = datetimeCapability.make();
     /** @type {Capabilities} */
     const ret = {
         seed: random.seed.make(),
+        datetime,
         deleter: deleterCapability.make(),
         scanner: dirscanner.make(),
         copier: copierCapability.make(),
@@ -75,7 +80,7 @@ const make = memconst(() => {
         writer: writerCapability.make(),
         reader: readerCapability.make(),
         appender: appendCapability.make(),
-        checker: checkerCapability.make(),
+        checker: checkerCapability.make({ datetime }),
         git: gitCapability,
         environment,
         logger: loggingCapability.make(() => ret),

--- a/backend/src/datetime.js
+++ b/backend/src/datetime.js
@@ -1,0 +1,18 @@
+/**
+ * Datetime capability for retrieving the current timestamp.
+ * @typedef {object} Datetime
+ * @property {() => number} now - Returns the current epoch milliseconds.
+ */
+
+function now() {
+    return Date.now();
+}
+
+/**
+ * @returns {Datetime}
+ */
+function make() {
+    return { now };
+}
+
+module.exports = { make };

--- a/backend/src/entry.js
+++ b/backend/src/entry.js
@@ -29,6 +29,7 @@ const creatorMake = require("./creator");
  * @property {Environment} environment - An environment instance.
  * @property {Logger} logger - A logger instance.
  * @property {import('./filesystem/reader').FileReader} reader - A file reader instance.
+ * @property {import('./datetime').Datetime} datetime - Datetime utilities.
  */
 
 /**
@@ -52,7 +53,9 @@ const creatorMake = require("./creator");
 async function createEntry(capabilities, entryData, files = []) {
     const creator = await creatorMake(capabilities);
     const id = eventId.make(capabilities);
-    const date = entryData.date ? new Date(entryData.date) : new Date();
+    const date = entryData.date
+        ? new Date(entryData.date)
+        : new Date(capabilities.datetime.now());
     if (isNaN(date.getTime())) {
         throw new Error('Invalid date');
     }

--- a/backend/src/routes/entries.js
+++ b/backend/src/routes/entries.js
@@ -32,6 +32,7 @@ const { processUserInput, InputParseError } = require("../event/from_input");
  * @property {FileChecker} checker - A file checker instance.
  * @property {Command} git - A command instance for Git operations.
  * @property {import('../filesystem/reader').FileReader} reader - A file reader instance.
+ * @property {import('../datetime').Datetime} datetime - Datetime utilities.
  */
 
 /**

--- a/backend/src/routes/periodic.js
+++ b/backend/src/routes/periodic.js
@@ -29,6 +29,7 @@ const { everyHour } = require("../schedule/tasks");
  * @property {Logger} logger - A logger instance.
  * @property {Scheduler} scheduler - A scheduler instance.
  * @property {import('../filesystem/reader').FileReader} reader - A file reader instance.
+ * @property {import('../datetime').Datetime} datetime - Datetime utilities.
  */
 
 /**

--- a/backend/src/schedule/tasks.js
+++ b/backend/src/schedule/tasks.js
@@ -29,6 +29,7 @@ const { processDiaryAudios } = require("../diary");
  * @property {Scheduler} scheduler - A scheduler instance.
  * @property {Logger} logger - A logger instance.
  * @property {import('../filesystem/reader').FileReader} reader - A file reader instance.
+ * @property {import('../datetime').Datetime} datetime - Datetime utilities.
  */
 
 /**

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -42,6 +42,7 @@ const workingRepository = require("./gitstore/working_repository");
  * @property {Scheduler} scheduler - A scheduler instance.
  * @property {import('./filesystem/reader').FileReader} reader - A file reader instance.
  * @property {AITranscription} aiTranscription - An AI transcription instance.
+ * @property {import('./datetime').Datetime} datetime - Datetime utilities.
  */
 
 /**

--- a/backend/tests/config.test.js
+++ b/backend/tests/config.test.js
@@ -3,7 +3,7 @@ const path = require("path");
 const config = require("../src/config");
 const configStorage = require("../src/config/storage");
 const { getMockedRootCapabilities } = require("./spies");
-const { stubEnvironment, stubLogger } = require("./stubs");
+const { stubEnvironment, stubLogger, stubDatetime } = require("./stubs");
 const temporary = require("./temporary");
 
 beforeEach(temporary.beforeEach);
@@ -13,6 +13,7 @@ function getTestCapabilities() {
     const capabilities = getMockedRootCapabilities();
     stubEnvironment(capabilities);
     stubLogger(capabilities);
+    stubDatetime(capabilities);
     return capabilities;
 }
 

--- a/backend/tests/diary.test.js
+++ b/backend/tests/diary.test.js
@@ -9,6 +9,7 @@ const dateFormatter = require("../src/event/date");
 const {
     stubEnvironment,
     stubLogger,
+    stubDatetime,
     stubEventLogRepository,
 } = require("./stubs");
 const { getMockedRootCapabilities } = require("./spies");
@@ -17,6 +18,7 @@ function getTestCapabilities() {
     const capabilities = getMockedRootCapabilities();
     stubEnvironment(capabilities);
     stubLogger(capabilities);
+    stubDatetime(capabilities);
 
     // Mock isFileStable to return true by default for existing tests
     capabilities.checker.isFileStable = jest.fn().mockResolvedValue(true);

--- a/backend/tests/entries.test.js
+++ b/backend/tests/entries.test.js
@@ -5,6 +5,7 @@ const { getMockedRootCapabilities } = require("./spies");
 const {
     stubEnvironment,
     stubLogger,
+    stubDatetime,
     stubEventLogRepository,
 } = require("./stubs");
 const fs = require("fs");
@@ -15,6 +16,7 @@ async function makeTestApp() {
     const capabilities = getMockedRootCapabilities();
     stubEnvironment(capabilities);
     stubLogger(capabilities);
+    stubDatetime(capabilities);
     await stubEventLogRepository(capabilities);
     const app = expressApp.make();
     capabilities.logger.enableHttpCallsLogging(app);

--- a/backend/tests/entry.test.js
+++ b/backend/tests/entry.test.js
@@ -1,10 +1,11 @@
 const { createEntry, getEntries } = require("../src/entry");
 const { getMockedRootCapabilities } = require("./spies");
-const { stubEnvironment, stubEventLogRepository } = require("./stubs");
+const { stubEnvironment, stubEventLogRepository, stubDatetime } = require("./stubs");
 
 async function getTestCapabilities() {
     const capabilities = getMockedRootCapabilities();
     stubEnvironment(capabilities);
+    stubDatetime(capabilities);
     await stubEventLogRepository(capabilities);
     return capabilities;
 }

--- a/backend/tests/event_log_storage.test.js
+++ b/backend/tests/event_log_storage.test.js
@@ -8,6 +8,7 @@ const { targetPath } = require("../src/event/asset");
 const {
     stubEnvironment,
     stubLogger,
+    stubDatetime,
     stubEventLogRepository,
 } = require("./stubs");
 const { getMockedRootCapabilities } = require("./spies");
@@ -16,6 +17,7 @@ function getTestCapabilities() {
     const capabilities = getMockedRootCapabilities();
     stubEnvironment(capabilities);
     stubLogger(capabilities);
+    stubDatetime(capabilities);
     return capabilities;
 }
 

--- a/backend/tests/from_input.test.js
+++ b/backend/tests/from_input.test.js
@@ -10,12 +10,13 @@ const {
     processUserInput
 } = require("../src/event/from_input");
 const { getMockedRootCapabilities } = require("./spies");
-const { stubEnvironment, stubLogger } = require("./stubs");
+const { stubEnvironment, stubLogger, stubDatetime } = require("./stubs");
 
 function getTestCapabilities() {
     const capabilities = getMockedRootCapabilities();
     stubEnvironment(capabilities);
     stubLogger(capabilities);
+    stubDatetime(capabilities);
     return capabilities;
 }
 

--- a/backend/tests/gitstore.test.js
+++ b/backend/tests/gitstore.test.js
@@ -5,11 +5,12 @@ const { transaction } = require("../src/gitstore");
 const defaultBranch = require("../src/gitstore/default_branch");
 const workingRepository = require("../src/gitstore/working_repository");
 const { getMockedRootCapabilities } = require("./spies");
-const { stubEnvironment, stubEventLogRepository } = require("./stubs");
+const { stubEnvironment, stubEventLogRepository, stubDatetime } = require("./stubs");
 
 function getTestCapabilities() {
     const capabilities = getMockedRootCapabilities();
     stubEnvironment(capabilities);
+    stubDatetime(capabilities);
     return capabilities;
 }
 

--- a/backend/tests/index.test.js
+++ b/backend/tests/index.test.js
@@ -1,13 +1,14 @@
 const request = require("supertest");
 const expressApp = require("../src/express_app");
 const { addRoutes } = require("../src/server");
-const { stubEnvironment, stubLogger } = require("./stubs");
+const { stubEnvironment, stubLogger, stubDatetime } = require("./stubs");
 const { getMockedRootCapabilities } = require("./spies");
 
 function getTestCapabilities() {
     const capabilities = getMockedRootCapabilities();
     stubEnvironment(capabilities);
     stubLogger(capabilities);
+    stubDatetime(capabilities);
     return capabilities;
 }
 

--- a/backend/tests/logger.test.js
+++ b/backend/tests/logger.test.js
@@ -2,12 +2,13 @@ const fs = require("fs");
 const path = require("path");
 const { make } = require("../src/logger");
 const { getMockedRootCapabilities } = require("./spies");
-const { stubEnvironment } = require("./stubs");
+const { stubEnvironment, stubDatetime } = require("./stubs");
 
 describe("logger capability", () => {
     it("writes info, warn, error, and debug to file", async () => {
         const capabilities = getMockedRootCapabilities();
         stubEnvironment(capabilities);
+        stubDatetime(capabilities);
         const tmpDir = await capabilities.creator.createTemporaryDirectory(capabilities);
         const logFilePath = path.join(tmpDir, "test.log");
         capabilities.environment.logFile = () => logFilePath;

--- a/backend/tests/periodic.test.js
+++ b/backend/tests/periodic.test.js
@@ -1,13 +1,14 @@
 const request = require("supertest");
 const express = require("express");
 const periodicRouter = require("../src/routes/periodic");
-const { stubEnvironment, stubLogger, stubEventLogRepository } = require("./stubs");
+const { stubEnvironment, stubLogger, stubEventLogRepository, stubDatetime } = require("./stubs");
 const { getMockedRootCapabilities } = require("./spies");
 
 function getTestCapabilities() {
     const capabilities = getMockedRootCapabilities();
     stubEnvironment(capabilities);
     stubLogger(capabilities);
+    stubDatetime(capabilities);
     return capabilities;
 }
 

--- a/backend/tests/ping.test.js
+++ b/backend/tests/ping.test.js
@@ -2,12 +2,13 @@ const request = require("supertest");
 const expressApp = require("../src/express_app");
 const { addRoutes } = require("../src/server");
 const { getMockedRootCapabilities } = require("./spies");
-const { stubEnvironment, stubLogger } = require("./stubs");
+const { stubEnvironment, stubLogger, stubDatetime } = require("./stubs");
 
 function getTestCapabilities() {
     const capabilities = getMockedRootCapabilities();
     stubEnvironment(capabilities);
     stubLogger(capabilities);
+    stubDatetime(capabilities);
     return capabilities;
 }
 

--- a/backend/tests/request_identifier.test.js
+++ b/backend/tests/request_identifier.test.js
@@ -8,12 +8,13 @@ const {
 } = require("../src/request_identifier");
 
 const { getMockedRootCapabilities } = require("./spies");
-const { stubEnvironment, stubLogger } = require("./stubs");
+const { stubEnvironment, stubLogger, stubDatetime } = require("./stubs");
 
 function getTestCapabilities() {
     const capabilities = getMockedRootCapabilities();
     stubEnvironment(capabilities);
     stubLogger(capabilities);
+    stubDatetime(capabilities);
     return capabilities;
 }
 

--- a/backend/tests/server.test.js
+++ b/backend/tests/server.test.js
@@ -6,6 +6,7 @@ const {
     stubLogger,
     stubNotifier,
     stubScheduler,
+    stubDatetime,
     stubEventLogRepository,
 } = require("./stubs");
 const { getMockedRootCapabilities } = require("./spies");
@@ -16,6 +17,7 @@ function getTestCapabilities() {
     stubLogger(capabilities);
     stubNotifier(capabilities);
     stubScheduler(capabilities);
+    stubDatetime(capabilities);
     return capabilities;
 }
 

--- a/backend/tests/static.test.js
+++ b/backend/tests/static.test.js
@@ -4,12 +4,13 @@ const request = require("supertest");
 const expressApp = require("../src/express_app");
 const { addRoutes } = require("../src/server");
 const { getMockedRootCapabilities } = require("./spies");
-const { stubEnvironment, stubLogger } = require("./stubs");
+const { stubEnvironment, stubLogger, stubDatetime } = require("./stubs");
 
 function getTestCapabilities() {
     const capabilities = getMockedRootCapabilities();
     stubEnvironment(capabilities);
     stubLogger(capabilities);
+    stubDatetime(capabilities);
     return capabilities;
 }
 

--- a/backend/tests/stubs.js
+++ b/backend/tests/stubs.js
@@ -95,11 +95,16 @@ function stubScheduler(capabilities) {
         });
 }
 
+function stubDatetime(capabilities) {
+    capabilities.datetime.now = jest.fn(() => Date.now());
+}
+
 module.exports = {
     stubEnvironment,
     stubLogger,
     stubAiTranscriber,
     stubNotifier,
     stubScheduler,
+    stubDatetime,
     stubEventLogRepository,
 };

--- a/backend/tests/transcribe.test.js
+++ b/backend/tests/transcribe.test.js
@@ -4,13 +4,14 @@ const request = require("supertest");
 const expressApp = require("../src/express_app");
 const { addRoutes } = require("../src/server");
 const { getMockedRootCapabilities } = require("./spies");
-const { stubEnvironment, stubLogger, stubAiTranscriber } = require("./stubs");
+const { stubEnvironment, stubLogger, stubAiTranscriber, stubDatetime } = require("./stubs");
 
 function getTestCapabilities() {
     const capabilities = getMockedRootCapabilities();
     stubEnvironment(capabilities);
     stubLogger(capabilities);
     stubAiTranscriber(capabilities);
+    stubDatetime(capabilities);
     return capabilities;
 }
 

--- a/backend/tests/transcribe_all.test.js
+++ b/backend/tests/transcribe_all.test.js
@@ -5,12 +5,13 @@ const { addRoutes } = require("../src/server");
 const { transcribeFile } = require("../src/transcribe");
 const expressApp = require("../src/express_app");
 const { getMockedRootCapabilities } = require("./spies");
-const { stubEnvironment, stubLogger } = require("./stubs");
+const { stubEnvironment, stubLogger, stubDatetime } = require("./stubs");
 
 function getTestCapabilities() {
     const capabilities = getMockedRootCapabilities();
     stubEnvironment(capabilities);
     stubLogger(capabilities);
+    stubDatetime(capabilities);
     return capabilities;
 }
 

--- a/backend/tests/upload.test.js
+++ b/backend/tests/upload.test.js
@@ -4,12 +4,13 @@ const path = require("path");
 const expressApp = require("../src/express_app");
 const { addRoutes } = require("../src/server");
 const { getMockedRootCapabilities } = require("./spies");
-const { stubEnvironment, stubLogger } = require("./stubs");
+const { stubEnvironment, stubLogger, stubDatetime } = require("./stubs");
 
 function getTestCapabilities() {
     const capabilities = getMockedRootCapabilities();
     stubEnvironment(capabilities);
     stubLogger(capabilities);
+    stubDatetime(capabilities);
     return capabilities;
 }
 

--- a/backend/tests/working_repository.test.js
+++ b/backend/tests/working_repository.test.js
@@ -8,6 +8,7 @@ const { getMockedRootCapabilities } = require("./spies");
 const {
     stubEnvironment,
     stubLogger,
+    stubDatetime,
     stubEventLogRepository,
 } = require("./stubs");
 const defaultBranch = require("../src/gitstore/default_branch");
@@ -16,6 +17,7 @@ function getTestCapabilities() {
     const capabilities = getMockedRootCapabilities();
     stubEnvironment(capabilities);
     stubLogger(capabilities);
+    stubDatetime(capabilities);
     return capabilities;
 }
 


### PR DESCRIPTION
## Summary
- add a `datetime` capability
- use the capability for non-deterministic time access
- wire `datetime` into root capabilities and file checker
- mock `datetime` in unit tests

## Testing
- `npm test`
- `npm run static-analysis`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68520719fc04832e93e4d241d63372c0