### PR TITLE
Add error type guards and remove class exports

### DIFF
--- a/backend/src/config/index.js
+++ b/backend/src/config/index.js
@@ -1,13 +1,14 @@
-const { 
-    serialize, 
-    deserialize, 
+const {
+    serialize,
+    deserialize,
     tryDeserialize,
-    TryDeserializeError,
-    MissingFieldError,
-    InvalidTypeError,
-    InvalidValueError,
-    InvalidStructureError,
-    InvalidArrayElementError
+    makeInvalidStructureError,
+    isTryDeserializeError,
+    isMissingFieldError,
+    isInvalidTypeError,
+    isInvalidValueError,
+    isInvalidStructureError,
+    isInvalidArrayElementError
 } = require("./structure");
 
 /** @typedef {import('./structure').Config} Config */
@@ -18,10 +19,11 @@ module.exports = {
     serialize,
     deserialize,
     tryDeserialize,
-    TryDeserializeError,
-    MissingFieldError,
-    InvalidTypeError,
-    InvalidValueError,
-    InvalidStructureError,
-    InvalidArrayElementError,
+    makeInvalidStructureError,
+    isTryDeserializeError,
+    isMissingFieldError,
+    isInvalidTypeError,
+    isInvalidValueError,
+    isInvalidStructureError,
+    isInvalidArrayElementError,
 };

--- a/backend/src/config/storage.js
+++ b/backend/src/config/storage.js
@@ -42,13 +42,13 @@ const { fromExisting } = require("../filesystem/file");
  * Reads and deserializes a config.json file
  * @param {ConfigReadCapabilities} capabilities - The minimal capabilities needed for reading
  * @param {import("../filesystem/file").ExistingFile} file - The config.json file to read
- * @returns {Promise<import('./structure').Config | import('./structure').TryDeserializeError>} The parsed config or error object
- */
+ * @returns {Promise<import('./structure').Config | Error>} The parsed config or error object
+*/
 async function readConfig(capabilities, file) {
     const objects = await readObjects(capabilities, file);
 
     if (objects.length === 0) {
-        return new config.InvalidStructureError("Config file is empty", []);
+        return config.makeInvalidStructureError("Config file is empty", []);
     }
 
     if (objects.length > 1) {

--- a/backend/src/config/structure.js
+++ b/backend/src/config/structure.js
@@ -120,6 +120,64 @@ class InvalidArrayElementError extends TryDeserializeError {
 }
 
 /**
+ * @param {unknown} object
+ * @returns {object is TryDeserializeError}
+ */
+function isTryDeserializeError(object) {
+    return object instanceof TryDeserializeError;
+}
+
+/**
+ * @param {unknown} object
+ * @returns {object is MissingFieldError}
+ */
+function isMissingFieldError(object) {
+    return object instanceof MissingFieldError;
+}
+
+/**
+ * @param {unknown} object
+ * @returns {object is InvalidTypeError}
+ */
+function isInvalidTypeError(object) {
+    return object instanceof InvalidTypeError;
+}
+
+/**
+ * @param {unknown} object
+ * @returns {object is InvalidValueError}
+ */
+function isInvalidValueError(object) {
+    return object instanceof InvalidValueError;
+}
+
+/**
+ * @param {unknown} object
+ * @returns {object is InvalidStructureError}
+ */
+function isInvalidStructureError(object) {
+    return object instanceof InvalidStructureError;
+}
+
+/**
+ * @param {unknown} object
+ * @returns {object is InvalidArrayElementError}
+ */
+function isInvalidArrayElementError(object) {
+    return object instanceof InvalidArrayElementError;
+}
+
+/**
+ * Factory for InvalidStructureError since it's used outside this module.
+ * @param {string} message
+ * @param {unknown} value
+ * @returns {InvalidStructureError}
+ */
+function makeInvalidStructureError(message, value) {
+    return new InvalidStructureError(message, value);
+}
+
+/**
  * @typedef Shortcut
  * @type {Object}
  * @property {RegexPattern} pattern - JavaScript regex pattern to match against input text
@@ -289,10 +347,11 @@ module.exports = {
     tryDeserialize,
     serializeShortcut,
     deserializeShortcut,
-    TryDeserializeError,
-    MissingFieldError,
-    InvalidTypeError,
-    InvalidValueError,
-    InvalidStructureError,
-    InvalidArrayElementError,
+    makeInvalidStructureError,
+    isTryDeserializeError,
+    isMissingFieldError,
+    isInvalidTypeError,
+    isInvalidValueError,
+    isInvalidStructureError,
+    isInvalidArrayElementError,
 };

--- a/backend/src/event/index.js
+++ b/backend/src/event/index.js
@@ -1,14 +1,14 @@
 
-const { 
-    serialize, 
-    deserialize, 
+const {
+    serialize,
+    deserialize,
     tryDeserialize,
-    TryDeserializeError,
-    MissingFieldError,
-    InvalidTypeError,
-    InvalidValueError,
-    InvalidStructureError,
-    NestedFieldError
+    isTryDeserializeError,
+    isMissingFieldError,
+    isInvalidTypeError,
+    isInvalidValueError,
+    isInvalidStructureError,
+    isNestedFieldError
 } = require('./structure');
 
 /** @typedef {import('./structure').Event} Event */
@@ -20,10 +20,10 @@ module.exports = {
     serialize,
     deserialize,
     tryDeserialize,
-    TryDeserializeError,
-    MissingFieldError,
-    InvalidTypeError,
-    InvalidValueError,
-    InvalidStructureError,
-    NestedFieldError,
+    isTryDeserializeError,
+    isMissingFieldError,
+    isInvalidTypeError,
+    isInvalidValueError,
+    isInvalidStructureError,
+    isNestedFieldError,
 };

--- a/backend/src/event/structure.js
+++ b/backend/src/event/structure.js
@@ -110,6 +110,54 @@ class NestedFieldError extends TryDeserializeError {
 }
 
 /**
+ * @param {unknown} object
+ * @returns {object is TryDeserializeError}
+ */
+function isTryDeserializeError(object) {
+    return object instanceof TryDeserializeError;
+}
+
+/**
+ * @param {unknown} object
+ * @returns {object is MissingFieldError}
+ */
+function isMissingFieldError(object) {
+    return object instanceof MissingFieldError;
+}
+
+/**
+ * @param {unknown} object
+ * @returns {object is InvalidTypeError}
+ */
+function isInvalidTypeError(object) {
+    return object instanceof InvalidTypeError;
+}
+
+/**
+ * @param {unknown} object
+ * @returns {object is InvalidValueError}
+ */
+function isInvalidValueError(object) {
+    return object instanceof InvalidValueError;
+}
+
+/**
+ * @param {unknown} object
+ * @returns {object is InvalidStructureError}
+ */
+function isInvalidStructureError(object) {
+    return object instanceof InvalidStructureError;
+}
+
+/**
+ * @param {unknown} object
+ * @returns {object is NestedFieldError}
+ */
+function isNestedFieldError(object) {
+    return object instanceof NestedFieldError;
+}
+
+/**
  * @typedef Modifiers
  * @type {Record<string, string>}
  */
@@ -337,10 +385,10 @@ module.exports = {
     serialize,
     deserialize,
     tryDeserialize,
-    TryDeserializeError,
-    MissingFieldError,
-    InvalidTypeError,
-    InvalidValueError,
-    InvalidStructureError,
-    NestedFieldError,
+    isTryDeserializeError,
+    isMissingFieldError,
+    isInvalidTypeError,
+    isInvalidValueError,
+    isInvalidStructureError,
+    isNestedFieldError,
 };

--- a/backend/src/event_log_storage.js
+++ b/backend/src/event_log_storage.js
@@ -241,11 +241,11 @@ class EventLogStorageClass {
                 this.capabilities,
                 this.configFile
             );
-            
+
             // If readConfig returned an error object, it means the config is invalid
-            if (configResult instanceof config.TryDeserializeError) {
+            if (config.isTryDeserializeError(configResult)) {
                 this.capabilities.logger.logWarning(
-                    { 
+                    {
                         filepath: this.configFile,
                         error: configResult.message,
                         field: configResult.field,
@@ -258,8 +258,8 @@ class EventLogStorageClass {
                 this.existingConfigCache = null;
                 return null;
             }
-            
-            this.existingConfigCache = configResult;
+
+            this.existingConfigCache = /** @type {import('./config/structure').Config} */ (configResult);
             return this.existingConfigCache;
         } catch (error) {
             this.existingConfigCache = null;
@@ -298,9 +298,9 @@ class EventLogStorageClass {
 
             for (const obj of objects) {
                 const result = event.tryDeserialize(obj);
-                if (result instanceof event.TryDeserializeError) {
+                if (event.isTryDeserializeError(result)) {
                     this.capabilities.logger.logWarning(
-                        { 
+                        {
                             invalidObject: obj,
                             error: result.message,
                             field: result.field,

--- a/backend/tests/config.test.js
+++ b/backend/tests/config.test.js
@@ -189,7 +189,7 @@ describe("config structure", () => {
 
             invalidObjects.forEach((obj) => {
                 const result = config.tryDeserialize(obj);
-                expect(result).toBeInstanceOf(config.TryDeserializeError);
+                expect(config.isTryDeserializeError(result)).toBe(true);
             });
         });
 
@@ -229,7 +229,7 @@ describe("config structure", () => {
 
             invalidShortcuts.forEach((obj) => {
                 const result = config.tryDeserialize(obj);
-                expect(result).toBeInstanceOf(config.TryDeserializeError);
+                expect(config.isTryDeserializeError(result)).toBe(true);
             });
         });
     });
@@ -520,7 +520,7 @@ describe("config storage", () => {
                     file
                 );
 
-                expect(result).toBeInstanceOf(config.InvalidStructureError);
+                expect(config.isInvalidStructureError(result)).toBe(true);
                 expect(result.message).toBe("Config file is empty");
             });
 
@@ -537,7 +537,7 @@ describe("config storage", () => {
                     file
                 );
 
-                expect(result).toBeInstanceOf(config.MissingFieldError);
+                expect(config.isMissingFieldError(result)).toBe(true);
                 expect(result.field).toBe("help");
             });
 

--- a/backend/tests/event_structure.test.js
+++ b/backend/tests/event_structure.test.js
@@ -13,7 +13,7 @@ describe('event.tryDeserialize', () => {
       modifiers: 0
     };
     const result = event.tryDeserialize(obj);
-    expect(result).toBeInstanceOf(event.InvalidTypeError);
+    expect(event.isInvalidTypeError(result)).toBe(true);
     expect(result.message).toContain("Invalid type for field 'modifiers'");
     expect(result.field).toBe('modifiers');
     expect(result.value).toBe(0);


### PR DESCRIPTION
## Summary
- add runtime type guards for config and event errors
- stop exporting error classes
- update config and event modules to use new guards
- adjust error handling in event log storage
- update tests for new guard functions

## Testing
- `npm test`
- `npm run static-analysis`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6860d9f57278832eb293d95db832aae9