### PR TITLE
Add custom request identifier error classes

### DIFF
--- a/backend/src/request_identifier.js
+++ b/backend/src/request_identifier.js
@@ -27,6 +27,48 @@ const randomModule = require("./random");
  */
 
 /**
+ * Error thrown when a request identifier is missing from the request.
+ */
+class MissingRequestIdentifierError extends Error {
+    constructor() {
+        super("Missing request_identifier field");
+        this.name = "MissingRequestIdentifierError";
+    }
+}
+
+/**
+ * Type guard for MissingRequestIdentifierError.
+ * @param {unknown} object
+ * @returns {object is MissingRequestIdentifierError}
+ */
+function isMissingRequestIdentifierError(object) {
+    return object instanceof MissingRequestIdentifierError;
+}
+
+/**
+ * Error thrown when a request identifier is invalid.
+ */
+class InvalidRequestIdentifierError extends Error {
+    /**
+     * @param {string} identifier
+     */
+    constructor(identifier) {
+        super("Request identifier must be a non-empty string");
+        this.name = "InvalidRequestIdentifierError";
+        this.identifier = identifier;
+    }
+}
+
+/**
+ * Type guard for InvalidRequestIdentifierError.
+ * @param {unknown} object
+ * @returns {object is InvalidRequestIdentifierError}
+ */
+function isInvalidRequestIdentifierError(object) {
+    return object instanceof InvalidRequestIdentifierError;
+}
+
+/**
  * Minimal capabilities needed for creating request directories
  * @typedef {object} MakeDirectoryCapabilities
  * @property {Creator} creator - A file system creator instance
@@ -50,11 +92,11 @@ class RequestIdentifierClass {
      */
     constructor(identifier) {
         if (typeof identifier !== 'string' || identifier.trim() === '') {
-            throw new Error("Request identifier must be a non-empty string");
+            throw new InvalidRequestIdentifierError(String(identifier));
         }
         this.identifier = identifier;
         if (this.__brand !== undefined) {
-            throw new Error("RequestIdentifier is a nominal type and should not be instantiated directly");
+            throw new InvalidRequestIdentifierError(String(identifier));
         }
     }
 }
@@ -72,7 +114,7 @@ function fromRequest(req) {
     const reqId = query['request_identifier'];
     const reqIdStr = String(reqId).trim();
     if (reqId === null || reqId === undefined || reqIdStr === '') {
-        throw new Error("Missing request_identifier field");
+        throw new MissingRequestIdentifierError();
     }
     return new RequestIdentifierClass(reqIdStr);
 }
@@ -134,4 +176,8 @@ module.exports = {
     markDone,
     isDone,
     makeDirectory,
+    MissingRequestIdentifierError,
+    isMissingRequestIdentifierError,
+    InvalidRequestIdentifierError,
+    isInvalidRequestIdentifierError,
 };

--- a/backend/tests/request_identifier.test.js
+++ b/backend/tests/request_identifier.test.js
@@ -5,6 +5,7 @@ const {
     makeDirectory,
     markDone,
     isDone,
+    MissingRequestIdentifierError,
 } = require("../src/request_identifier");
 
 const { getMockedRootCapabilities } = require("./spies");
@@ -28,16 +29,12 @@ describe("Request Identifier", () => {
 
         it("throws error when request_identifier is missing", () => {
             const req = { query: {} };
-            expect(() => fromRequest(req)).toThrow(
-                "Missing request_identifier field"
-            );
+            expect(() => fromRequest(req)).toThrow(MissingRequestIdentifierError);
         });
 
         it("throws error when request_identifier is empty", () => {
             const req = { query: { request_identifier: "" } };
-            expect(() => fromRequest(req)).toThrow(
-                "Missing request_identifier field"
-            );
+            expect(() => fromRequest(req)).toThrow(MissingRequestIdentifierError);
         });
 
         it("trims whitespace from request_identifier", () => {
@@ -48,9 +45,7 @@ describe("Request Identifier", () => {
 
         it("throws error when request_identifier is only whitespace", () => {
             const req = { query: { request_identifier: "   " } };
-            expect(() => fromRequest(req)).toThrow(
-                "Missing request_identifier field"
-            );
+            expect(() => fromRequest(req)).toThrow(MissingRequestIdentifierError);
         });
     });
 


### PR DESCRIPTION
## Summary
- add `MissingRequestIdentifierError` and `InvalidRequestIdentifierError`
- update `request_identifier` module to throw custom errors
- export error classes and update tests

## Testing
- `npm test`
- `npm run static-analysis`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6860da0d5508832e883af559deb0639d