### PR TITLE
Fix encapsulation of error classes

### DIFF
--- a/backend/src/event/from_input.js
+++ b/backend/src/event/from_input.js
@@ -64,7 +64,7 @@
 /**
  * Error thrown when input cannot be parsed according to the expected structure.
  */
-class InputParseError extends Error {
+class InputParseErrorClass extends Error {
     /** @type {string} */
     input;
 
@@ -82,7 +82,7 @@ class InputParseError extends Error {
 /**
  * Error thrown when shortcut application fails.
  */
-class ShortcutApplicationError extends Error {
+class ShortcutApplicationErrorClass extends Error {
     /** @type {string} */
     input;
     /** @type {string} */
@@ -99,6 +99,45 @@ class ShortcutApplicationError extends Error {
         this.input = input;
         this.pattern = pattern;
     }
+}
+
+/**
+ * Factory for InputParseError.
+ * @param {string} message
+ * @param {string} input
+ * @returns {Error}
+ */
+function makeInputParseError(message, input) {
+    return new InputParseErrorClass(message, input);
+}
+
+/**
+ * Type guard for InputParseError.
+ * @param {unknown} object
+ * @returns {object is Error}
+ */
+function isInputParseError(object) {
+    return object instanceof InputParseErrorClass;
+}
+
+/**
+ * Factory for ShortcutApplicationError.
+ * @param {string} message
+ * @param {string} input
+ * @param {string} pattern
+ * @returns {Error}
+ */
+function makeShortcutApplicationError(message, input, pattern) {
+    return new ShortcutApplicationErrorClass(message, input, pattern);
+}
+
+/**
+ * Type guard for ShortcutApplicationError.
+ * @param {unknown} object
+ * @returns {object is Error}
+ */
+function isShortcutApplicationError(object) {
+    return object instanceof ShortcutApplicationErrorClass;
 }
 
 /**
@@ -120,19 +159,28 @@ function parseModifier(modifier) {
     const match = modifier.match(pattern);
 
     if (!match) {
-        throw new InputParseError(`Not a valid modifier: ${JSON.stringify(modifier)}`, modifier);
+        throw makeInputParseError(
+            `Not a valid modifier: ${JSON.stringify(modifier)}`,
+            modifier
+        );
     }
 
     const type = match[1];
     const description = (match[3] || "").trim();
 
     if (!type) {
-        throw new InputParseError(`Type is required but not found in modifier: ${JSON.stringify(modifier)}`, modifier);
+        throw makeInputParseError(
+            `Type is required but not found in modifier: ${JSON.stringify(modifier)}`,
+            modifier
+        );
     }
 
     // Reject modifiers that contain square brackets (invalid format)
     if (description.includes('[') || description.includes(']')) {
-        throw new InputParseError(`Not a valid modifier: ${JSON.stringify(modifier)}`, modifier);
+        throw makeInputParseError(
+            `Not a valid modifier: ${JSON.stringify(modifier)}`,
+            modifier
+        );
     }
 
     return { type, description };
@@ -152,7 +200,7 @@ function parseStructuredInput(input) {
     const match = input.match(pattern);
 
     if (!match) {
-        throw new InputParseError("Bad structure of input", input);
+        throw makeInputParseError("Bad structure of input", input);
     }
 
     const type = match[1];
@@ -160,14 +208,17 @@ function parseStructuredInput(input) {
     const description = (match[3] || "").trim();
 
     if (!type) {
-        throw new InputParseError("Type is required but not found in input", input);
+        throw makeInputParseError("Type is required but not found in input", input);
     }
 
     // Check if description contains patterns that look like modifiers (e.g., [key value])
     // This prevents modifiers from appearing after the description has started
     const modifierLikePattern = /\[[^\]]*\s+[^\]]*\]/;
     if (modifierLikePattern.test(description)) {
-        throw new InputParseError("Modifiers must appear immediately after the type, before any description text", input);
+        throw makeInputParseError(
+            "Modifiers must appear immediately after the type, before any description text",
+            input
+        );
     }
 
     // Parse modifiers - only match those with spaces (valid modifier format)
@@ -224,7 +275,7 @@ async function applyShortcuts(capabilities, input) {
                     return replaceLoop(newInput);
                 }
             } catch (error) {
-                throw new ShortcutApplicationError(
+                throw makeShortcutApplicationError(
                     `Invalid regex pattern in shortcut: ${error instanceof Error ? error.message : String(error)}`,
                     currentInput,
                     shortcut.pattern
@@ -259,8 +310,10 @@ async function processUserInput(capabilities, rawInput) {
 }
 
 module.exports = {
-    InputParseError,
-    ShortcutApplicationError,
+    makeInputParseError,
+    isInputParseError,
+    makeShortcutApplicationError,
+    isShortcutApplicationError,
     normalizeInput,
     parseModifier,
     parseStructuredInput,

--- a/backend/src/routes/entries.js
+++ b/backend/src/routes/entries.js
@@ -3,7 +3,10 @@ const upload = require("../storage");
 const { createEntry, getEntries, EntryValidationError } = require("../entry");
 const { random: randomRequestId } = require("../request_identifier");
 const { serialize } = require("../event");
-const { processUserInput, InputParseError } = require("../event/from_input");
+const {
+    processUserInput,
+    isInputParseError,
+} = require("../event/from_input");
 
 /**
  * @typedef {import('../environment').Environment} Environment
@@ -248,7 +251,7 @@ async function handleEntryPost(req, res, capabilities, reqId) {
         try {
             processed = await processUserInput(capabilities, rawInput);
         } catch (error) {
-            if (error instanceof InputParseError) {
+            if (isInputParseError(error)) {
                 capabilities.logger.logInfo(
                     {
                         request_identifier: reqId.identifier,

--- a/backend/tests/from_input.test.js
+++ b/backend/tests/from_input.test.js
@@ -1,6 +1,8 @@
 const {
-    InputParseError,
-    ShortcutApplicationError,
+    makeInputParseError,
+    isInputParseError,
+    makeShortcutApplicationError,
+    isShortcutApplicationError,
     normalizeInput,
     parseModifier,
     parseStructuredInput,
@@ -73,8 +75,15 @@ describe("parseModifier", () => {
     });
 
     test("throws InputParseError for invalid format", () => {
-        expect(() => parseModifier("")).toThrow(InputParseError);
-        expect(() => parseModifier("   ")).toThrow(InputParseError);
+        expect(() => parseModifier("")).toThrow();
+        expect(() => parseModifier("   ")).toThrow();
+        let err;
+        try {
+            parseModifier("");
+        } catch (e) {
+            err = e;
+        }
+        expect(isInputParseError(err)).toBe(true);
     });
 
     test("error includes original input", () => {
@@ -84,7 +93,7 @@ describe("parseModifier", () => {
         } catch (e) {
             error = e;
         }
-        expect(error).toBeInstanceOf(InputParseError);
+        expect(isInputParseError(error)).toBe(true);
         expect(error.input).toBe("invalid format here [brackets]");
         expect(error.message).toContain("Not a valid modifier");
     });
@@ -164,14 +173,28 @@ describe("parseStructuredInput", () => {
     });
 
     test("throws InputParseError for invalid structure", () => {
-        expect(() => parseStructuredInput("")).toThrow(InputParseError);
-        expect(() => parseStructuredInput("   ")).toThrow(InputParseError);
-        expect(() => parseStructuredInput("[invalid] structure")).toThrow(InputParseError);
-        expect(() => parseStructuredInput("123invalid")).toThrow(InputParseError);
+        expect(() => parseStructuredInput("")).toThrow();
+        expect(() => parseStructuredInput("   ")).toThrow();
+        expect(() => parseStructuredInput("[invalid] structure")).toThrow();
+        expect(() => parseStructuredInput("123invalid")).toThrow();
+        let err1;
+        try {
+            parseStructuredInput("");
+        } catch (e) {
+            err1 = e;
+        }
+        expect(isInputParseError(err1)).toBe(true);
     });
 
     test("throws InputParseError when type is missing", () => {
-        expect(() => parseStructuredInput("[loc office] - no type")).toThrow(InputParseError);
+        expect(() => parseStructuredInput("[loc office] - no type")).toThrow();
+        let err2;
+        try {
+            parseStructuredInput("[loc office] - no type");
+        } catch (e) {
+            err2 = e;
+        }
+        expect(isInputParseError(err2)).toBe(true);
     });
 
     test("error includes original input", () => {
@@ -181,7 +204,7 @@ describe("parseStructuredInput", () => {
         } catch (e) {
             error = e;
         }
-        expect(error).toBeInstanceOf(InputParseError);
+        expect(isInputParseError(error)).toBe(true);
         expect(error.input).toBe("123invalid");
     });
 
@@ -195,8 +218,17 @@ describe("parseStructuredInput", () => {
         ];
 
         for (const input of invalidInputs) {
-            expect(() => parseStructuredInput(input)).toThrow(InputParseError);
-            expect(() => parseStructuredInput(input)).toThrow("Modifiers must appear immediately after the type, before any description text");
+            expect(() => parseStructuredInput(input)).toThrow();
+            expect(() => parseStructuredInput(input)).toThrow(
+                "Modifiers must appear immediately after the type, before any description text"
+            );
+            let errLoop;
+            try {
+                parseStructuredInput(input);
+            } catch (e) {
+                errLoop = e;
+            }
+            expect(isInputParseError(errLoop)).toBe(true);
         }
     });
 
@@ -442,7 +474,14 @@ describe("processUserInput", () => {
         });
 
         await expect(processUserInput(capabilities, "[invalid] format"))
-            .rejects.toThrow(InputParseError);
+            .rejects.toThrow();
+        let errProc;
+        try {
+            await processUserInput(capabilities, "[invalid] format");
+        } catch (e) {
+            errProc = e;
+        }
+        expect(isInputParseError(errProc)).toBe(true);
     });
 
     test("handles minimal input", async () => {
@@ -469,19 +508,19 @@ describe("processUserInput", () => {
 
 describe("Error Classes", () => {
     test("InputParseError stores input and message", () => {
-        const error = new InputParseError("Test message", "test input");
+        const error = makeInputParseError("Test message", "test input");
         expect(error.message).toBe("Test message");
         expect(error.input).toBe("test input");
         expect(error).toBeInstanceOf(Error);
-        expect(error.name).toBe("InputParseError");
+        expect(isInputParseError(error)).toBe(true);
     });
 
     test("ShortcutApplicationError stores input and message", () => {
-        const error = new ShortcutApplicationError("Test message", "test input");
+        const error = makeShortcutApplicationError("Test message", "test input", "pattern");
         expect(error.message).toBe("Test message");
         expect(error.input).toBe("test input");
         expect(error).toBeInstanceOf(Error);
-        expect(error.name).toBe("ShortcutApplicationError");
+        expect(isShortcutApplicationError(error)).toBe(true);
     });
 });
 
@@ -533,7 +572,14 @@ describe("Integration Tests", () => {
         });
 
         await expect(processUserInput(capabilities, "bad"))
-            .rejects.toThrow(InputParseError);
+            .rejects.toThrow();
+        let errEdge;
+        try {
+            await processUserInput(capabilities, "bad");
+        } catch (e) {
+            errEdge = e;
+        }
+        expect(isInputParseError(errEdge)).toBe(true);
     });
 
     test("preserves complex descriptions", async () => {


### PR DESCRIPTION
## Summary
- avoid exporting `InputParseError` and `ShortcutApplicationError` classes
- provide factory and type guard helpers instead
- update routes and tests to use new helpers

## Testing
- `npm test`
- `npm run static-analysis`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6860da033488832ebe6e1267cdba3e04