### PR TITLE
Fix coding convention violations

### DIFF
--- a/backend/src/config/structure.js
+++ b/backend/src/config/structure.js
@@ -317,10 +317,8 @@ function tryDeserialize(obj) {
                 return new InvalidArrayElementError("shortcuts", i, shortcut, "third element (description) must be a string if provided");
             }
 
-            // Cast to proper type after validation
-            validatedShortcuts.push(
-                /** @type {SerializedShortcut} */ (shortcut)
-            );
+            // Build validated shortcut after validation
+            validatedShortcuts.push([pattern, replacement, description]);
         }
 
         // Create validated SerializedConfig object

--- a/backend/src/event/structure.js
+++ b/backend/src/event/structure.js
@@ -158,6 +158,15 @@ function isNestedFieldError(object) {
 }
 
 /**
+ * Checks if a value is a plain object with string keys.
+ * @param {unknown} value
+ * @returns {value is Record<string, unknown>}
+ */
+function isStringRecord(value) {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
  * @typedef Modifiers
  * @type {Record<string, string>}
  */
@@ -290,7 +299,10 @@ function tryDeserialize(obj) {
             return new InvalidTypeError("modifiers", rawModifiers, "object");
         }
         /** @type {Record<string, unknown>} */
-        const modifiers = hasModifiers ? /** @type {Record<string, unknown>} */ (rawModifiers) : {};
+        let modifiers = {};
+        if (hasModifiers && isStringRecord(rawModifiers)) {
+            modifiers = rawModifiers;
+        }
 
         // Manually validate and parse the date
         const dateObj = new Date(date);

--- a/backend/src/event_log_storage.js
+++ b/backend/src/event_log_storage.js
@@ -259,7 +259,12 @@ class EventLogStorageClass {
                 return null;
             }
 
-            this.existingConfigCache = /** @type {import('./config/structure').Config} */ (configResult);
+            if (configResult instanceof Error) {
+                this.existingConfigCache = null;
+                return null;
+            }
+
+            this.existingConfigCache = configResult;
             return this.existingConfigCache;
         } catch (error) {
             this.existingConfigCache = null;

--- a/backend/src/json_stream_file/index.js
+++ b/backend/src/json_stream_file/index.js
@@ -27,9 +27,14 @@ async function readObjects(capabilities, file) {
         const jsonParser = parser({ jsonStreaming: true });
         const pipeline = rs.pipe(jsonParser).pipe(streamValues());
 
-        pipeline.on("data", (/** @type {{ value: unknown }} */ { value }) => {
-            objects.push(value);
-        });
+        /**
+         * @param {{ value: unknown }} chunk
+         */
+        function onData(chunk) {
+            objects.push(chunk.value);
+        }
+
+        pipeline.on("data", onData);
 
         pipeline.on("end", () => {
             resolve(objects);

--- a/backend/src/request_identifier.js
+++ b/backend/src/request_identifier.js
@@ -109,8 +109,7 @@ class RequestIdentifierClass {
  * @returns {RequestIdentifier}
  */
 function fromRequest(req) {
-    /** @type {any} */
-    const query = req.query;
+    const query = req.query || {};
     const reqId = query['request_identifier'];
     const reqIdStr = String(reqId).trim();
     if (reqId === null || reqId === undefined || reqIdStr === '') {

--- a/backend/src/routes/entries.js
+++ b/backend/src/routes/entries.js
@@ -372,9 +372,10 @@ function parsePaginationParams(query) {
         ? String(Array.isArray(orderRaw) ? orderRaw[0] : orderRaw)
         : "dateDescending";
 
-    const order = ['dateAscending', 'dateDescending'].includes(orderStr)
-        ? /** @type {'dateAscending'|'dateDescending'} */ (orderStr)
-        : 'dateDescending';
+    const order =
+        orderStr === 'dateAscending' || orderStr === 'dateDescending'
+            ? orderStr
+            : 'dateDescending';
 
     return { page, limit, order };
 }

--- a/backend/src/routes/periodic.js
+++ b/backend/src/routes/periodic.js
@@ -39,8 +39,7 @@ const { everyHour } = require("../schedule/tasks");
  * @param {import('express').Response} res
  */
 async function handlePeriodicRequest(capabilities, req, res) {
-    /** @type {any} */
-    const query = req.query;
+    const query = req.query || {};
     const period = query['period'];
 
     capabilities.logger.logDebug(

--- a/backend/src/routes/ping.js
+++ b/backend/src/routes/ping.js
@@ -21,8 +21,7 @@ const runtimeIdentifier = require("../runtime_identifier");
  * @param {import('express').Response} res
  */
 async function handlePingRequest(capabilities, req, res) {
-    /** @type {any} */
-    const query = req.query;
+    const query = req.query || {};
     const id = query["runtime_identifier"];
 
     if (id !== undefined) {

--- a/backend/src/routes/transcribe.js
+++ b/backend/src/routes/transcribe.js
@@ -54,8 +54,7 @@ async function handleTranscribeRequest(capabilities, req, res) {
     }
 
     // pull input and output params
-    /** @type {any} */
-    const query = req.query;
+    const query = req.query || {};
     const rawIn = query["input"];
     // Log the transcription request
     capabilities.logger.logInfo(

--- a/backend/src/routes/transcribe_all.js
+++ b/backend/src/routes/transcribe_all.js
@@ -52,8 +52,7 @@ async function handleTranscribeAllRequest(capabilities, req, res) {
         });
     }
 
-    /** @type {any} */
-    const query = req.query;
+    const query = req.query || {};
     const rawDir = query["input_dir"];
     capabilities.logger.logInfo(
         {

--- a/backend/src/routes/upload.js
+++ b/backend/src/routes/upload.js
@@ -44,7 +44,7 @@ function makeRouter(capabilities) {
             });
         }
 
-        const files = /** @type {Express.Multer.File[]} */ (req.files || []);
+        const files = Array.isArray(req.files) ? req.files : [];
         const uploaded = files.map((f) => f.filename);
         capabilities.logger.logInfo(
             { files: uploaded, request_identifier: reqId.identifier },


### PR DESCRIPTION
## Summary
- remove inline type casts from request and config handling
- add runtime checks instead of type-casts
- adjust schedule and ping routes for safer query parsing
- introduce isStringRecord helper for event parsing
- update JSON stream handler without casting

## Testing
- `npm test`
- `npm run static-analysis`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68615dbaef14832eb2c2886a65cd8f5f