### PR TITLE
Fix process exit to use capability

### DIFF
--- a/backend/src/capabilities/root.js
+++ b/backend/src/capabilities/root.js
@@ -19,6 +19,7 @@
 /** @typedef {import('../schedule').Scheduler} Scheduler */
 /** @typedef {import('../ai/transcription').AITranscription} AITranscription */
 /** @typedef {import('../datetime').Datetime} Datetime */
+/** @typedef {import('../exiter').Exiter} Exiter */
 
 
 /**
@@ -39,6 +40,7 @@
  * @property {Scheduler} scheduler - A scheduler instance.
  * @property {AITranscription} aiTranscription - An AI transcription instance.
  * @property {Datetime} datetime - Datetime utilities.
+ * @property {Exiter} exiter - Process exiting capability.
  */
 
 const memconst = require("../memconst");
@@ -59,6 +61,7 @@ const notifierCapability = require("../notifications");
 const schedulerCapability = require("../schedule");
 const aiTranscriptionCapability = require("../ai/transcription");
 const datetimeCapability = require("../datetime");
+const exiterCapability = require("../exiter");
 
 /**
  * This structure collects maximum capabilities that any part of Volodyslav can access.
@@ -87,6 +90,7 @@ const make = memconst(() => {
         notifier: notifierCapability.make(),
         scheduler: schedulerCapability.make(),
         aiTranscription: aiTranscriptionCapability.make({ environment }),
+        exiter: exiterCapability.make(),
     };
 
     return ret;

--- a/backend/src/exiter.js
+++ b/backend/src/exiter.js
@@ -1,0 +1,18 @@
+/**
+ * @typedef {ReturnType<typeof make>} Exiter
+ */
+
+/**
+ * Exits the process with the provided code.
+ * @param {number} code
+ * @returns {never}
+ */
+function exit(code) {
+    process.exit(code);
+}
+
+function make() {
+    return { exit };
+}
+
+module.exports = { make };

--- a/backend/src/gentlewrap.js
+++ b/backend/src/gentlewrap.js
@@ -12,6 +12,7 @@
 /**
  * @typedef {object} Capabilities
  * @property {Logger} logger - A logger instance.
+ * @property {import('./exiter').Exiter} exiter - Process exiting capability.
  */
 
 /**
@@ -38,7 +39,7 @@ async function gentleCall(capabilities, fn, errorsList) {
                     ? String(e.message)
                     : String(e);
             capabilities.logger.logError({}, message);
-            process.exit(1);
+            capabilities.exiter.exit(1);
         } else {
             throw e;
         }

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -29,7 +29,7 @@ async function entryTyped(capabilities) {
         .action(async (options) => {
             if (options.version) {
                 await printVersion(capabilities);
-                process.exit(0);
+                capabilities.exiter.exit(0);
             }
         });
 


### PR DESCRIPTION
## Summary
- add new `exiter` capability for process termination
- include exiter in root capabilities
- use `capabilities.exiter.exit` in `gentlewrap` and `index` modules

## Testing
- `npm test` *(fails: jest not found)*
- `npm run static-analysis` *(fails: missing dependencies)*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68615dd47c1c832eb459afe29ac43dd5