### PR TITLE
Refactor working repository tests

### DIFF
--- a/backend/tests/working_repository.basic.test.js
+++ b/backend/tests/working_repository.basic.test.js
@@ -1,0 +1,80 @@
+const path = require("path");
+const workingRepository = require("../src/gitstore/working_repository");
+const fsp = require("fs/promises");
+const { getMockedRootCapabilities } = require("./spies");
+const {
+    stubEnvironment,
+    stubLogger,
+    stubDatetime,
+    stubEventLogRepository,
+} = require("./stubs");
+
+function getTestCapabilities() {
+    const capabilities = getMockedRootCapabilities();
+    stubEnvironment(capabilities);
+    stubLogger(capabilities);
+    stubDatetime(capabilities);
+    return capabilities;
+}
+
+describe("working_repository", () => {
+    test("synchronize creates working repository when it doesn't exist", async () => {
+        const capabilities = getTestCapabilities();
+        await capabilities.logger.setup(capabilities);
+        const localRepoPath = path.join(
+            capabilities.environment.workingDirectory(),
+            "working-git-repository",
+            ".git"
+        );
+
+        // Set up a real git repo to clone from
+        await stubEventLogRepository(capabilities);
+
+        // Ensure the repository doesn't exist before synchronization.
+        const indexExistsBeforeSync = await fsp
+            .stat(path.join(localRepoPath, "index"))
+            .then(() => true)
+            .catch(() => false);
+
+        expect(indexExistsBeforeSync).toBe(false);
+
+        // Execute synchronize
+        await workingRepository.synchronize(capabilities);
+
+        // Verify the repository was created and has the index file
+        const indexExists = await fsp
+            .stat(path.join(localRepoPath, "index"))
+            .then(() => true)
+            .catch(() => false);
+
+        expect(indexExists).toBe(true);
+    });
+
+    test("getRepository returns the correct repository path", async () => {
+        const capabilities = getTestCapabilities();
+        await capabilities.logger.setup(capabilities);
+
+        // Set up a real git repo to clone from
+        await stubEventLogRepository(capabilities);
+
+        // Execute getRepository (which should trigger synchronize)
+        const repoPath = await workingRepository.getRepository(capabilities);
+
+        // Verify correct path is returned
+        const expectedPath = path.join(
+            capabilities.environment.workingDirectory(),
+            "working-git-repository",
+            ".git"
+        );
+        expect(repoPath).toBe(expectedPath);
+
+        // Verify the repo actually exists
+        const indexExists = await fsp
+            .stat(path.join(expectedPath, "index"))
+            .then(() => true)
+            .catch(() => false);
+
+        expect(indexExists).toBe(true);
+    });
+});
+

--- a/backend/tests/working_repository.errors.test.js
+++ b/backend/tests/working_repository.errors.test.js
@@ -1,0 +1,83 @@
+const workingRepository = require("../src/gitstore/working_repository");
+const { getMockedRootCapabilities } = require("./spies");
+const {
+    stubEnvironment,
+    stubLogger,
+    stubDatetime,
+} = require("./stubs");
+
+function getTestCapabilities() {
+    const capabilities = getMockedRootCapabilities();
+    stubEnvironment(capabilities);
+    stubLogger(capabilities);
+    stubDatetime(capabilities);
+    return capabilities;
+}
+
+describe("working_repository", () => {
+    test("synchronize throws WorkingRepositoryError on git failure", async () => {
+        const capabilities = getTestCapabilities();
+        await capabilities.logger.setup(capabilities);
+
+        // Make the eventLogRepository return a non-existent path
+        const origEventLogRepo = require("../src/environment").eventLogRepository;
+        require("../src/environment").eventLogRepository = jest
+            .fn()
+            .mockReturnValue("/nonexistent/repo");
+
+        // Execute and verify error is thrown with the expected message
+        await expect(
+            workingRepository.synchronize(capabilities)
+        ).rejects.toThrow("Failed to synchronize repository");
+
+        // Restore original function
+        require("../src/environment").eventLogRepository = origEventLogRepo;
+    });
+
+    // Separate test for WorkingRepositoryError type checking
+    test("errors from synchronize are WorkingRepositoryError instances", async () => {
+        const capabilities = getTestCapabilities();
+        await capabilities.logger.setup(capabilities);
+
+        // Make the eventLogRepository return a non-existent path
+        const origEventLogRepo = require("../src/environment").eventLogRepository;
+        require("../src/environment").eventLogRepository = jest
+            .fn()
+            .mockReturnValue("/nonexistent/repo");
+
+        // Execute and save the error
+        let thrownError = null;
+        try {
+            await workingRepository.synchronize(capabilities);
+        } catch (error) {
+            thrownError = error;
+        }
+
+        // Verify error is of the correct type
+        expect(thrownError).not.toBeNull();
+        expect(workingRepository.isWorkingRepositoryError(thrownError)).toBe(true);
+
+        // Restore original function
+        require("../src/environment").eventLogRepository = origEventLogRepo;
+    });
+
+    test("synchronize throws error for invalid repository path", async () => {
+        const capabilities = getTestCapabilities();
+        await capabilities.logger.setup(capabilities);
+
+        // Mock an invalid repository path
+        const origEventLogRepo = capabilities.environment.eventLogRepository;
+        capabilities.environment.eventLogRepository = jest
+            .fn()
+            .mockReturnValue("/invalid/path");
+
+        // Execute and verify error is thrown
+        await expect(
+            workingRepository.synchronize(capabilities)
+        ).rejects.toThrow("Failed to synchronize repository");
+
+        // Restore original function
+        capabilities.environment.eventLogRepository = origEventLogRepo;
+    });
+});
+


### PR DESCRIPTION
## Summary
- split `working_repository.test.js` into basic, error and remote suites

## Testing
- `npm test`
- `npm run static-analysis`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68634b22d438832e934b54be97a44c3a