### PR TITLE
Fix CLI unknown command handling

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -24,14 +24,7 @@ async function entryTyped(capabilities) {
 
     program.name("volodyslav").description("Volodyslav Media Service CLI");
 
-    program
-        .option("-v, --version", "Display the version")
-        .action(async (options) => {
-            if (options.version) {
-                await printVersion(capabilities);
-                process.exit(0);
-            }
-        });
+    program.option("-v, --version", "Display the version");
 
     program
         .command("start")
@@ -39,6 +32,13 @@ async function entryTyped(capabilities) {
         .action(start(capabilities));
 
     await program.parseAsync(process.argv);
+
+    const options = program.opts();
+
+    if (options["version"]) {
+        await printVersion(capabilities);
+        return;
+    }
 
     // If we made it here then no sub‐commands or flags were used
     // so show the help and exit

--- a/backend/tests/cli.test.js
+++ b/backend/tests/cli.test.js
@@ -1,0 +1,16 @@
+const path = require('path');
+const { execFile } = require('child_process');
+
+describe('CLI', () => {
+    test('prints unknown command error', async () => {
+        const cliPath = path.join(__dirname, '..', 'src', 'index.js');
+        await new Promise((resolve, _reject) => {
+            execFile('node', [cliPath, 'unknown'], (error, stdout, stderr) => {
+                expect(error).not.toBeNull();
+                expect(stderr).toContain("error: unknown command 'unknown'");
+                expect(stderr).not.toContain('too many arguments');
+                resolve();
+            });
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- fix CLI to let commander handle unknown commands
- add regression test for CLI unknown command behavior

## Testing
- `npm test`
- `npm run static-analysis`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6863651d4908832eb89f1747b71fcae5