### PR TITLE
Improve CLI error handling

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -26,10 +26,17 @@ async function entryTyped(capabilities) {
 
     program
         .option("-v, --version", "Display the version")
-        .action(async (options) => {
+        .argument("[cmd]", "Command to execute")
+        .action(async (cmd, options) => {
             if (options.version) {
                 await printVersion(capabilities);
                 process.exit(0);
+            }
+            if (cmd) {
+                console.error(`error: unknown command '${cmd}'`);
+                program.help({ error: true });
+            } else {
+                program.outputHelp();
             }
         });
 
@@ -39,12 +46,6 @@ async function entryTyped(capabilities) {
         .action(start(capabilities));
 
     await program.parseAsync(process.argv);
-
-    // If we made it here then no sub‐commands or flags were used
-    // so show the help and exit
-    if (process.argv.slice(2).length === 0) {
-        program.outputHelp(); // or .help() to print and exit
-    }
 }
 
 async function entry() {

--- a/backend/tests/cli.test.js
+++ b/backend/tests/cli.test.js
@@ -1,0 +1,20 @@
+const path = require('path');
+const { promisify } = require('util');
+const { execFile } = require('child_process');
+
+const execFileAsync = promisify(execFile);
+const cliPath = path.join(__dirname, '..', 'src', 'index.js');
+
+describe('CLI', () => {
+    test('unknown command shows helpful message', async () => {
+        await expect(execFileAsync('node', [cliPath, 'unknown'])).rejects.toMatchObject({
+            code: expect.any(Number),
+            stderr: expect.stringMatching(/unknown command/i),
+        });
+    });
+
+    test('--version displays version', async () => {
+        const { stdout } = await execFileAsync('node', [cliPath, '--version']);
+        expect(stdout.trim()).not.toHaveLength(0);
+    });
+});


### PR DESCRIPTION
## Summary
- handle unknown CLI commands
- add CLI integration test

## Testing
- `npm test`
- `npm run static-analysis`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686374d81038832e8a33299e34dbcf74