### PR TITLE
Split shortcuts tests

### DIFF
--- a/backend/tests/entries_post_shortcuts.config.test.js
+++ b/backend/tests/entries_post_shortcuts.config.test.js
@@ -1,0 +1,138 @@
+const request = require("supertest");
+const { makeTestApp } = require("./api_ordering_test_setup");
+const fs = require("fs");
+const path = require("path");
+
+describe("POST /api/entries - rawInput transformation and shortcuts", () => {
+    it("works without shortcuts when config file doesn't exist", async () => {
+        const { app, capabilities } = await makeTestApp();
+        const fixedTime = new Date("2025-05-23T12:00:00.000Z").getTime();
+        capabilities.datetime.now.mockReturnValue(fixedTime);
+
+        const requestBody = {
+            rawInput: "WORK [loc office] - No shortcuts here",
+        };
+
+        const res = await request(app)
+            .post("/api/entries")
+            .send(requestBody)
+            .set("Content-Type", "application/json");
+
+        expect(res.statusCode).toBe(201);
+        expect(res.body.success).toBe(true);
+        expect(res.body.entry).toMatchObject({
+            type: "WORK",
+            description: "- No shortcuts here",
+            modifiers: { loc: "office" },
+            input: "WORK [loc office] - No shortcuts here",
+            original: "WORK [loc office] - No shortcuts here"
+        });
+    });
+
+    it("works with empty shortcuts config", async () => {
+        const { app, capabilities } = await makeTestApp();
+        const fixedTime = new Date("2025-05-23T12:00:00.000Z").getTime();
+        capabilities.datetime.now.mockReturnValue(fixedTime);
+
+        // Create config with empty shortcuts using transaction system
+        const { transaction } = require("../src/event_log_storage");
+        await transaction(capabilities, async (storage) => {
+            storage.setConfig({
+                help: "test config",
+                shortcuts: []
+            });
+        });
+
+        const requestBody = {
+            rawInput: "EXERCISE [loc gym] - Weightlifting session",
+        };
+
+        const res = await request(app)
+            .post("/api/entries")
+            .send(requestBody)
+            .set("Content-Type", "application/json");
+
+        expect(res.statusCode).toBe(201);
+        expect(res.body.success).toBe(true);
+        expect(res.body.entry).toMatchObject({
+            type: "EXERCISE",
+            description: "- Weightlifting session",
+            modifiers: { loc: "gym" },
+            input: "EXERCISE [loc gym] - Weightlifting session",
+            original: "EXERCISE [loc gym] - Weightlifting session"
+        });
+    });
+
+    it("handles malformed config gracefully", async () => {
+        const { app, capabilities } = await makeTestApp();
+        const fixedTime = new Date("2025-05-23T12:00:00.000Z").getTime();
+        capabilities.datetime.now.mockReturnValue(fixedTime);
+
+        // Create malformed config
+        const configPath = capabilities.environment.eventLogRepository() + "/config.json";
+        fs.mkdirSync(path.dirname(configPath), { recursive: true });
+        fs.writeFileSync(configPath, "invalid json content");
+
+        const requestBody = {
+            rawInput: "MEETING [with John] - Project discussion",
+        };
+
+        const res = await request(app)
+            .post("/api/entries")
+            .send(requestBody)
+            .set("Content-Type", "application/json");
+
+        expect(res.statusCode).toBe(201);
+        expect(res.body.success).toBe(true);
+        expect(res.body.entry).toMatchObject({
+            type: "MEETING",
+            description: "- Project discussion",
+            modifiers: { with: "John" },
+            input: "MEETING [with John] - Project discussion",
+            original: "MEETING [with John] - Project discussion"
+        });
+
+        // Clean up
+        fs.unlinkSync(configPath);
+    });
+    it("confirms no transformation when config file doesn't exist (expected behavior)", async () => {
+        // This test verifies what happens when there's no config file - 
+        // this is likely what's happening in your real application
+        const { app, capabilities } = await makeTestApp();
+        const fixedTime = new Date("2025-05-23T12:00:00.000Z").getTime();
+        capabilities.datetime.now.mockReturnValue(fixedTime);
+
+        // Ensure no config file exists
+        const eventLogRepo = capabilities.environment.eventLogRepository();
+        const configPath = eventLogRepo + "/config.json";
+        
+        // Make sure the directory exists but no config file
+        fs.mkdirSync(path.dirname(configPath), { recursive: true });
+        
+        // Verify no config file exists
+        if (fs.existsSync(configPath)) {
+            fs.unlinkSync(configPath);
+        }
+
+        // Test with input that would be transformed if shortcuts existed
+        const requestBody = { rawInput: "w [loc o] - Should not be transformed" };
+
+        const res = await request(app)
+            .post("/api/entries")
+            .send(requestBody)
+            .set("Content-Type", "application/json");
+
+        expect(res.statusCode).toBe(201);
+        expect(res.body.success).toBe(true);
+        
+        // Without config, no transformation should happen
+        expect(res.body.entry.original).toBe("w [loc o] - Should not be transformed");
+        expect(res.body.entry.input).toBe("w [loc o] - Should not be transformed"); // Same as original
+        expect(res.body.entry.type).toBe("w"); // Not transformed
+
+        // Test the config endpoint too
+        const configRes = await request(app).get("/api/config");
+        expect(configRes.statusCode).toBe(200);
+        expect(configRes.body.config).toBeNull(); // No config file means null config
+    });
+});

--- a/backend/tests/entries_post_shortcuts.transform.test.js
+++ b/backend/tests/entries_post_shortcuts.transform.test.js
@@ -1,27 +1,5 @@
 const request = require("supertest");
-const expressApp = require("../src/express_app");
-const { addRoutes } = require("../src/server");
-const { getMockedRootCapabilities } = require("./spies");
-const {
-    stubEnvironment,
-    stubLogger,
-    stubDatetime,
-    stubEventLogRepository,
-} = require("./stubs");
-const fs = require("fs");
-const path = require("path");
-
-async function makeTestApp() {
-    const capabilities = getMockedRootCapabilities();
-    stubEnvironment(capabilities);
-    stubLogger(capabilities);
-    stubDatetime(capabilities);
-    await stubEventLogRepository(capabilities);
-    const app = expressApp.make();
-    capabilities.logger.enableHttpCallsLogging(app);
-    await addRoutes(capabilities, app);
-    return { app, capabilities };
-}
+const { makeTestApp } = require("./api_ordering_test_setup");
 
 describe("POST /api/entries - rawInput transformation and shortcuts", () => {
     it("applies shortcuts from config when creating entries", async () => {
@@ -102,98 +80,6 @@ describe("POST /api/entries - rawInput transformation and shortcuts", () => {
             input: "WORK [loc office] - Fixed bug",
             original: "wo - Fixed bug"
         });
-    });
-
-    it("works without shortcuts when config file doesn't exist", async () => {
-        const { app, capabilities } = await makeTestApp();
-        const fixedTime = new Date("2025-05-23T12:00:00.000Z").getTime();
-        capabilities.datetime.now.mockReturnValue(fixedTime);
-
-        const requestBody = {
-            rawInput: "WORK [loc office] - No shortcuts here",
-        };
-
-        const res = await request(app)
-            .post("/api/entries")
-            .send(requestBody)
-            .set("Content-Type", "application/json");
-
-        expect(res.statusCode).toBe(201);
-        expect(res.body.success).toBe(true);
-        expect(res.body.entry).toMatchObject({
-            type: "WORK",
-            description: "- No shortcuts here",
-            modifiers: { loc: "office" },
-            input: "WORK [loc office] - No shortcuts here",
-            original: "WORK [loc office] - No shortcuts here"
-        });
-    });
-
-    it("works with empty shortcuts config", async () => {
-        const { app, capabilities } = await makeTestApp();
-        const fixedTime = new Date("2025-05-23T12:00:00.000Z").getTime();
-        capabilities.datetime.now.mockReturnValue(fixedTime);
-
-        // Create config with empty shortcuts using transaction system
-        const { transaction } = require("../src/event_log_storage");
-        await transaction(capabilities, async (storage) => {
-            storage.setConfig({
-                help: "test config",
-                shortcuts: []
-            });
-        });
-
-        const requestBody = {
-            rawInput: "EXERCISE [loc gym] - Weightlifting session",
-        };
-
-        const res = await request(app)
-            .post("/api/entries")
-            .send(requestBody)
-            .set("Content-Type", "application/json");
-
-        expect(res.statusCode).toBe(201);
-        expect(res.body.success).toBe(true);
-        expect(res.body.entry).toMatchObject({
-            type: "EXERCISE",
-            description: "- Weightlifting session",
-            modifiers: { loc: "gym" },
-            input: "EXERCISE [loc gym] - Weightlifting session",
-            original: "EXERCISE [loc gym] - Weightlifting session"
-        });
-    });
-
-    it("handles malformed config gracefully", async () => {
-        const { app, capabilities } = await makeTestApp();
-        const fixedTime = new Date("2025-05-23T12:00:00.000Z").getTime();
-        capabilities.datetime.now.mockReturnValue(fixedTime);
-
-        // Create malformed config
-        const configPath = capabilities.environment.eventLogRepository() + "/config.json";
-        fs.mkdirSync(path.dirname(configPath), { recursive: true });
-        fs.writeFileSync(configPath, "invalid json content");
-
-        const requestBody = {
-            rawInput: "MEETING [with John] - Project discussion",
-        };
-
-        const res = await request(app)
-            .post("/api/entries")
-            .send(requestBody)
-            .set("Content-Type", "application/json");
-
-        expect(res.statusCode).toBe(201);
-        expect(res.body.success).toBe(true);
-        expect(res.body.entry).toMatchObject({
-            type: "MEETING",
-            description: "- Project discussion",
-            modifiers: { with: "John" },
-            input: "MEETING [with John] - Project discussion",
-            original: "MEETING [with John] - Project discussion"
-        });
-
-        // Clean up
-        fs.unlinkSync(configPath);
     });
 
     it("preserves word boundaries in shortcuts", async () => {
@@ -440,44 +326,4 @@ describe("POST /api/entries - rawInput transformation and shortcuts", () => {
         expect(res.body.entry.type).toBe("TRANSFORMED");
     });
 
-    it("confirms no transformation when config file doesn't exist (expected behavior)", async () => {
-        // This test verifies what happens when there's no config file - 
-        // this is likely what's happening in your real application
-        const { app, capabilities } = await makeTestApp();
-        const fixedTime = new Date("2025-05-23T12:00:00.000Z").getTime();
-        capabilities.datetime.now.mockReturnValue(fixedTime);
-
-        // Ensure no config file exists
-        const eventLogRepo = capabilities.environment.eventLogRepository();
-        const configPath = eventLogRepo + "/config.json";
-        
-        // Make sure the directory exists but no config file
-        fs.mkdirSync(path.dirname(configPath), { recursive: true });
-        
-        // Verify no config file exists
-        if (fs.existsSync(configPath)) {
-            fs.unlinkSync(configPath);
-        }
-
-        // Test with input that would be transformed if shortcuts existed
-        const requestBody = { rawInput: "w [loc o] - Should not be transformed" };
-
-        const res = await request(app)
-            .post("/api/entries")
-            .send(requestBody)
-            .set("Content-Type", "application/json");
-
-        expect(res.statusCode).toBe(201);
-        expect(res.body.success).toBe(true);
-        
-        // Without config, no transformation should happen
-        expect(res.body.entry.original).toBe("w [loc o] - Should not be transformed");
-        expect(res.body.entry.input).toBe("w [loc o] - Should not be transformed"); // Same as original
-        expect(res.body.entry.type).toBe("w"); // Not transformed
-
-        // Test the config endpoint too
-        const configRes = await request(app).get("/api/config");
-        expect(configRes.statusCode).toBe(200);
-        expect(configRes.body.config).toBeNull(); // No config file means null config
-    });
 });


### PR DESCRIPTION
## Summary
- break up `entries_post_shortcuts.test.js` into two smaller files
- keep helper `makeTestApp` in `api_ordering_test_setup` for both

## Testing
- `npm test`
- `npm run static-analysis`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6863a5cac2e8832e985f9d2328f794c7