### PR TITLE
Refactor input handling

### DIFF
--- a/backend/src/event/from_input.js
+++ b/backend/src/event/from_input.js
@@ -54,191 +54,20 @@
  * @property {import('../logger').Logger} logger - Logger for error reporting
  */
 
-/**
- * @typedef {object} ParsedInput
- * @property {string} type - The type of the event
- * @property {string} description - The description of the event
- * @property {Record<string, string>} modifiers - The modifiers for the event
- */
+/** @typedef {import('./parsers').ParsedInput} ParsedInput */
 
-/**
- * Error thrown when input cannot be parsed according to the expected structure.
- */
-class InputParseErrorClass extends Error {
-    /** @type {string} */
-    input;
+const {
+    makeInputParseError,
+    isInputParseError,
+    makeShortcutApplicationError,
+    isShortcutApplicationError,
+} = require("./input_errors");
 
-    /**
-     * @param {string} message
-     * @param {string} input
-     */
-    constructor(message, input) {
-        super(message);
-        this.name = "InputParseError";
-        this.input = input;
-    }
-}
-
-/**
- * Error thrown when shortcut application fails.
- */
-class ShortcutApplicationErrorClass extends Error {
-    /** @type {string} */
-    input;
-    /** @type {string} */
-    pattern;
-
-    /**
-     * @param {string} message
-     * @param {string} input
-     * @param {string} pattern
-     */
-    constructor(message, input, pattern) {
-        super(message);
-        this.name = "ShortcutApplicationError";
-        this.input = input;
-        this.pattern = pattern;
-    }
-}
-
-/**
- * Factory for InputParseError.
- * @param {string} message
- * @param {string} input
- * @returns {Error}
- */
-function makeInputParseError(message, input) {
-    return new InputParseErrorClass(message, input);
-}
-
-/**
- * Type guard for InputParseError.
- * @param {unknown} object
- * @returns {object is Error}
- */
-function isInputParseError(object) {
-    return object instanceof InputParseErrorClass;
-}
-
-/**
- * Factory for ShortcutApplicationError.
- * @param {string} message
- * @param {string} input
- * @param {string} pattern
- * @returns {Error}
- */
-function makeShortcutApplicationError(message, input, pattern) {
-    return new ShortcutApplicationErrorClass(message, input, pattern);
-}
-
-/**
- * Type guard for ShortcutApplicationError.
- * @param {unknown} object
- * @returns {object is Error}
- */
-function isShortcutApplicationError(object) {
-    return object instanceof ShortcutApplicationErrorClass;
-}
-
-/**
- * Normalizes input by collapsing whitespace.
- * @param {string} input - The input string to normalize
- * @returns {string} - The normalized input
- */
-function normalizeInput(input) {
-    return input.split(/\s+/).join(" ").trim();
-}
-
-/**
- * Parses a modifier string like "certainty 9" into {type: "certainty", description: "9"}
- * @param {string} modifier - The modifier string to parse
- * @returns {{type: string, description: string}} - The parsed modifier
- */
-function parseModifier(modifier) {
-    const pattern = /^\s*(\w+)(\s+(.+))?\s*$/;
-    const match = modifier.match(pattern);
-
-    if (!match) {
-        throw makeInputParseError(
-            `Not a valid modifier: ${JSON.stringify(modifier)}`,
-            modifier
-        );
-    }
-
-    const type = match[1];
-    const description = (match[3] || "").trim();
-
-    if (!type) {
-        throw makeInputParseError(
-            `Type is required but not found in modifier: ${JSON.stringify(modifier)}`,
-            modifier
-        );
-    }
-
-    // Reject modifiers that contain square brackets (invalid format)
-    if (description.includes('[') || description.includes(']')) {
-        throw makeInputParseError(
-            `Not a valid modifier: ${JSON.stringify(modifier)}`,
-            modifier
-        );
-    }
-
-    return { type, description };
-}
-
-/**
- * Parses structured input in the format: TYPE [MODIFIERS...] DESCRIPTION
- * @param {string} input - The input string to parse
- * @returns {ParsedInput} - The parsed input structure
- */
-function parseStructuredInput(input) {
-    // Match: TYPE [modifiers...] description
-    // TYPE must be a single word (letters and digits only, starting with a letter)
-    // modifiers are optional, description is optional
-    // Only capture brackets that contain spaces (valid modifiers) immediately after type
-    const pattern = /^\s*([A-Za-z][A-Za-z0-9]*)\s*((?:\[[^\]]*\s+[^\]]*\]\s*)*)\s*(.*)$/;
-    const match = input.match(pattern);
-
-    if (!match) {
-        throw makeInputParseError("Bad structure of input", input);
-    }
-
-    const type = match[1];
-    const modifiersStr = (match[2] || "").trim();
-    const description = (match[3] || "").trim();
-
-    if (!type) {
-        throw makeInputParseError("Type is required but not found in input", input);
-    }
-
-    // Check if description contains patterns that look like modifiers (e.g., [key value])
-    // This prevents modifiers from appearing after the description has started
-    const modifierLikePattern = /\[[^\]]*\s+[^\]]*\]/;
-    if (modifierLikePattern.test(description)) {
-        throw makeInputParseError(
-            "Modifiers must appear immediately after the type, before any description text",
-            input
-        );
-    }
-
-    // Parse modifiers - only match those with spaces (valid modifier format)
-    const modifierMatches = modifiersStr.match(/\[[^\]]*\s+[^\]]*\]/g) || [];
-    /** @type {Record<string, string>} */
-    const modifiers = {};
-
-    for (const modifierMatch of modifierMatches) {
-        // Remove brackets
-        const modifierContent = modifierMatch.slice(1, -1);
-        const parsed = parseModifier(modifierContent);
-        modifiers[parsed.type] = parsed.description;
-    }
-
-    return {
-        type: type,
-        description,
-        modifiers
-    };
-}
+const {
+    normalizeInput,
+    parseModifier,
+    parseStructuredInput,
+} = require("./parsers");
 
 /**
  * Applies shortcuts recursively to transform the input.

--- a/backend/src/event/input_errors.js
+++ b/backend/src/event/input_errors.js
@@ -1,0 +1,83 @@
+/**
+ * Error classes and helpers for user input processing.
+ */
+
+class InputParseErrorClass extends Error {
+    /** @type {string} */
+    input;
+
+    /**
+     * @param {string} message
+     * @param {string} input
+     */
+    constructor(message, input) {
+        super(message);
+        this.name = "InputParseError";
+        this.input = input;
+    }
+}
+
+class ShortcutApplicationErrorClass extends Error {
+    /** @type {string} */
+    input;
+    /** @type {string} */
+    pattern;
+
+    /**
+     * @param {string} message
+     * @param {string} input
+     * @param {string} pattern
+     */
+    constructor(message, input, pattern) {
+        super(message);
+        this.name = "ShortcutApplicationError";
+        this.input = input;
+        this.pattern = pattern;
+    }
+}
+
+/**
+ * Factory for InputParseError.
+ * @param {string} message
+ * @param {string} input
+ * @returns {Error}
+ */
+function makeInputParseError(message, input) {
+    return new InputParseErrorClass(message, input);
+}
+
+/**
+ * Type guard for InputParseError.
+ * @param {unknown} object
+ * @returns {object is Error}
+ */
+function isInputParseError(object) {
+    return object instanceof InputParseErrorClass;
+}
+
+/**
+ * Factory for ShortcutApplicationError.
+ * @param {string} message
+ * @param {string} input
+ * @param {string} pattern
+ * @returns {Error}
+ */
+function makeShortcutApplicationError(message, input, pattern) {
+    return new ShortcutApplicationErrorClass(message, input, pattern);
+}
+
+/**
+ * Type guard for ShortcutApplicationError.
+ * @param {unknown} object
+ * @returns {object is Error}
+ */
+function isShortcutApplicationError(object) {
+    return object instanceof ShortcutApplicationErrorClass;
+}
+
+module.exports = {
+    makeInputParseError,
+    isInputParseError,
+    makeShortcutApplicationError,
+    isShortcutApplicationError,
+};

--- a/backend/src/event/parsers.js
+++ b/backend/src/event/parsers.js
@@ -1,0 +1,118 @@
+/**
+ * Parsing helpers for user input.
+ */
+
+const { makeInputParseError } = require("./input_errors");
+
+/**
+ * @typedef {object} ParsedInput
+ * @property {string} type - The type of the event
+ * @property {string} description - The description of the event
+ * @property {Record<string, string>} modifiers - The modifiers for the event
+ */
+
+/**
+ * Normalizes input by collapsing whitespace.
+ * @param {string} input - The input string to normalize
+ * @returns {string} - The normalized input
+ */
+function normalizeInput(input) {
+    return input.split(/\s+/).join(" ").trim();
+}
+
+/**
+ * Parses a modifier string like "certainty 9" into {type: "certainty", description: "9"}
+ * @param {string} modifier - The modifier string to parse
+ * @returns {{type: string, description: string}} - The parsed modifier
+ */
+function parseModifier(modifier) {
+    const pattern = /^\s*(\w+)(\s+(.+))?\s*$/;
+    const match = modifier.match(pattern);
+
+    if (!match) {
+        throw makeInputParseError(
+            `Not a valid modifier: ${JSON.stringify(modifier)}`,
+            modifier
+        );
+    }
+
+    const type = match[1];
+    const description = (match[3] || "").trim();
+
+    if (!type) {
+        throw makeInputParseError(
+            `Type is required but not found in modifier: ${JSON.stringify(modifier)}`,
+            modifier
+        );
+    }
+
+    // Reject modifiers that contain square brackets (invalid format)
+    if (description.includes("[") || description.includes("]")) {
+        throw makeInputParseError(
+            `Not a valid modifier: ${JSON.stringify(modifier)}`,
+            modifier
+        );
+    }
+
+    return { type, description };
+}
+
+/**
+ * Parses structured input in the format: TYPE [MODIFIERS...] DESCRIPTION
+ * @param {string} input - The input string to parse
+ * @returns {ParsedInput} - The parsed input structure
+ */
+function parseStructuredInput(input) {
+    // Match: TYPE [modifiers...] description
+    // TYPE must be a single word (letters and digits only, starting with a letter)
+    // modifiers are optional, description is optional
+    // Only capture brackets that contain spaces (valid modifiers) immediately after type
+    const pattern = /^\s*([A-Za-z][A-Za-z0-9]*)\s*((?:\[[^\]]*\s+[^\]]*\]\s*)*)\s*(.*)$/;
+    const match = input.match(pattern);
+
+    if (!match) {
+        throw makeInputParseError("Bad structure of input", input);
+    }
+
+    const type = match[1];
+    const modifiersStr = (match[2] || "").trim();
+    const description = (match[3] || "").trim();
+
+    if (!type) {
+        throw makeInputParseError("Type is required but not found in input", input);
+    }
+
+    // Check if description contains patterns that look like modifiers (e.g., [key value])
+    // This prevents modifiers from appearing after the description has started
+    const modifierLikePattern = /\[[^\]]*\s+[^\]]*\]/;
+    if (modifierLikePattern.test(description)) {
+        throw makeInputParseError(
+            "Modifiers must appear immediately after the type, before any description text",
+            input
+        );
+    }
+
+    // Parse modifiers - only match those with spaces (valid modifier format)
+    const modifierMatches = modifiersStr.match(/\[[^\]]*\s+[^\]]*\]/g) || [];
+    /** @type {Record<string, string>} */
+    const modifiers = {};
+
+    for (const modifierMatch of modifierMatches) {
+        // Remove brackets
+        const modifierContent = modifierMatch.slice(1, -1);
+        const parsed = parseModifier(modifierContent);
+        modifiers[parsed.type] = parsed.description;
+    }
+
+    return {
+        type: type,
+        description,
+        modifiers,
+    };
+}
+
+module.exports = {
+    normalizeInput,
+    parseModifier,
+    parseStructuredInput,
+};


### PR DESCRIPTION
## Summary
- split oversized `from_input.js`
- add `input_errors.js` and `parsers.js`
- keep existing exports in `from_input.js`

## Testing
- `npm test`
- `npm run static-analysis`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6863a5cf598c832eb3a958d20c8ed245