### PR TITLE
refactor: move event log storage types

### DIFF
--- a/backend/src/event_log_storage/class.js
+++ b/backend/src/event_log_storage/class.js
@@ -2,74 +2,13 @@ const event = require("../event");
 const { readObjects } = require("../json_stream_file");
 
 
-/** @typedef {import('../filesystem/deleter').FileDeleter} FileDeleter */
-/** @typedef {import('../filesystem/copier').FileCopier} FileCopier */
-/** @typedef {import('../filesystem/writer').FileWriter} FileWriter */
-/** @typedef {import('../filesystem/appender').FileAppender} FileAppender */
-/** @typedef {import('../filesystem/creator').FileCreator} FileCreator */
-/** @typedef {import('../filesystem/file').ExistingFile} ExistingFile */
-/** @typedef {import('../filesystem/checker').FileChecker} FileChecker */
-/** @typedef {import('../subprocess/command').Command} Command */
-/** @typedef {import('../environment').Environment} Environment */
-/** @typedef {import('../logger').Logger} Logger */
-
-/**
- * @typedef {object} Capabilities
- * @property {FileDeleter} deleter - A file deleter instance.
- * @property {FileCopier} copier - A file copier instance.
- * @property {FileWriter} writer - A file writer instance.
- * @property {FileAppender} appender - A file appender instance.
- * @property {FileCreator} creator - A directory creator instance.
- * @property {FileChecker} checker - A file checker instance.
- * @property {Command} git - A command instance for Git operations.
- * @property {Environment} environment - An environment instance.
- * @property {Logger} logger - A logger instance.
- * @property {import('../filesystem/reader').FileReader} reader - A file reader instance.
- */
-
-/**
- * Minimal capabilities needed for appending entries to files
- * @typedef {object} AppendCapabilities
- * @property {FileAppender} appender - A file appender instance
- */
-
-/**
- * Minimal capabilities needed for copying assets
- * @typedef {object} CopyAssetCapabilities
- * @property {FileCreator} creator - A file creator instance
- * @property {FileCopier} copier - A file copier instance
- * @property {Environment} environment - An environment instance (for targetPath)
- */
-
-/**
- * Minimal capabilities needed for cleaning up assets
- * @typedef {object} CleanupAssetCapabilities
- * @property {FileDeleter} deleter - A file deleter instance
- * @property {Environment} environment - An environment instance (for targetPath)
- * @property {Logger} logger - A logger instance
- */
-
-/**
- * Minimal capabilities needed for reading existing entries
- * @typedef {object} ReadEntriesCapabilities
- * @property {import('../filesystem/reader').FileReader} reader - A file reader instance
- * @property {Logger} logger - A logger instance
- */
-
-/**
- * Comprehensive capabilities needed for EventLogStorage operations and transactions
- * @typedef {object} EventLogStorageCapabilities
- * @property {import('../filesystem/reader').FileReader} reader - A file reader instance
- * @property {FileWriter} writer - A file writer instance
- * @property {FileCreator} creator - A file creator instance
- * @property {FileChecker} checker - A file checker instance
- * @property {FileDeleter} deleter - A file deleter instance
- * @property {FileCopier} copier - A file copier instance
- * @property {FileAppender} appender - A file appender instance
- * @property {Command} git - A Git command instance
- * @property {Environment} environment - An environment instance
- * @property {Logger} logger - A logger instance
- */
+/** @typedef {import('./types').Capabilities} Capabilities */
+/** @typedef {import('./types').AppendCapabilities} AppendCapabilities */
+/** @typedef {import('./types').CopyAssetCapabilities} CopyAssetCapabilities */
+/** @typedef {import('./types').CleanupAssetCapabilities} CleanupAssetCapabilities */
+/** @typedef {import('./types').ReadEntriesCapabilities} ReadEntriesCapabilities */
+/** @typedef {import('./types').EventLogStorageCapabilities} EventLogStorageCapabilities */
+/** @typedef {import('./types').ExistingFile} ExistingFile */
 
 /**
  * A class to manage the storage of event log entries.

--- a/backend/src/event_log_storage/transaction.js
+++ b/backend/src/event_log_storage/transaction.js
@@ -17,10 +17,10 @@ const configStorage = require("../config/storage");
 const { EventLogStorageClass } = require("./class");
 
 /** @typedef {import("../filesystem/file").ExistingFile} ExistingFile */
-/** @typedef {import("./class").AppendCapabilities} AppendCapabilities */
-/** @typedef {import("./class").CopyAssetCapabilities} CopyAssetCapabilities */
-/** @typedef {import("./class").CleanupAssetCapabilities} CleanupAssetCapabilities */
-/** @typedef {import("./class").EventLogStorageCapabilities} EventLogStorageCapabilities */
+/** @typedef {import("./types").AppendCapabilities} AppendCapabilities */
+/** @typedef {import("./types").CopyAssetCapabilities} CopyAssetCapabilities */
+/** @typedef {import("./types").CleanupAssetCapabilities} CleanupAssetCapabilities */
+/** @typedef {import("./types").EventLogStorageCapabilities} EventLogStorageCapabilities */
 /** @typedef {import("./class").EventLogStorage} EventLogStorage */
 
 /**

--- a/backend/src/event_log_storage/types.js
+++ b/backend/src/event_log_storage/types.js
@@ -1,0 +1,74 @@
+/**
+ * Type definitions for EventLogStorage capabilities.
+ */
+
+/** @typedef {import('../filesystem/deleter').FileDeleter} FileDeleter */
+/** @typedef {import('../filesystem/copier').FileCopier} FileCopier */
+/** @typedef {import('../filesystem/writer').FileWriter} FileWriter */
+/** @typedef {import('../filesystem/appender').FileAppender} FileAppender */
+/** @typedef {import('../filesystem/creator').FileCreator} FileCreator */
+/** @typedef {import('../filesystem/file').ExistingFile} ExistingFile */
+/** @typedef {import('../filesystem/checker').FileChecker} FileChecker */
+/** @typedef {import('../subprocess/command').Command} Command */
+/** @typedef {import('../environment').Environment} Environment */
+/** @typedef {import('../logger').Logger} Logger */
+
+/**
+ * @typedef {object} Capabilities
+ * @property {FileDeleter} deleter - A file deleter instance.
+ * @property {FileCopier} copier - A file copier instance.
+ * @property {FileWriter} writer - A file writer instance.
+ * @property {FileAppender} appender - A file appender instance.
+ * @property {FileCreator} creator - A directory creator instance.
+ * @property {FileChecker} checker - A file checker instance.
+ * @property {Command} git - A command instance for Git operations.
+ * @property {Environment} environment - An environment instance.
+ * @property {Logger} logger - A logger instance.
+ * @property {import('../filesystem/reader').FileReader} reader - A file reader instance.
+ */
+
+/**
+ * Minimal capabilities needed for appending entries to files
+ * @typedef {object} AppendCapabilities
+ * @property {FileAppender} appender - A file appender instance
+ */
+
+/**
+ * Minimal capabilities needed for copying assets
+ * @typedef {object} CopyAssetCapabilities
+ * @property {FileCreator} creator - A file creator instance
+ * @property {FileCopier} copier - A file copier instance
+ * @property {Environment} environment - An environment instance (for targetPath)
+ */
+
+/**
+ * Minimal capabilities needed for cleaning up assets
+ * @typedef {object} CleanupAssetCapabilities
+ * @property {FileDeleter} deleter - A file deleter instance
+ * @property {Environment} environment - An environment instance (for targetPath)
+ * @property {Logger} logger - A logger instance
+ */
+
+/**
+ * Minimal capabilities needed for reading existing entries
+ * @typedef {object} ReadEntriesCapabilities
+ * @property {import('../filesystem/reader').FileReader} reader - A file reader instance
+ * @property {Logger} logger - A logger instance
+ */
+
+/**
+ * Comprehensive capabilities needed for EventLogStorage operations and transactions
+ * @typedef {object} EventLogStorageCapabilities
+ * @property {import('../filesystem/reader').FileReader} reader - A file reader instance
+ * @property {FileWriter} writer - A file writer instance
+ * @property {FileCreator} creator - A file creator instance
+ * @property {FileChecker} checker - A file checker instance
+ * @property {FileDeleter} deleter - A file deleter instance
+ * @property {FileCopier} copier - A file copier instance
+ * @property {FileAppender} appender - A file appender instance
+ * @property {Command} git - A Git command instance
+ * @property {Environment} environment - An environment instance
+ * @property {Logger} logger - A logger instance
+ */
+
+module.exports = {};


### PR DESCRIPTION
## Summary
- extract type definitions from event_log_storage/class.js
- update class.js and transaction.js to reference new types

## Testing
- `npm test` *(fails: jest not found)*
- `npm run static-analysis` *(fails: missing type declarations)*
- `npm run build` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6864df770b64832e8e321458c6e1c317