### PR TITLE
Fix JSDoc return annotations

### DIFF
--- a/frontend/src/DescriptionEntry/ConfigSection.jsx
+++ b/frontend/src/DescriptionEntry/ConfigSection.jsx
@@ -29,6 +29,7 @@ import { HelpTab } from "./tabs/HelpTab.jsx";
  * @param {string} props.currentInput - Current input value to show preview
  * @param {Array<any>} [props.recentEntries] - Array of recent entries to display
  * @param {boolean} [props.isLoadingEntries] - Whether entries are loading
+ * @returns {JSX.Element|null}
  */
 export const ConfigSection = ({ onShortcutClick, currentInput = "", recentEntries = [], isLoadingEntries = false }) => {
     const [config, setConfig] = useState(/** @type {Config|null} */ (null));

--- a/frontend/src/DescriptionEntry/EntryItem.jsx
+++ b/frontend/src/DescriptionEntry/EntryItem.jsx
@@ -23,6 +23,7 @@ import { CARD_STYLES, TEXT_STYLES, BADGE_STYLES } from "./styles.js";
  * @param {Object} props
  * @param {Entry} props.entry - The entry data
  * @param {number} props.index - Index for fallback key
+ * @returns {JSX.Element}
  */
 export const EntryItem = ({ entry, index }) => (
     <Box key={entry.id || index} {...CARD_STYLES.entry}>
@@ -46,6 +47,7 @@ export const EntryItem = ({ entry, index }) => (
 
 /**
  * Loading skeleton for entries
+ * @returns {JSX.Element}
  */
 export const EntryItemSkeleton = () => (
     <Box {...CARD_STYLES.entry}>

--- a/frontend/src/DescriptionEntry/FormInputSection.jsx
+++ b/frontend/src/DescriptionEntry/FormInputSection.jsx
@@ -25,6 +25,7 @@ import {
  * @param {boolean} props.isSubmitting - Whether form is submitting
  * @param {React.RefObject<HTMLInputElement>} props.inputRef - Input element ref
  * @param {boolean} [props.hasPhotos] - Whether photos are attached
+ * @returns {JSX.Element}
  */
 export const FormInputSection = ({
     description,

--- a/frontend/src/DescriptionEntry/RecentEntriesSection.jsx
+++ b/frontend/src/DescriptionEntry/RecentEntriesSection.jsx
@@ -22,6 +22,7 @@ import { CARD_STYLES, TEXT_STYLES, SPACING } from "./styles.js";
  * @param {Object} props
  * @param {Entry[]} props.entries - Array of recent entries
  * @param {boolean} props.isLoading - Whether entries are loading
+ * @returns {JSX.Element|null}
  */
 export const RecentEntriesSection = ({ entries, isLoading }) => {
     if (isLoading) {

--- a/frontend/src/DescriptionEntry/hooks.js
+++ b/frontend/src/DescriptionEntry/hooks.js
@@ -22,8 +22,23 @@ import {
 } from "./errors.js";
 
 /**
+ * @typedef {object} DescriptionEntryHook
+ * @property {string} description
+ * @property {boolean} isSubmitting
+ * @property {any[]} recentEntries
+ * @property {boolean} isLoadingEntries
+ * @property {string|null} pendingRequestIdentifier
+ * @property {(value: string) => void} setDescription
+ * @property {() => Promise<void>} handleSubmit
+ * @property {() => void} handleTakePhotos
+ * @property {(e: React.KeyboardEvent) => void} handleKeyUp
+ * @property {() => Promise<void>} fetchRecentEntries
+ */
+
+/**
  * Custom hook for managing description entry form state and actions
  * @param {number} numberOfEntries - Number of recent entries to fetch
+ * @returns {DescriptionEntryHook}
  */
 export const useDescriptionEntry = (numberOfEntries = 10) => {
     const [description, setDescription] = useState("");

--- a/frontend/src/DescriptionEntry/icons.jsx
+++ b/frontend/src/DescriptionEntry/icons.jsx
@@ -1,6 +1,11 @@
 import React from "react";
 
-// Simple icon components using forwardRef to avoid warnings
+/**
+ * Simple icon components using forwardRef to avoid warnings
+ * @param {React.ComponentPropsWithoutRef<"span">} props
+ * @param {React.Ref<HTMLSpanElement>} ref
+ * @returns {JSX.Element}
+ */
 export const ChevronDownIcon = React.forwardRef((props, ref) => (
     <span ref={ref} {...props}>
         ▼
@@ -8,6 +13,11 @@ export const ChevronDownIcon = React.forwardRef((props, ref) => (
 ));
 ChevronDownIcon.displayName = "ChevronDownIcon";
 
+/**
+ * @param {React.ComponentPropsWithoutRef<"span">} props
+ * @param {React.Ref<HTMLSpanElement>} ref
+ * @returns {JSX.Element}
+ */
 export const ChevronUpIcon = React.forwardRef((props, ref) => (
     <span ref={ref} {...props}>
         ▲
@@ -15,6 +25,11 @@ export const ChevronUpIcon = React.forwardRef((props, ref) => (
 ));
 ChevronUpIcon.displayName = "ChevronUpIcon";
 
+/**
+ * @param {React.ComponentPropsWithoutRef<"span">} props
+ * @param {React.Ref<HTMLSpanElement>} ref
+ * @returns {JSX.Element}
+ */
 export const InfoIcon = React.forwardRef((props, ref) => (
     <span ref={ref} {...props}>
         ℹ️

--- a/frontend/src/DescriptionEntry/tabs/HelpTab.jsx
+++ b/frontend/src/DescriptionEntry/tabs/HelpTab.jsx
@@ -14,6 +14,7 @@ const syntaxExamples = [
  * @param {Object} props
  * @param {string} props.helpText - The help text to display
  * @param {(value: string) => void} props.onShortcutClick - Called when a syntax example is clicked
+ * @returns {JSX.Element}
  */
 export const HelpTab = ({ helpText, onShortcutClick }) => (
     <VStack spacing={SPACING.lg} align="stretch">

--- a/frontend/src/DescriptionEntry/tabs/RecentEntriesTab.jsx
+++ b/frontend/src/DescriptionEntry/tabs/RecentEntriesTab.jsx
@@ -9,6 +9,7 @@ import { SPACING } from "../styles.js";
  * @param {Array<any>} props.recentEntries - Array of recent entries
  * @param {boolean} props.isLoadingEntries - Whether entries are loading
  * @param {(value: string) => void} props.onShortcutClick - Called when an entry is clicked
+ * @returns {JSX.Element}
  */
 export const RecentEntriesTab = ({ recentEntries, isLoadingEntries, onShortcutClick }) => {
     if (isLoadingEntries) {

--- a/frontend/src/DescriptionEntry/tabs/ShortcutsTab.jsx
+++ b/frontend/src/DescriptionEntry/tabs/ShortcutsTab.jsx
@@ -47,6 +47,7 @@ const getShortcutPreview = (shortcut, currentInput) => {
  * @param {Array<any>} props.shortcuts - Array of shortcuts
  * @param {(value: string) => void} props.onShortcutClick - Called when a shortcut is clicked
  * @param {string} props.currentInput - Current input text for preview
+ * @returns {JSX.Element}
  */
 export const ShortcutsTab = ({ shortcuts, onShortcutClick, currentInput }) => (
     <VStack spacing={SPACING.md} align="stretch">

--- a/frontend/src/DescriptionEntry/tabs/SyntaxTab.jsx
+++ b/frontend/src/DescriptionEntry/tabs/SyntaxTab.jsx
@@ -13,6 +13,7 @@ const syntaxExamples = [
  * Syntax examples tab component
  * @param {Object} props
  * @param {(value: string) => void} props.onShortcutClick - Called when an example is clicked
+ * @returns {JSX.Element}
  */
 export const SyntaxTab = ({ onShortcutClick }) => (
     <VStack spacing={SPACING.md} align="stretch">


### PR DESCRIPTION
## Summary
- add missing `@returns` tags across React components
- document return type of `useDescriptionEntry` hook

## Testing
- `npm test`
- `npm run static-analysis`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6864df8ee76c832ead428a4aadbaf027