### PR TITLE
Fix JSDoc comment and factory export

### DIFF
--- a/backend/src/event_log_storage/class.js
+++ b/backend/src/event_log_storage/class.js
@@ -317,4 +317,13 @@ class EventLogStorageClass {
 
 /** @typedef {EventLogStorageClass} EventLogStorage */
 
-module.exports = { EventLogStorageClass };
+/**
+ * Factory for {@link EventLogStorageClass}
+ * @param {EventLogStorageCapabilities} capabilities
+ * @returns {EventLogStorage}
+ */
+function makeEventLogStorage(capabilities) {
+    return new EventLogStorageClass(capabilities);
+}
+
+module.exports = { makeEventLogStorage };

--- a/backend/src/event_log_storage/transaction.js
+++ b/backend/src/event_log_storage/transaction.js
@@ -14,7 +14,7 @@ const gitstore = require("../gitstore");
 const event = require("../event");
 const { targetPath } = require("../event/asset");
 const configStorage = require("../config/storage");
-const { EventLogStorageClass } = require("./class");
+const { makeEventLogStorage } = require("./class");
 
 /** @typedef {import("../filesystem/file").ExistingFile} ExistingFile */
 /** @typedef {import("./class").AppendCapabilities} AppendCapabilities */
@@ -170,7 +170,7 @@ async function cleanupAssets(capabilities, eventLogStorage) {
  * @returns {Promise<T>}
  */
 async function transaction(capabilities, transformation) {
-    const eventLogStorage = new EventLogStorageClass(capabilities);
+    const eventLogStorage = makeEventLogStorage(capabilities);
     try {
         return await performGitTransaction(
             capabilities,

--- a/backend/src/routes/entries.js
+++ b/backend/src/routes/entries.js
@@ -5,7 +5,6 @@ const { handleEntryPost } = require("./entries/post");
 const { handleEntriesGet } = require("./entries/list");
 
 /**
-/**
  * @typedef {import('../environment').Environment} Environment
  * @typedef {import('../logger').Logger} Logger
  * @typedef {import('../random/seed').NonDeterministicSeed} NonDeterministicSeed

--- a/frontend/src/DescriptionEntry/DescriptionEntry.jsx
+++ b/frontend/src/DescriptionEntry/DescriptionEntry.jsx
@@ -28,7 +28,10 @@ export default function DescriptionEntry() {
         }
     }, []);
 
-    const handleShortcutClick = (/** @type {string} */ text) => {
+    /**
+     * @param {string} text
+     */
+    const handleShortcutClick = (text) => {
         setDescription(text);
         // Focus the input after setting the text
         if (inputRef.current) {

--- a/frontend/src/DescriptionEntry/api.js
+++ b/frontend/src/DescriptionEntry/api.js
@@ -15,6 +15,25 @@ import { EntrySubmissionError } from "./errors.js";
  */
 
 /**
+ * @param {unknown} obj
+ * @returns {obj is Entry}
+ */
+export function isEntry(obj) {
+    return (
+        obj !== null &&
+        typeof obj === 'object' &&
+        'id' in obj && typeof obj.id === 'string' &&
+        'date' in obj && typeof obj.date === 'string' &&
+        'type' in obj && typeof obj.type === 'string' &&
+        'description' in obj && typeof obj.description === 'string' &&
+        'input' in obj && typeof obj.input === 'string' &&
+        'original' in obj && typeof obj.original === 'string' &&
+        'modifiers' in obj && typeof obj.modifiers === 'object' && obj.modifiers !== null &&
+        'creator' in obj && typeof obj.creator === 'object' && obj.creator !== null
+    );
+}
+
+/**
  * @typedef {[string, string] | [string, string, string]} Shortcut
  * A tuple representing a shortcut:
  * - [0]: pattern - Regex pattern to match
@@ -38,8 +57,10 @@ export const fetchRecentEntries = async (limit = 10) => {
 
     if (response.ok) {
         const data = await response.json();
-        // data.results is any, cast to Entry[]
-        return /** @type {Entry[]} */ (data.results || []);
+        if (Array.isArray(data.results)) {
+            return data.results.filter(isEntry);
+        }
+        return [];
     } else {
         logger.warn("Failed to fetch recent entries:", response.status);
         return [];


### PR DESCRIPTION
## Summary
- fix stray JSDoc comment in entries router
- add factory function for `EventLogStorageClass`
- update transaction logic to use the new factory
- add type guard for entries API
- improve shortcut click handler docs

## Testing
- `npm test`
- `npm run static-analysis`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6864df8d3f4c832eb2b100bcebc77467