### PR TITLE
Refactor event log storage per AGENTS guidelines

### DIFF
--- a/backend/src/event_log_storage/class.js
+++ b/backend/src/event_log_storage/class.js
@@ -1,75 +1,14 @@
 const event = require("../event");
 const { readObjects } = require("../json_stream_file");
 
+/** @typedef {import('./types').Capabilities} Capabilities */
+/** @typedef {import('./types').AppendCapabilities} AppendCapabilities */
+/** @typedef {import('./types').CopyAssetCapabilities} CopyAssetCapabilities */
+/** @typedef {import('./types').CleanupAssetCapabilities} CleanupAssetCapabilities */
+/** @typedef {import('./types').ReadEntriesCapabilities} ReadEntriesCapabilities */
+/** @typedef {import('./types').EventLogStorageCapabilities} EventLogStorageCapabilities */
+/** @typedef {import('./types').ExistingFile} ExistingFile */
 
-/** @typedef {import('../filesystem/deleter').FileDeleter} FileDeleter */
-/** @typedef {import('../filesystem/copier').FileCopier} FileCopier */
-/** @typedef {import('../filesystem/writer').FileWriter} FileWriter */
-/** @typedef {import('../filesystem/appender').FileAppender} FileAppender */
-/** @typedef {import('../filesystem/creator').FileCreator} FileCreator */
-/** @typedef {import('../filesystem/file').ExistingFile} ExistingFile */
-/** @typedef {import('../filesystem/checker').FileChecker} FileChecker */
-/** @typedef {import('../subprocess/command').Command} Command */
-/** @typedef {import('../environment').Environment} Environment */
-/** @typedef {import('../logger').Logger} Logger */
-
-/**
- * @typedef {object} Capabilities
- * @property {FileDeleter} deleter - A file deleter instance.
- * @property {FileCopier} copier - A file copier instance.
- * @property {FileWriter} writer - A file writer instance.
- * @property {FileAppender} appender - A file appender instance.
- * @property {FileCreator} creator - A directory creator instance.
- * @property {FileChecker} checker - A file checker instance.
- * @property {Command} git - A command instance for Git operations.
- * @property {Environment} environment - An environment instance.
- * @property {Logger} logger - A logger instance.
- * @property {import('../filesystem/reader').FileReader} reader - A file reader instance.
- */
-
-/**
- * Minimal capabilities needed for appending entries to files
- * @typedef {object} AppendCapabilities
- * @property {FileAppender} appender - A file appender instance
- */
-
-/**
- * Minimal capabilities needed for copying assets
- * @typedef {object} CopyAssetCapabilities
- * @property {FileCreator} creator - A file creator instance
- * @property {FileCopier} copier - A file copier instance
- * @property {Environment} environment - An environment instance (for targetPath)
- */
-
-/**
- * Minimal capabilities needed for cleaning up assets
- * @typedef {object} CleanupAssetCapabilities
- * @property {FileDeleter} deleter - A file deleter instance
- * @property {Environment} environment - An environment instance (for targetPath)
- * @property {Logger} logger - A logger instance
- */
-
-/**
- * Minimal capabilities needed for reading existing entries
- * @typedef {object} ReadEntriesCapabilities
- * @property {import('../filesystem/reader').FileReader} reader - A file reader instance
- * @property {Logger} logger - A logger instance
- */
-
-/**
- * Comprehensive capabilities needed for EventLogStorage operations and transactions
- * @typedef {object} EventLogStorageCapabilities
- * @property {import('../filesystem/reader').FileReader} reader - A file reader instance
- * @property {FileWriter} writer - A file writer instance
- * @property {FileCreator} creator - A file creator instance
- * @property {FileChecker} checker - A file checker instance
- * @property {FileDeleter} deleter - A file deleter instance
- * @property {FileCopier} copier - A file copier instance
- * @property {FileAppender} appender - A file appender instance
- * @property {Command} git - A Git command instance
- * @property {Environment} environment - An environment instance
- * @property {Logger} logger - A logger instance
- */
 
 /**
  * A class to manage the storage of event log entries.
@@ -317,4 +256,24 @@ class EventLogStorageClass {
 
 /** @typedef {EventLogStorageClass} EventLogStorage */
 
-module.exports = { EventLogStorageClass };
+/**
+ * Creates a new EventLogStorage instance.
+ * @param {EventLogStorageCapabilities} capabilities
+ * @returns {EventLogStorage}
+ */
+function make(capabilities) {
+    return new EventLogStorageClass(capabilities);
+}
+
+/**
+ * @param {unknown} object
+ * @returns {object is EventLogStorage}
+ */
+function isEventLogStorage(object) {
+    return object instanceof EventLogStorageClass;
+}
+
+module.exports = {
+    make,
+    isEventLogStorage,
+};

--- a/backend/src/event_log_storage/transaction.js
+++ b/backend/src/event_log_storage/transaction.js
@@ -14,13 +14,13 @@ const gitstore = require("../gitstore");
 const event = require("../event");
 const { targetPath } = require("../event/asset");
 const configStorage = require("../config/storage");
-const { EventLogStorageClass } = require("./class");
+const { make } = require("./class");
 
 /** @typedef {import("../filesystem/file").ExistingFile} ExistingFile */
-/** @typedef {import("./class").AppendCapabilities} AppendCapabilities */
-/** @typedef {import("./class").CopyAssetCapabilities} CopyAssetCapabilities */
-/** @typedef {import("./class").CleanupAssetCapabilities} CleanupAssetCapabilities */
-/** @typedef {import("./class").EventLogStorageCapabilities} EventLogStorageCapabilities */
+/** @typedef {import("./types").AppendCapabilities} AppendCapabilities */
+/** @typedef {import("./types").CopyAssetCapabilities} CopyAssetCapabilities */
+/** @typedef {import("./types").CleanupAssetCapabilities} CleanupAssetCapabilities */
+/** @typedef {import("./types").EventLogStorageCapabilities} EventLogStorageCapabilities */
 /** @typedef {import("./class").EventLogStorage} EventLogStorage */
 
 /**
@@ -170,7 +170,7 @@ async function cleanupAssets(capabilities, eventLogStorage) {
  * @returns {Promise<T>}
  */
 async function transaction(capabilities, transformation) {
-    const eventLogStorage = new EventLogStorageClass(capabilities);
+    const eventLogStorage = make(capabilities);
     try {
         return await performGitTransaction(
             capabilities,

--- a/backend/src/event_log_storage/types.js
+++ b/backend/src/event_log_storage/types.js
@@ -1,0 +1,69 @@
+/**
+ * Type definitions for EventLogStorage capabilities.
+ */
+
+/** @typedef {import('../filesystem/deleter').FileDeleter} FileDeleter */
+/** @typedef {import('../filesystem/copier').FileCopier} FileCopier */
+/** @typedef {import('../filesystem/writer').FileWriter} FileWriter */
+/** @typedef {import('../filesystem/appender').FileAppender} FileAppender */
+/** @typedef {import('../filesystem/creator').FileCreator} FileCreator */
+/** @typedef {import('../filesystem/file').ExistingFile} ExistingFile */
+/** @typedef {import('../filesystem/checker').FileChecker} FileChecker */
+/** @typedef {import('../subprocess/command').Command} Command */
+/** @typedef {import('../environment').Environment} Environment */
+/** @typedef {import('../logger').Logger} Logger */
+
+/**
+ * @typedef {object} Capabilities
+ * @property {FileDeleter} deleter
+ * @property {FileCopier} copier
+ * @property {FileWriter} writer
+ * @property {FileAppender} appender
+ * @property {FileCreator} creator
+ * @property {FileChecker} checker
+ * @property {Command} git
+ * @property {Environment} environment
+ * @property {Logger} logger
+ * @property {import('../filesystem/reader').FileReader} reader
+ */
+
+/**
+ * @typedef {object} AppendCapabilities
+ * @property {FileAppender} appender
+ */
+
+/**
+ * @typedef {object} CopyAssetCapabilities
+ * @property {FileCreator} creator
+ * @property {FileCopier} copier
+ * @property {Environment} environment
+ */
+
+/**
+ * @typedef {object} CleanupAssetCapabilities
+ * @property {FileDeleter} deleter
+ * @property {Environment} environment
+ * @property {Logger} logger
+ */
+
+/**
+ * @typedef {object} ReadEntriesCapabilities
+ * @property {import('../filesystem/reader').FileReader} reader
+ * @property {Logger} logger
+ */
+
+/**
+ * @typedef {object} EventLogStorageCapabilities
+ * @property {import('../filesystem/reader').FileReader} reader
+ * @property {FileWriter} writer
+ * @property {FileCreator} creator
+ * @property {FileChecker} checker
+ * @property {FileDeleter} deleter
+ * @property {FileCopier} copier
+ * @property {FileAppender} appender
+ * @property {Command} git
+ * @property {Environment} environment
+ * @property {Logger} logger
+ */
+
+module.exports = {};


### PR DESCRIPTION
## Summary
- break out JSDoc capability types from class.js
- expose factory/guard instead of exporting EventLogStorageClass
- update transaction.js to use factory
- keep build/test passing

## Testing
- `npm test`
- `npm run static-analysis`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6864df892fa8832e8131cc2a49e905bf