### PR TITLE
Add printf logger helper

### DIFF
--- a/backend/src/logger.js
+++ b/backend/src/logger.js
@@ -10,6 +10,7 @@ const {
     logWarning,
     logInfo,
     logDebug,
+    printf,
 } = require('./logger/log_methods.js');
 
 /** @typedef {import('./environment').Environment} Environment */
@@ -94,6 +95,14 @@ function make(getCapabilities) {
         logDebug(state, obj, msg);
     }
 
+    /**
+     * @param {unknown} obj
+     * @param {string} msg
+     */
+    function printfWrapper(obj, msg) {
+        printf(state, obj, msg);
+    }
+
     return {
         enableHttpCallsLogging: enableWrapper,
         setup: setupWrapper,
@@ -101,6 +110,7 @@ function make(getCapabilities) {
         logWarning: warnWrapper,
         logInfo: infoWrapper,
         logDebug: debugWrapper,
+        printf: printfWrapper,
     };
 }
 

--- a/backend/src/logger/log_methods.js
+++ b/backend/src/logger/log_methods.js
@@ -96,10 +96,24 @@ function logDebug(state, obj, msg) {
     }
 }
 
+/**
+ * Simple printf-like helper.
+ * Prints the given arguments to stderr without any additional handling.
+ *
+ * @param {LoggerState} _state - The logger state (unused).
+ * @param {unknown} obj The error object, message string, or object with error details
+ * @param {string} msg
+ * @returns {void}
+ */
+function printf(_state, obj, msg) {
+    console.error(obj, msg);
+}
+
 module.exports = {
     logError,
     logWarning,
     logInfo,
     logDebug,
+    printf,
 };
 

--- a/backend/tests/logger.test.js
+++ b/backend/tests/logger.test.js
@@ -59,4 +59,19 @@ describe("logger capability", () => {
         expect(content).not.toMatch(/info should not appear/);
         expect(content).toMatch(/error should appear/);
     });
+
+    it("printf prints to stderr", () => {
+        let called = false;
+        const origError = console.error;
+        console.error = () => {
+            called = true;
+        };
+        try {
+            const logger = make();
+            logger.printf({ foo: 1 }, "hello");
+            expect(called).toBe(true);
+        } finally {
+            console.error = origError;
+        }
+    });
 });

--- a/backend/tests/stubs.js
+++ b/backend/tests/stubs.js
@@ -58,6 +58,7 @@ function stubLogger(capabilities) {
     capabilities.logger.logWarning = jest.fn();
     capabilities.logger.logInfo = jest.fn();
     capabilities.logger.logDebug = jest.fn();
+    capabilities.logger.printf = jest.fn();
 }
 
 /**


### PR DESCRIPTION
## Summary
- add `printf` function to logger implementation
- expose `printf` via the logger factory
- update logger stubs
- test that `printf` writes to stderr

## Testing
- `npm test`
- `npm run static-analysis`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6865e967aa18832e9fe3d21bf255934d