### PR TITLE
Implement event deletion iterator

### DIFF
--- a/backend/src/event_log_storage/transaction.js
+++ b/backend/src/event_log_storage/transaction.js
@@ -46,6 +46,21 @@ async function appendEntriesToFile(capabilities, file, entries) {
 }
 
 /**
+ * Overwrites a file with the provided entries serialized as JSON.
+ * @param {EventLogStorageCapabilities} capabilities
+ * @param {ExistingFile} file
+ * @param {Array<import('../event').Event>} entries
+ */
+async function writeEntriesToFile(capabilities, file, entries) {
+    const lines = entries.map((e) => {
+        const serialized = event.serialize(e);
+        return JSON.stringify(serialized, null, '\t');
+    });
+    const content = lines.join('\n') + (lines.length > 0 ? '\n' : '');
+    await capabilities.writer.writeFile(file, content);
+}
+
+/**
  * New helper to copy all queued assets into the asset directory.
  * Ensures that the parent directory exists before copying files.
  * @param {CopyAssetCapabilities} capabilities - The minimal capabilities needed for copying assets
@@ -97,18 +112,41 @@ async function performGitTransaction(
         // Run user-provided transformation to accumulate entries and config
         const result = await transformation(eventLogStorage);
 
-        // Get the new entries to persist
+        // Get queued updates
         const newEntries = eventLogStorage.getNewEntries();
+        const deletedIds = Array.from(eventLogStorage.getDeletedIds());
+        const deletedIdStrings = new Set(deletedIds.map((d) => d.identifier));
         const newConfig = eventLogStorage.getNewConfig();
 
         // Track if we need to commit
         let needsCommit = false;
 
-        // Persist and commit when we have new entries or configuration changes
-        if (newEntries.length > 0) {
-            // Persist queued entries
-            const existingDataFile = dataFile == null ? await capabilities.creator.createFile(dataPath) : dataFile;
-            await appendEntriesToFile(capabilities, existingDataFile, newEntries);
+        // Persist when we have new entries or deletions
+        if (newEntries.length > 0 || deletedIdStrings.size > 0) {
+            const existingDataFile =
+                dataFile == null
+                    ? await capabilities.creator.createFile(dataPath)
+                    : dataFile;
+            if (deletedIdStrings.size > 0) {
+                const existing = dataFile
+                    ? await eventLogStorage.getExistingEntries()
+                    : [];
+                const remaining = existing.filter(
+                    (e) => !deletedIdStrings.has(e.id.identifier)
+                );
+                remaining.push(...newEntries);
+                await writeEntriesToFile(
+                    capabilities,
+                    existingDataFile,
+                    remaining
+                );
+            } else {
+                await appendEntriesToFile(
+                    capabilities,
+                    existingDataFile,
+                    newEntries
+                );
+            }
             needsCommit = true;
         }
 

--- a/backend/tests/event_log_storage.delete.test.js
+++ b/backend/tests/event_log_storage.delete.test.js
@@ -1,0 +1,204 @@
+const path = require("path");
+const { transaction } = require("../src/event_log_storage");
+const gitstore = require("../src/gitstore");
+const { readObjects } = require("../src/json_stream_file");
+const event = require("../src/event/structure");
+const {
+    stubEnvironment,
+    stubLogger,
+    stubDatetime,
+    stubEventLogRepository,
+} = require("./stubs");
+const { getMockedRootCapabilities } = require("./spies");
+
+function getTestCapabilities() {
+    const capabilities = getMockedRootCapabilities();
+    stubEnvironment(capabilities);
+    stubLogger(capabilities);
+    stubDatetime(capabilities);
+    return capabilities;
+}
+
+describe("event_log_storage deletion", () => {
+    test("transaction allows deleting existing entries", async () => {
+        const capabilities = getTestCapabilities();
+        await stubEventLogRepository(capabilities);
+
+        const e1 = {
+            id: { identifier: "delete1" },
+            date: new Date("2025-05-12"),
+            original: "first",
+            input: "first",
+            type: "test",
+            description: "first",
+            creator: { name: "t", uuid: "u", version: "1" },
+        };
+        const e2 = {
+            id: { identifier: "delete2" },
+            date: new Date("2025-05-13"),
+            original: "second",
+            input: "second",
+            type: "test",
+            description: "second",
+            creator: { name: "t", uuid: "u", version: "1" },
+        };
+
+        await transaction(capabilities, async (s) => {
+            s.addEntry(e1, []);
+            s.addEntry(e2, []);
+        });
+
+        await transaction(capabilities, async (s) => {
+            s.deleteEntry(e1.id);
+        });
+
+        await gitstore.transaction(capabilities, async (store) => {
+            const workTree = await store.getWorkTree();
+            const dataPath = path.join(workTree, "data.json");
+            const dataFile = await capabilities.checker.instantiate(dataPath);
+            const objects = await readObjects(capabilities, dataFile);
+            expect(objects).toHaveLength(1);
+            expect(objects[0].id).toBe(event.serialize(e2).id);
+        });
+    });
+
+    test("deleteEntry removes entry queued in same transaction", async () => {
+        const capabilities = getTestCapabilities();
+        await stubEventLogRepository(capabilities);
+
+        const e1 = {
+            id: { identifier: "todel1" },
+            date: new Date("2025-05-14"),
+            original: "one",
+            input: "one",
+            type: "test",
+            description: "one",
+            creator: { name: "t", uuid: "u", version: "1" },
+        };
+        const e2 = {
+            id: { identifier: "todel2" },
+            date: new Date("2025-05-15"),
+            original: "two",
+            input: "two",
+            type: "test",
+            description: "two",
+            creator: { name: "t", uuid: "u", version: "1" },
+        };
+
+        await transaction(capabilities, async (s) => {
+            s.addEntry(e1, []);
+            s.addEntry(e2, []);
+            s.deleteEntry(e1.id);
+        });
+
+        await gitstore.transaction(capabilities, async (store) => {
+            const workTree = await store.getWorkTree();
+            const dataPath = path.join(workTree, "data.json");
+            const dataFile = await capabilities.checker.instantiate(dataPath);
+            const objects = await readObjects(capabilities, dataFile);
+            expect(objects).toHaveLength(1);
+            expect(objects[0].id).toBe(event.serialize(e2).id);
+        });
+    });
+
+    test("deleting the only entry results in empty log", async () => {
+        const capabilities = getTestCapabilities();
+        await stubEventLogRepository(capabilities);
+
+        const e1 = {
+            id: { identifier: "solo" },
+            date: new Date("2025-05-16"),
+            original: "solo",
+            input: "solo",
+            type: "test",
+            description: "solo",
+            creator: { name: "t", uuid: "u", version: "1" },
+        };
+
+        await transaction(capabilities, async (s) => {
+            s.addEntry(e1, []);
+        });
+
+        await transaction(capabilities, async (s) => {
+            s.deleteEntry(e1.id);
+        });
+
+        await gitstore.transaction(capabilities, async (store) => {
+            const workTree = await store.getWorkTree();
+            const dataPath = path.join(workTree, "data.json");
+            const dataFile = await capabilities.checker.instantiate(dataPath);
+            const objects = await readObjects(capabilities, dataFile);
+            expect(objects).toHaveLength(0);
+        });
+    });
+
+    test("getDeletedIds returns an iterator of EventIds", async () => {
+        const capabilities = getTestCapabilities();
+        await stubEventLogRepository(capabilities);
+
+        const e = {
+            id: { identifier: "iter" },
+            date: new Date("2025-06-01"),
+            original: "i",
+            input: "i",
+            type: "test",
+            description: "iter",
+            creator: { name: "t", uuid: "u", version: "1" },
+        };
+
+        await transaction(capabilities, async (s) => {
+            s.addEntry(e, []);
+        });
+
+        await transaction(capabilities, async (s) => {
+            s.deleteEntry(e.id);
+            const iter = s.getDeletedIds();
+            expect(typeof iter[Symbol.iterator]).toBe("function");
+            const arr = Array.from(iter);
+            expect(arr).toHaveLength(1);
+            expect(arr[0]).toEqual(e.id);
+        });
+    });
+
+    test("transaction can delete multiple entries in one call", async () => {
+        const capabilities = getTestCapabilities();
+        await stubEventLogRepository(capabilities);
+
+        const e1 = {
+            id: { identifier: "multi1" },
+            date: new Date("2025-06-02"),
+            original: "m1",
+            input: "m1",
+            type: "test",
+            description: "m1",
+            creator: { name: "t", uuid: "u", version: "1" },
+        };
+        const e2 = {
+            id: { identifier: "multi2" },
+            date: new Date("2025-06-03"),
+            original: "m2",
+            input: "m2",
+            type: "test",
+            description: "m2",
+            creator: { name: "t", uuid: "u", version: "1" },
+        };
+
+        await transaction(capabilities, async (s) => {
+            s.addEntry(e1, []);
+            s.addEntry(e2, []);
+        });
+
+        await transaction(capabilities, async (s) => {
+            s.deleteEntry(e1.id);
+            s.deleteEntry(e2.id);
+        });
+
+        await gitstore.transaction(capabilities, async (store) => {
+            const workTree = await store.getWorkTree();
+            const dataPath = path.join(workTree, "data.json");
+            const dataFile = await capabilities.checker.instantiate(dataPath);
+            const objects = await readObjects(capabilities, dataFile);
+            expect(objects).toHaveLength(0);
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- store deleted event IDs in a `Set`
- return an iterator from `getDeletedIds`
- handle deletions in transaction using a string set
- extend deletion tests for iterator behavior and multiple deletes

## Testing
- `npx jest backend/tests/event_log_storage.delete.test.js`
- `npm test`
- `npm run static-analysis`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6869993ff0b0832eaba10c9875d9d18b