### PR TITLE
Add deletion from describe page

### DIFF
--- a/frontend/src/DescriptionEntry/ConfigSection.jsx
+++ b/frontend/src/DescriptionEntry/ConfigSection.jsx
@@ -26,12 +26,13 @@ import { HelpTab } from "./tabs/HelpTab.jsx";
  * Component that displays configuration help and shortcuts
  * @param {Object} props
  * @param {(value: string) => void} props.onShortcutClick - Called when a shortcut is clicked
+ * @param {(id: string) => void} props.onDeleteEntry - Called when an entry delete is requested
  * @param {string} props.currentInput - Current input value to show preview
  * @param {Array<any>} [props.recentEntries] - Array of recent entries to display
  * @param {boolean} [props.isLoadingEntries] - Whether entries are loading
  * @returns {JSX.Element|null}
  */
-export const ConfigSection = ({ onShortcutClick, currentInput = "", recentEntries = [], isLoadingEntries = false }) => {
+export const ConfigSection = ({ onShortcutClick, onDeleteEntry, currentInput = "", recentEntries = [], isLoadingEntries = false }) => {
     const [config, setConfig] = useState(/** @type {Config|null} */ (null));
     const [isLoading, setIsLoading] = useState(true);
 
@@ -80,10 +81,11 @@ export const ConfigSection = ({ onShortcutClick, currentInput = "", recentEntrie
 
                         <TabPanels>
                             <TabPanel px={0}>
-                                <RecentEntriesTab 
+                                <RecentEntriesTab
                                     recentEntries={recentEntries}
                                     isLoadingEntries={isLoadingEntries}
                                     onShortcutClick={onShortcutClick}
+                                    onDeleteEntry={onDeleteEntry}
                                 />
                             </TabPanel>
 

--- a/frontend/src/DescriptionEntry/DescriptionEntry.jsx
+++ b/frontend/src/DescriptionEntry/DescriptionEntry.jsx
@@ -17,6 +17,7 @@ export default function DescriptionEntry() {
         setDescription,
         handleTakePhotos,
         handleKeyUp,
+        handleDeleteEntry,
     } = useDescriptionEntry(NUMBER_OF_RECENT_ENTRIES);
 
     const inputRef = useRef(null);
@@ -59,6 +60,7 @@ export default function DescriptionEntry() {
                 {/* Configuration Section */}
                 <ConfigSection
                     onShortcutClick={handleShortcutClick}
+                    onDeleteEntry={handleDeleteEntry}
                     currentInput={description}
                     recentEntries={recentEntries}
                     isLoadingEntries={isLoadingEntries}

--- a/frontend/src/DescriptionEntry/EntryItem.jsx
+++ b/frontend/src/DescriptionEntry/EntryItem.jsx
@@ -6,6 +6,7 @@ import {
     Text,
     Badge,
     Skeleton,
+    IconButton,
 } from "@chakra-ui/react";
 import { formatRelativeDate } from "./utils.js";
 import { CARD_STYLES, TEXT_STYLES, BADGE_STYLES } from "./styles.js";
@@ -23,9 +24,10 @@ import { CARD_STYLES, TEXT_STYLES, BADGE_STYLES } from "./styles.js";
  * @param {Object} props
  * @param {Entry} props.entry - The entry data
  * @param {number} props.index - Index for fallback key
+ * @param {(id: string) => void} [props.onDelete] - Called when delete button is clicked
  * @returns {JSX.Element}
  */
-export const EntryItem = ({ entry, index }) => (
+export const EntryItem = ({ entry, index, onDelete }) => (
     <Box key={entry.id || index} {...CARD_STYLES.entry}>
         <HStack justify="space-between" align="flex-start">
             <VStack align="flex-start" spacing={1} flex={1}>
@@ -41,6 +43,15 @@ export const EntryItem = ({ entry, index }) => (
                     {entry.description}
                 </Text>
             </VStack>
+            {onDelete && (
+                <IconButton
+                    aria-label="Delete entry"
+                    size="sm"
+                    variant="ghost"
+                    onClick={(e) => { e.stopPropagation(); onDelete(entry.id); }}
+                    icon={<span>&times;</span>}
+                />
+            )}
         </HStack>
     </Box>
 );

--- a/frontend/src/DescriptionEntry/api.js
+++ b/frontend/src/DescriptionEntry/api.js
@@ -194,3 +194,25 @@ export const fetchConfig = async () => {
         return null;
     }
 };
+
+/**
+ * Deletes an entry by id via the API.
+ * @param {string} id - Entry identifier to delete.
+ * @returns {Promise<boolean>} - True on success, false otherwise.
+ */
+export const deleteEntry = async (id) => {
+    try {
+        const response = await fetch(
+            `${API_BASE_URL}/entries?id=${encodeURIComponent(id)}`,
+            { method: "DELETE" }
+        );
+        if (response.ok) {
+            return true;
+        }
+        logger.warn("Failed to delete entry:", response.status);
+        return false;
+    } catch (error) {
+        logger.error("Error deleting entry:", error);
+        return false;
+    }
+};

--- a/frontend/src/DescriptionEntry/hooks.js
+++ b/frontend/src/DescriptionEntry/hooks.js
@@ -3,6 +3,7 @@ import { useToast } from "@chakra-ui/react";
 import {
     fetchRecentEntries as apiFetchRecentEntries,
     submitEntry,
+    deleteEntry as apiDeleteEntry,
 } from "./api";
 import { isValidDescription, createToastConfig } from "./utils.js";
 import { logger } from "./logger.js";
@@ -153,6 +154,7 @@ const processCameraReturn = async (cameraReturn, setDescription, setPendingReque
  * @property {() => Promise<void>} handleSubmit
  * @property {() => void} handleTakePhotos
  * @property {(e: React.KeyboardEvent) => void} handleKeyUp
+ * @property {(id: string) => Promise<void>} handleDeleteEntry
  * @property {() => Promise<void>} fetchRecentEntries
  */
 
@@ -222,6 +224,25 @@ export const useDescriptionEntry = (numberOfEntries = 10) => {
         }
     };
 
+    /**
+     * Deletes an entry and refreshes list.
+     * @param {string} id
+     * @returns {Promise<void>}
+     */
+    const handleDeleteEntry = async (id) => {
+        try {
+            const success = await apiDeleteEntry(id);
+            if (success) {
+                fetchRecentEntries();
+            } else {
+                toast(createToastConfig.error("Failed to delete entry"));
+            }
+        } catch (error) {
+            logger.error("Error deleting entry:", error);
+            toast(createToastConfig.error("Failed to delete entry"));
+        }
+    };
+
     // Fetch entries on mount
     useEffect(() => {
         fetchRecentEntries();
@@ -248,6 +269,7 @@ export const useDescriptionEntry = (numberOfEntries = 10) => {
         handleSubmit,
         handleTakePhotos,
         handleKeyUp,
+        handleDeleteEntry,
         fetchRecentEntries,
     };
 };

--- a/frontend/src/DescriptionEntry/tabs/RecentEntriesTab.jsx
+++ b/frontend/src/DescriptionEntry/tabs/RecentEntriesTab.jsx
@@ -9,9 +9,10 @@ import { SPACING } from "../styles.js";
  * @param {Array<any>} props.recentEntries - Array of recent entries
  * @param {boolean} props.isLoadingEntries - Whether entries are loading
  * @param {(value: string) => void} props.onShortcutClick - Called when an entry is clicked
+ * @param {(id: string) => void} props.onDeleteEntry - Called when delete button is clicked
  * @returns {JSX.Element}
  */
-export const RecentEntriesTab = ({ recentEntries, isLoadingEntries, onShortcutClick }) => {
+export const RecentEntriesTab = ({ recentEntries, isLoadingEntries, onShortcutClick, onDeleteEntry }) => {
     if (isLoadingEntries) {
         return (
             <VStack spacing={SPACING.md} align="stretch">
@@ -41,7 +42,7 @@ export const RecentEntriesTab = ({ recentEntries, isLoadingEntries, onShortcutCl
                     p={2}
                     borderRadius="md"
                 >
-                    <EntryItem entry={entry} index={index} />
+                    <EntryItem entry={entry} index={index} onDelete={() => onDeleteEntry(entry.id)} />
                 </Box>
             ))}
         </VStack>

--- a/frontend/tests/DescriptionEntry.delete.test.jsx
+++ b/frontend/tests/DescriptionEntry.delete.test.jsx
@@ -1,0 +1,111 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+jest.mock("../src/DescriptionEntry/api", () => ({
+    fetchRecentEntries: jest.fn(),
+    submitEntry: jest.fn(),
+    fetchConfig: jest.fn(),
+    deleteEntry: jest.fn(),
+}));
+
+jest.mock("../src/DescriptionEntry/logger", () => ({
+    logger: {
+        error: jest.fn(),
+        warn: jest.fn(),
+        info: jest.fn(),
+        debug: jest.fn(),
+    },
+}));
+
+jest.mock("../src/DescriptionEntry/cameraUtils", () => ({
+    generateRequestIdentifier: jest.fn(),
+    navigateToCamera: jest.fn(),
+    checkCameraReturn: jest.fn(),
+    cleanupUrlParams: jest.fn(),
+    restoreDescription: jest.fn(),
+    retrievePhotos: jest.fn(),
+}));
+
+import DescriptionEntry from "../src/DescriptionEntry/DescriptionEntry.jsx";
+import {
+    fetchRecentEntries,
+    submitEntry,
+    fetchConfig,
+    deleteEntry,
+} from "../src/DescriptionEntry/api";
+import {
+    generateRequestIdentifier,
+    navigateToCamera,
+    checkCameraReturn,
+    cleanupUrlParams,
+    restoreDescription,
+    retrievePhotos,
+} from "../src/DescriptionEntry/cameraUtils";
+
+
+describe("DescriptionEntry deletion", () => {
+    const defaultMockConfig = {
+        help: "help text",
+        shortcuts: [],
+    };
+
+    beforeEach(() => {
+        fetchRecentEntries.mockClear();
+        submitEntry.mockClear();
+        fetchConfig.mockClear();
+        deleteEntry.mockClear();
+
+        generateRequestIdentifier.mockReset();
+        navigateToCamera.mockReset();
+        checkCameraReturn.mockReset();
+        cleanupUrlParams.mockReset();
+        restoreDescription.mockReset();
+        retrievePhotos.mockReset();
+
+        fetchRecentEntries.mockResolvedValue([]);
+        submitEntry.mockResolvedValue({ success: true, entry: { input: "t" } });
+        fetchConfig.mockResolvedValue(defaultMockConfig);
+        deleteEntry.mockResolvedValue(true);
+        generateRequestIdentifier.mockReturnValue("req");
+        checkCameraReturn.mockReturnValue({ isReturn: false, requestIdentifier: null });
+        restoreDescription.mockReturnValue(null);
+        retrievePhotos.mockReturnValue([]);
+
+        Object.defineProperty(window, "sessionStorage", {
+            value: {
+                getItem: jest.fn(),
+                setItem: jest.fn(),
+                removeItem: jest.fn(),
+                clear: jest.fn(),
+            },
+            writable: true,
+        });
+    });
+
+    it("deletes an entry when delete button is clicked", async () => {
+        const mockEntries = [
+            { id: "1", original: "test entry", date: "2023-01-01", description: "desc", type: "note" },
+        ];
+        fetchRecentEntries.mockResolvedValueOnce(mockEntries);
+
+        render(<DescriptionEntry />);
+
+        await waitFor(() => {
+            expect(fetchRecentEntries).toHaveBeenCalled();
+        });
+
+        fireEvent.click(screen.getByText("Recent Entries"));
+
+        await waitFor(() => {
+            expect(screen.getByLabelText("Delete entry")).toBeInTheDocument();
+        });
+
+        fireEvent.click(screen.getByLabelText("Delete entry"));
+
+        await waitFor(() => {
+            expect(deleteEntry).toHaveBeenCalledWith("1");
+            expect(fetchRecentEntries).toHaveBeenCalledTimes(2);
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- allow deleting entries from the Describe page
- call API endpoint to remove entry and refresh list
- show delete icon for each recent entry
- test deletion flow

## Testing
- `npm test`
- `npm run static-analysis`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6869ffe94c1c832eac37d7b0156196fe