### PR TITLE
Fix encapsulation for EntryValidationError

### DIFF
--- a/backend/src/entry.js
+++ b/backend/src/entry.js
@@ -17,6 +17,24 @@ class EntryValidationError extends Error {
     }
 }
 
+/**
+ * Factory for EntryValidationError.
+ * @param {string} message - The validation error message
+ * @returns {EntryValidationError}
+ */
+function makeEntryValidationError(message) {
+    return new EntryValidationError(message);
+}
+
+/**
+ * Type guard for EntryValidationError.
+ * @param {unknown} object
+ * @returns {object is EntryValidationError}
+ */
+function isEntryValidationError(object) {
+    return object instanceof EntryValidationError;
+}
+
 /** @typedef {import('./event/asset').Asset} Asset */
 /** @typedef {import('./random/seed').NonDeterministicSeed} NonDeterministicSeed */
 /** @typedef {import('./filesystem/deleter').FileDeleter} FileDeleter */
@@ -194,4 +212,10 @@ async function deleteEntry(capabilities, id) {
     );
 }
 
-module.exports = { createEntry, getEntries, deleteEntry, EntryValidationError };
+module.exports = {
+    createEntry,
+    getEntries,
+    deleteEntry,
+    makeEntryValidationError,
+    isEntryValidationError,
+};

--- a/backend/src/routes/entries/post.js
+++ b/backend/src/routes/entries/post.js
@@ -1,4 +1,4 @@
-const { createEntry, EntryValidationError } = require("../../entry");
+const { createEntry, isEntryValidationError } = require("../../entry");
 const { serialize } = require("../../event");
 const {
     processUserInput,
@@ -201,7 +201,7 @@ async function handleEntryPost(req, res, capabilities, reqId) {
 
         return res.status(201).json({ success: true, entry: serialize(event) });
     } catch (error) {
-        if (error instanceof EntryValidationError || error instanceof FileValidationError) {
+        if (isEntryValidationError(error) || error instanceof FileValidationError) {
             capabilities.logger.logInfo(
                 {
                     request_identifier: reqId.identifier,


### PR DESCRIPTION
## Summary
- convert `EntryValidationError` class to internal factory pattern
- update `entries/post.js` route to use new type guard

## Testing
- `npm test`
- `npm run static-analysis`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686c2789d794832e81e56bcdaa7146c0