### PR TITLE
Fix exports for dirscanner

### DIFF
--- a/backend/src/filesystem/dirscanner.js
+++ b/backend/src/filesystem/dirscanner.js
@@ -119,5 +119,4 @@ function make() {
 module.exports = {
     isDirScannerError,
     make,
-    DirectoryMemberClass,
 };


### PR DESCRIPTION
## Summary
- remove `DirectoryMemberClass` from `dirscanner` module exports

## Testing
- `npm test`
- `npm run static-analysis`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686c277ef0cc832eae1a1525671c0345