### PR TITLE
Fix logging to follow conventions

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { Button, Box, VStack, Heading, Text } from '@chakra-ui/react';
+import { logger } from './DescriptionEntry/logger.js';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 function App() {
@@ -18,7 +19,7 @@ function App() {
     };
 
     const handleAppInstalled = () => {
-      console.log('PWA was installed');
+      logger.info('PWA was installed');
       setIsInstallable(false);
       setDeferredPrompt(null);
     };
@@ -46,12 +47,12 @@ function App() {
       const outcome = result?.outcome;
       
       if (outcome === 'accepted') {
-        console.log('User accepted the install prompt');
+        logger.info('User accepted the install prompt');
       } else {
-        console.log('User dismissed the install prompt');
+        logger.info('User dismissed the install prompt');
       }
     } catch (error) {
-      console.log('Install prompt error:', error);
+      logger.error('Install prompt error:', error);
     }
 
     // Clear the deferredPrompt so it can only be used once

--- a/frontend/src/index.jsx
+++ b/frontend/src/index.jsx
@@ -7,6 +7,7 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import Camera from './Camera/Camera.jsx';
 import DescriptionEntry from './DescriptionEntry/DescriptionEntry.jsx';
 import { ChakraProvider } from '@chakra-ui/react';
+import { logger } from './DescriptionEntry/logger.js';
 
 const root = document.getElementById('root');
 if (root === null) {
@@ -21,7 +22,7 @@ const updateSW = registerSW({
         }
     },
     onOfflineReady() {
-        console.log('App ready to work offline');
+        logger.info('App ready to work offline');
     },
 });
 

--- a/frontend/src/sw.js
+++ b/frontend/src/sw.js
@@ -12,6 +12,7 @@
 // not the main browser context, so self, __WB_MANIFEST, etc. are available globally
 
 import { precacheAndRoute, cleanupOutdatedCaches } from "workbox-precaching";
+import { logger } from "./DescriptionEntry/logger.js";
 
 // Precache all static assets
 precacheAndRoute(self.__WB_MANIFEST);
@@ -21,11 +22,11 @@ cleanupOutdatedCaches();
 
 // Basic service worker events
 self.addEventListener("install", () => {
-    console.log("Service worker installing");
+    logger.info("Service worker installing");
     self.skipWaiting();
 });
 
 self.addEventListener("activate", (event) => {
-    console.log("Service worker activating");
+    logger.info("Service worker activating");
     event.waitUntil(self.clients.claim());
 });


### PR DESCRIPTION
## Summary
- use the shared logger in the React frontend and service worker

## Testing
- `npm test`
- `npm run static-analysis`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686c277ef0cc832eae1a1525671c0345