### PR TITLE
Fix coding convention violations

### DIFF
--- a/backend/src/capabilities/root.js
+++ b/backend/src/capabilities/root.js
@@ -12,6 +12,7 @@
 /** @typedef {import('../filesystem/appender').FileAppender} FileAppender */
 /** @typedef {import('../filesystem/creator').FileCreator} FileCreator */
 /** @typedef {import('../filesystem/checker').FileChecker} FileChecker */
+/** @typedef {import('../exiter').Exiter} Exiter */
 /** @typedef {import('../subprocess/command').Command} Command */
 /** @typedef {import('../environment').Environment} Environment */
 /** @typedef {import('../logger').Logger} Logger */
@@ -34,6 +35,7 @@
  * @property {FileChecker} checker - A file checker instance.
  * @property {Command} git - A command instance for Git operations.
  * @property {Environment} environment - An environment instance.
+ * @property {Exiter} exiter - A process exit instance.
  * @property {Logger} logger - A logger instance.
  * @property {Notifier} notifier - A notifier instance.
  * @property {Scheduler} scheduler - A scheduler instance.
@@ -55,6 +57,7 @@ const checkerCapability = require("../filesystem/checker");
 const gitCapability = require("../executables").git;
 const environmentCapability = require("../environment");
 const loggingCapability = require("../logger");
+const exiterCapability = require("../exiter");
 const notifierCapability = require("../notifications");
 const schedulerCapability = require("../schedule");
 const aiTranscriptionCapability = require("../ai/transcription");
@@ -83,6 +86,7 @@ const make = memconst(() => {
         checker: checkerCapability.make({ datetime }),
         git: gitCapability,
         environment,
+        exiter: exiterCapability.make(),
         logger: loggingCapability.make(() => ret),
         notifier: notifierCapability.make(),
         scheduler: schedulerCapability.make(),

--- a/backend/src/exiter.js
+++ b/backend/src/exiter.js
@@ -1,0 +1,22 @@
+/**
+ * Provides a capability for exiting the process.
+ */
+
+/**
+ * @typedef {object} Exiter
+ * @property {(code: number) => void} exit
+ */
+
+/**
+ * Exit the process with the given code.
+ * @param {number} code - Exit code.
+ */
+function exit(code) {
+    process.exit(code);
+}
+
+function make() {
+    return { exit };
+}
+
+module.exports = { make };

--- a/backend/src/express_app.js
+++ b/backend/src/express_app.js
@@ -1,14 +1,7 @@
 const express = require("express");
 const { gentleWrap } = require("./gentlewrap");
 
-/** @typedef {import('./environment').Environment} Environment */
-/** @typedef {import('./logger').Logger} Logger */
-
-/**
- * @typedef {object} Capabilities
- * @property {Environment} environment - An environment instance.
- * @property {Logger} logger - A logger instance.
- */
+/** @typedef {import('./server').Capabilities} Capabilities */
 
 class ServerAddressAlreadyInUseError extends Error {
     constructor() {

--- a/backend/src/gentlewrap.js
+++ b/backend/src/gentlewrap.js
@@ -12,6 +12,7 @@
 /**
  * @typedef {object} Capabilities
  * @property {Logger} logger - A logger instance.
+ * @property {import('./exiter').Exiter} exiter - A process exit instance.
  */
 
 /**
@@ -38,7 +39,8 @@ async function gentleCall(capabilities, fn, errorsList) {
                     ? String(e.message)
                     : String(e);
             capabilities.logger.logError({}, message);
-            process.exit(1);
+            capabilities.exiter.exit(1);
+            return Promise.reject(e);
         } else {
             throw e;
         }

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -30,7 +30,7 @@ async function entryTyped(capabilities) {
         .action(async (cmd, options) => {
             if (options.version) {
                 await printVersion(capabilities);
-                process.exit(0);
+                capabilities.exiter.exit(0);
             }
             if (cmd) {
                 capabilities.logger.logError({ cmd }, `Unknown command ${JSON.stringify(cmd)}`);

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -25,6 +25,7 @@ const workingRepository = require("./gitstore/working_repository");
 /** @typedef {import('./notifications').Notifier} Notifier */
 /** @typedef {import('./schedule').Scheduler} Scheduler */
 /** @typedef {import('./ai/transcription').AITranscription} AITranscription */
+/** @typedef {import('./exiter').Exiter} Exiter */
 
 /**
  * @typedef {object} Capabilities
@@ -38,6 +39,7 @@ const workingRepository = require("./gitstore/working_repository");
  * @property {FileChecker} checker - A file checker instance.
  * @property {Command} git - A command instance for Git operations.
  * @property {Environment} environment - An environment instance.
+ * @property {Exiter} exiter - A process exit instance.
  * @property {Logger} logger - A logger instance.
  * @property {Notifier} notifier - A notifier instance.
  * @property {Scheduler} scheduler - A scheduler instance.


### PR DESCRIPTION
## Summary
- add new `exiter` capability for process exits
- use `exiter` in gentle wrapper and CLI entry
- update capability definitions
- adjust express app typing to use server capabilities

## Testing
- `npm test`
- `npm run static-analysis`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686c277d039c832eb72a561202869977