### PR TITLE
Fix encoding of event log storage class

### DIFF
--- a/backend/src/event_log_storage/class.js
+++ b/backend/src/event_log_storage/class.js
@@ -1,7 +1,5 @@
 const event = require("../event");
 const { readObjects } = require("../json_stream_file");
-
-
 /** @typedef {import('./types').Capabilities} Capabilities */
 /** @typedef {import('./types').AppendCapabilities} AppendCapabilities */
 /** @typedef {import('./types').CopyAssetCapabilities} CopyAssetCapabilities */
@@ -12,17 +10,7 @@ const { readObjects } = require("../json_stream_file");
 /** @typedef {import('../event/id').EventId} EventId */
 
 /**
- * A class to manage the storage of event log entries.
- *
- * Class to accumulate event entries before persisting.
- *
- * Intuitive Usage:
- * 1. Create an instance implicitly via `transaction()`.
- * 2. Call `addEntry()` once or multiple times to queue up events.
- * 3. `getNewEntries()` returns the queued array without side effects.
- *
- * Internal Note:
- * - `newEntries` is a simple in-memory array and does not interact with Git or the filesystem directly.
+ * A class to accumulate event log entries before persisting them.
  */
 class EventLogStorageClass {
     /**
@@ -286,4 +274,25 @@ class EventLogStorageClass {
 
 /** @typedef {EventLogStorageClass} EventLogStorage */
 
-module.exports = { EventLogStorageClass };
+/**
+ * Creates a new EventLogStorage instance.
+ * @param {EventLogStorageCapabilities} capabilities
+ * @returns {EventLogStorage}
+ */
+function make(capabilities) {
+    return new EventLogStorageClass(capabilities);
+}
+
+/**
+ * Type guard for EventLogStorage.
+ * @param {unknown} object
+ * @returns {object is EventLogStorage}
+ */
+function isEventLogStorage(object) {
+    return object instanceof EventLogStorageClass;
+}
+
+module.exports = {
+    make,
+    isEventLogStorage,
+};

--- a/backend/src/event_log_storage/transaction.js
+++ b/backend/src/event_log_storage/transaction.js
@@ -14,7 +14,7 @@ const gitstore = require("../gitstore");
 const event = require("../event");
 const { targetPath } = require("../event/asset");
 const configStorage = require("../config/storage");
-const { EventLogStorageClass } = require("./class");
+const { make: makeEventLogStorage } = require("./class");
 
 /** @typedef {import("../filesystem/file").ExistingFile} ExistingFile */
 /** @typedef {import("./types").AppendCapabilities} AppendCapabilities */
@@ -208,7 +208,7 @@ async function cleanupAssets(capabilities, eventLogStorage) {
  * @returns {Promise<T>}
  */
 async function transaction(capabilities, transformation) {
-    const eventLogStorage = new EventLogStorageClass(capabilities);
+    const eventLogStorage = makeEventLogStorage(capabilities);
     try {
         return await performGitTransaction(
             capabilities,


### PR DESCRIPTION
## Summary
- encapsulate `EventLogStorageClass` with a factory and type guard
- use the new factory in transaction logic

## Testing
- `npm test`
- `npm run static-analysis`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686c277d039c832eb72a561202869977