### PR TITLE
Remove type casts in frontend utils

### DIFF
--- a/frontend/src/DescriptionEntry/DescriptionEntry.jsx
+++ b/frontend/src/DescriptionEntry/DescriptionEntry.jsx
@@ -29,7 +29,11 @@ export default function DescriptionEntry() {
         }
     }, []);
 
-    const handleShortcutClick = (/** @type {string} */ text) => {
+    /**
+     * Apply a shortcut value to the input.
+     * @param {string} text
+     */
+    const handleShortcutClick = (text) => {
         setDescription(text);
         // Focus the input after setting the text
         if (inputRef.current) {

--- a/frontend/src/DescriptionEntry/logger.js
+++ b/frontend/src/DescriptionEntry/logger.js
@@ -4,16 +4,36 @@
  */
 
 export const logger = {
-    error: (/** @type {any} */ message, /** @type {any[]} */ ...args) => {
+    /**
+     * Log an error message.
+     * @param {*} message
+     * @param {...*} args
+     */
+    error: (message, ...args) => {
         console.error(message, ...args);
     },
-    warn: (/** @type {any} */ message, /** @type {any[]} */ ...args) => {
+    /**
+     * Log a warning message.
+     * @param {*} message
+     * @param {...*} args
+     */
+    warn: (message, ...args) => {
         console.warn(message, ...args);
     },
-    info: (/** @type {any} */ message, /** @type {any[]} */ ...args) => {
+    /**
+     * Log an info message.
+     * @param {*} message
+     * @param {...*} args
+     */
+    info: (message, ...args) => {
         console.info(message, ...args);
     },
-    debug: (/** @type {any} */ message, /** @type {any[]} */ ...args) => {
+    /**
+     * Log a debug message.
+     * @param {*} message
+     * @param {...*} args
+     */
+    debug: (message, ...args) => {
         console.debug(message, ...args);
     }
 };

--- a/frontend/src/DescriptionEntry/photoStorage.js
+++ b/frontend/src/DescriptionEntry/photoStorage.js
@@ -30,12 +30,15 @@ async function openDatabase() {
         };
 
         request.onupgradeneeded = (event) => {
-            if (!event.target) return;
-            /** @type {IDBOpenDBRequest} */
-            const req = /** @type {IDBOpenDBRequest} */ (event.target);
-            const db = req.result;
-            if (!db.objectStoreNames.contains(STORE_NAME)) {
-                db.createObjectStore(STORE_NAME);
+            const target = event.target;
+            if (
+                typeof IDBOpenDBRequest !== 'undefined' &&
+                target instanceof IDBOpenDBRequest
+            ) {
+                const db = target.result;
+                if (!db.objectStoreNames.contains(STORE_NAME)) {
+                    db.createObjectStore(STORE_NAME);
+                }
             }
         };
     });
@@ -69,7 +72,7 @@ export async function storePhotos(key, photosData) {
 
             store.put(photosData, key);
         });
-    } catch (/** @type {unknown} */ error) {
+    } catch (error) {
         // Fix error.name checks for unknown type
         if (error && typeof error === 'object' && 'name' in error && error.name === 'PhotoStorageError') {
             throw error;
@@ -108,7 +111,7 @@ export async function retrievePhotos(key) {
                 resolve(request.result || null);
             };
         });
-    } catch (/** @type {unknown} */ error) {
+    } catch (error) {
         if (error && typeof error === 'object' && 'name' in error && error.name === 'PhotoRetrievalError') {
             throw error;
         }
@@ -147,7 +150,7 @@ export async function removePhotos(key) {
 
             store.delete(key);
         });
-    } catch (/** @type {unknown} */ error) {
+    } catch (error) {
         if (error && typeof error === 'object' && 'name' in error && error.name === 'PhotoStorageError') {
             throw error;
         }
@@ -184,7 +187,7 @@ export async function clearAllPhotos() {
 
             store.clear();
         });
-    } catch (/** @type {unknown} */ error) {
+    } catch (error) {
         if (error && typeof error === 'object' && 'name' in error && error.name === 'PhotoStorageError') {
             throw error;
         }

--- a/frontend/src/DescriptionEntry/utils.js
+++ b/frontend/src/DescriptionEntry/utils.js
@@ -36,39 +36,58 @@ export const isValidDescription = (description) => {
  * Creates toast notification configurations
  */
 export const createToastConfig = {
+    /**
+     * Toast shown when description is empty.
+     * @returns {import('@chakra-ui/react').UseToastOptions}
+     */
     emptyDescription: () => ({
         title: "Empty description",
         description: "Please enter a description before saving.",
-        status: /** @type {"warning"} */ ("warning"),
+        status: "warning",
         duration: 3000,
         isClosable: true,
-        position: /** @type {"top"} */ ("top"),
+        position: "top",
     }),
-    
-    success: (/** @type {string} */ savedInput) => ({
+
+    /**
+     * Toast shown on successful save.
+     * @param {string} savedInput
+     * @returns {import('@chakra-ui/react').UseToastOptions}
+     */
+    success: (savedInput) => ({
         title: "Event logged successfully",
         description: `Saved: ${savedInput}`,
-        status: /** @type {"success"} */ ("success"),
+        status: "success",
         duration: 4000,
         isClosable: true,
-        position: /** @type {"top"} */ ("top"),
+        position: "top",
     }),
-    
-    error: (/** @type {string} */ errorMessage) => ({
+
+    /**
+     * Toast shown when saving fails.
+     * @param {string} errorMessage
+     * @returns {import('@chakra-ui/react').UseToastOptions}
+     */
+    error: (errorMessage) => ({
         title: "Error logging event",
         description: errorMessage || "Please check your connection and try again.",
-        status: /** @type {"error"} */ ("error"),
+        status: "error",
         duration: 5000,
         isClosable: true,
-        position: /** @type {"top"} */ ("top"),
+        position: "top",
     }),
-    
-    warning: (/** @type {string} */ warningMessage) => ({
+
+    /**
+     * Generic warning toast.
+     * @param {string} warningMessage
+     * @returns {import('@chakra-ui/react').UseToastOptions}
+     */
+    warning: (warningMessage) => ({
         title: "Warning",
         description: warningMessage || "Please check and try again.",
-        status: /** @type {"warning"} */ ("warning"),
+        status: "warning",
         duration: 5000,
         isClosable: true,
-        position: /** @type {"top"} */ ("top"),
+        position: "top",
     }),
 };


### PR DESCRIPTION
## Summary
- clean up `createToastConfig` utilities
- document logger and shortcut handler
- avoid IDBOpenDBRequest cast in photoStorage

## Testing
- `npm test`
- `npm run static-analysis`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686c277f9f64832ea1b4af328afca88b