### PR TITLE
Fix toast config typing

### DIFF
--- a/frontend/src/DescriptionEntry/utils.js
+++ b/frontend/src/DescriptionEntry/utils.js
@@ -35,40 +35,67 @@ export const isValidDescription = (description) => {
 /**
  * Creates toast notification configurations
  */
+/**
+ * @typedef {"warning" | "success" | "error"} ToastStatus
+ */
+
+/**
+ * @typedef {"top"} ToastPosition
+ */
+
+/**
+ * @typedef {object} ToastConfig
+ * @property {string} title
+ * @property {string} description
+ * @property {ToastStatus} status
+ * @property {number} duration
+ * @property {boolean} isClosable
+ * @property {ToastPosition} position
+ */
+
+/**
+ * @typedef {object} ToastConfigFactory
+ * @property {() => ToastConfig} emptyDescription
+ * @property {(savedInput: string) => ToastConfig} success
+ * @property {(errorMessage: string) => ToastConfig} error
+ * @property {(warningMessage: string) => ToastConfig} warning
+ */
+
+/** @type {ToastConfigFactory} */
 export const createToastConfig = {
     emptyDescription: () => ({
         title: "Empty description",
         description: "Please enter a description before saving.",
-        status: /** @type {"warning"} */ ("warning"),
+        status: "warning",
         duration: 3000,
         isClosable: true,
-        position: /** @type {"top"} */ ("top"),
+        position: "top",
     }),
-    
-    success: (/** @type {string} */ savedInput) => ({
+
+    success: (savedInput) => ({
         title: "Event logged successfully",
         description: `Saved: ${savedInput}`,
-        status: /** @type {"success"} */ ("success"),
+        status: "success",
         duration: 4000,
         isClosable: true,
-        position: /** @type {"top"} */ ("top"),
+        position: "top",
     }),
-    
-    error: (/** @type {string} */ errorMessage) => ({
+
+    error: (errorMessage) => ({
         title: "Error logging event",
         description: errorMessage || "Please check your connection and try again.",
-        status: /** @type {"error"} */ ("error"),
+        status: "error",
         duration: 5000,
         isClosable: true,
-        position: /** @type {"top"} */ ("top"),
+        position: "top",
     }),
-    
-    warning: (/** @type {string} */ warningMessage) => ({
+
+    warning: (warningMessage) => ({
         title: "Warning",
         description: warningMessage || "Please check and try again.",
-        status: /** @type {"warning"} */ ("warning"),
+        status: "warning",
         duration: 5000,
         isClosable: true,
-        position: /** @type {"top"} */ ("top"),
+        position: "top",
     }),
 };


### PR DESCRIPTION
## Summary
- eliminate type casting in toast utilities by introducing explicit JSDoc types

## Testing
- `npm test`
- `npm run static-analysis`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686c27885974832e847f12f950433c7c