### PR TITLE
Fix encapsulation of EventLogStorage

### DIFF
--- a/backend/src/event_log_storage/class.js
+++ b/backend/src/event_log_storage/class.js
@@ -284,6 +284,27 @@ class EventLogStorageClass {
     }
 }
 
-/** @typedef {EventLogStorageClass} EventLogStorage */
+/** @typedef {InstanceType<typeof EventLogStorageClass>} EventLogStorage */
 
-module.exports = { EventLogStorageClass };
+/**
+ * Factory to create an EventLogStorage instance.
+ * @param {EventLogStorageCapabilities} capabilities - The capabilities object.
+ * @returns {EventLogStorage}
+ */
+function make(capabilities) {
+    return new EventLogStorageClass(capabilities);
+}
+
+/**
+ * Type guard for EventLogStorage instances.
+ * @param {unknown} object
+ * @returns {object is EventLogStorage}
+ */
+function isEventLogStorage(object) {
+    return object instanceof EventLogStorageClass;
+}
+
+module.exports = {
+    make,
+    isEventLogStorage,
+};

--- a/backend/src/event_log_storage/transaction.js
+++ b/backend/src/event_log_storage/transaction.js
@@ -14,7 +14,7 @@ const gitstore = require("../gitstore");
 const event = require("../event");
 const { targetPath } = require("../event/asset");
 const configStorage = require("../config/storage");
-const { EventLogStorageClass } = require("./class");
+const { make } = require("./class");
 
 /** @typedef {import("../filesystem/file").ExistingFile} ExistingFile */
 /** @typedef {import("./types").AppendCapabilities} AppendCapabilities */
@@ -208,7 +208,7 @@ async function cleanupAssets(capabilities, eventLogStorage) {
  * @returns {Promise<T>}
  */
 async function transaction(capabilities, transformation) {
-    const eventLogStorage = new EventLogStorageClass(capabilities);
+    const eventLogStorage = make(capabilities);
     try {
         return await performGitTransaction(
             capabilities,


### PR DESCRIPTION
## Summary
- hide `EventLogStorageClass` behind factory function and type guard
- update transaction logic to use new factory

## Testing
- `npm test`
- `npm run static-analysis`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686c27885974832e847f12f950433c7c