### PR TITLE
Fix test helper to use capabilities

### DIFF
--- a/backend/tests/stub_event_log_repository.js
+++ b/backend/tests/stub_event_log_repository.js
@@ -1,4 +1,3 @@
-const fs = require("fs/promises");
 const path = require("path");
 const temporary = require("./temporary");
 const defaultBranch = require("../src/gitstore/default_branch");
@@ -27,7 +26,7 @@ async function stubEventLogRepository(capabilities) {
 
     // Create a worktree
     const workTree = path.join(temporary.input(), "worktree");
-    await fs.mkdir(workTree, { recursive: true });
+    await capabilities.creator.createDirectory(workTree);
     await capabilities.git.call(
         "init",
         "--initial-branch",
@@ -38,9 +37,11 @@ async function stubEventLogRepository(capabilities) {
 
     // Create some content
     const testFile = path.join(workTree, "test.txt");
-    await fs.writeFile(testFile, "initial content");
+    const testFileObj = await capabilities.creator.createFile(testFile);
+    await capabilities.writer.writeFile(testFileObj, "initial content");
     const dataFile = path.join(workTree, "data.json");
-    await fs.writeFile(dataFile, "");
+    const dataFileObj = await capabilities.creator.createFile(dataFile);
+    await capabilities.writer.writeFile(dataFileObj, "");
 
     // Add and commit the content
     await capabilities.git.call("-C", workTree, "add", "--all");
@@ -74,7 +75,7 @@ async function stubEventLogRepository(capabilities) {
         defaultBranch
     );
 
-    await fs.rm(workTree, { recursive: true, force: true });
+    await capabilities.deleter.deleteDirectory(workTree);
 }
 
 module.exports = { stubEventLogRepository };


### PR DESCRIPTION
## Summary
- remove direct fs usage in test repository helper
- use creator, writer, and deleter capabilities instead

## Testing
- `npm test`
- `npm run static-analysis`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686d766eea14832eb0a66bf75188d679