### PR TITLE
Apply encapsulation conventions for frontend errors

### DIFF
--- a/frontend/src/Camera/Camera.jsx
+++ b/frontend/src/Camera/Camera.jsx
@@ -14,6 +14,12 @@ import { useCameraLogic } from "./camera_logic.js";
  * @typedef {{ blob: Blob; name: string }} Photo
  */
 
+/**
+ * Camera component allowing users to capture photos and
+ * navigate back to the main application once done.
+ *
+ * @returns {JSX.Element}
+ */
 export default function Camera() {
     const request_identifier = useMemo(() => {
         const params = new URLSearchParams(window.location.search);

--- a/frontend/src/Camera/camera_logic.js
+++ b/frontend/src/Camera/camera_logic.js
@@ -1,8 +1,8 @@
 import { useState, useRef, useEffect } from "react";
 import { useToast } from "@chakra-ui/react";
 import {
-    PhotoStorageError,
-    PhotoConversionError,
+    isPhotoStorageError,
+    isPhotoConversionError,
 } from "../DescriptionEntry/errors.js";
 import { processPhotos } from "./process_photos.js";
 
@@ -217,10 +217,10 @@ export function useCameraLogic(requestIdentifier, returnTo) {
             let title = "Error processing photos";
             let description = "An unexpected error occurred.";
 
-            if (err instanceof PhotoConversionError) {
+            if (isPhotoConversionError(err)) {
                 title = "Photo conversion failed";
                 description = `Failed to process ${err.photoName || "one or more photos"}. Please try taking new photos.`;
-            } else if (err instanceof PhotoStorageError) {
+            } else if (isPhotoStorageError(err)) {
                 title = "Storage error";
                 description = err.message;
             } else if (err instanceof Error) {

--- a/frontend/src/Camera/process_photos.js
+++ b/frontend/src/Camera/process_photos.js
@@ -1,4 +1,8 @@
-import { PhotoStorageError, PhotoConversionError } from "../DescriptionEntry/errors.js";
+import {
+    makePhotoStorageError,
+    makePhotoConversionError,
+    isPhotoStorageError,
+} from "../DescriptionEntry/errors.js";
 import { storePhotos } from "../DescriptionEntry/photoStorage.js";
 
 /**
@@ -27,7 +31,7 @@ export async function processPhotos(photos, requestIdentifier, returnTo, navigat
                             resolve(base64Data);
                         } else {
                             reject(
-                                new PhotoConversionError(
+                                makePhotoConversionError(
                                     "FileReader did not return a string",
                                     photo.name
                                 )
@@ -36,7 +40,7 @@ export async function processPhotos(photos, requestIdentifier, returnTo, navigat
                     };
                     reader.onerror = () =>
                         reject(
-                            new PhotoConversionError(
+                            makePhotoConversionError(
                                 "FileReader failed",
                                 photo.name,
                                 reader.error
@@ -51,7 +55,7 @@ export async function processPhotos(photos, requestIdentifier, returnTo, navigat
                     type: photo.blob.type || "image/jpeg",
                 };
             } catch (error) {
-                throw new PhotoConversionError(
+                throw makePhotoConversionError(
                     `Failed to process photo ${photo.name}`,
                     photo.name,
                     error instanceof Error ? error : new Error(String(error))
@@ -63,10 +67,10 @@ export async function processPhotos(photos, requestIdentifier, returnTo, navigat
     try {
         await storePhotos(`photos_${requestIdentifier}`, photosData);
     } catch (storageError) {
-        if (storageError instanceof PhotoStorageError) {
+        if (isPhotoStorageError(storageError)) {
             throw storageError;
         }
-        throw new PhotoStorageError(
+        throw makePhotoStorageError(
             "Failed to save photos. Please try again.",
             storageError instanceof Error ? storageError : new Error(String(storageError))
         );

--- a/frontend/src/DescriptionEntry/api.js
+++ b/frontend/src/DescriptionEntry/api.js
@@ -1,6 +1,9 @@
 const API_BASE_URL = "/api";
 import { logger } from "./logger.js";
-import { EntrySubmissionError } from "./errors.js";
+import {
+    makeEntrySubmissionError,
+    isEntrySubmissionError,
+} from "./errors.js";
 import { makeEntry } from "./entry.js";
 
 /**
@@ -111,13 +114,13 @@ export async function submitEntry(rawInput, requestIdentifier = undefined, files
     } catch (error) {
         // Network or fetch-level errors
         if (error instanceof TypeError && error.message.includes('fetch')) {
-            throw new EntrySubmissionError(
+            throw makeEntrySubmissionError(
                 "Unable to reach the server. Please check your internet connection.",
                 null,
                 error
             );
         }
-        throw new EntrySubmissionError(
+        throw makeEntrySubmissionError(
             "An unexpected error occurred during submission.",
             null,
             error instanceof Error ? error : new Error(String(error))
@@ -130,16 +133,16 @@ export async function submitEntry(rawInput, requestIdentifier = undefined, files
             if (result.success) {
                 return result;
             } else {
-                throw new EntrySubmissionError(
+                throw makeEntrySubmissionError(
                     result.error || "API returned unsuccessful response",
                     response.status
                 );
             }
         } catch (parseError) {
-            if (parseError instanceof EntrySubmissionError) {
+            if (isEntrySubmissionError(parseError)) {
                 throw parseError;
             }
-            throw new EntrySubmissionError(
+            throw makeEntrySubmissionError(
                 "Unable to parse server response",
                 response.status,
                 parseError instanceof Error ? parseError : new Error(String(parseError))
@@ -155,7 +158,7 @@ export async function submitEntry(rawInput, requestIdentifier = undefined, files
             errorMessage = `HTTP ${response.status} ${response.statusText}`;
         }
         
-        throw new EntrySubmissionError(errorMessage, response.status);
+        throw makeEntrySubmissionError(errorMessage, response.status);
     }
 }
 

--- a/frontend/src/DescriptionEntry/errors.js
+++ b/frontend/src/DescriptionEntry/errors.js
@@ -1,3 +1,6 @@
 // Aggregated exports for DescriptionEntry error handling
-export * from './error_classes.js';
+//
+// The underlying error classes are kept private to this folder to
+// enforce the project's encapsulation convention.  Only factory
+// functions and type guards are exported for external use.
 export * from './error_helpers.js';

--- a/frontend/tests/DescriptionEntry.errorHandling.test.jsx
+++ b/frontend/tests/DescriptionEntry.errorHandling.test.jsx
@@ -3,8 +3,8 @@
  */
 
 import {
-    PhotoRetrievalError,
-    EntrySubmissionError,
+    makePhotoRetrievalError,
+    makeEntrySubmissionError,
     getUserFriendlyErrorMessage,
     isPhotoRetrievalError,
     isEntrySubmissionError
@@ -13,7 +13,7 @@ import {
 describe('Error Handling System', () => {
     describe('Error Classes', () => {
         it('creates PhotoRetrievalError with correct properties', () => {
-            const error = new PhotoRetrievalError(
+            const error = makePhotoRetrievalError(
                 'Photo data corrupted',
                 'test-request-id'
             );
@@ -26,7 +26,7 @@ describe('Error Handling System', () => {
         });
 
         it('creates EntrySubmissionError with correct properties', () => {
-            const error = new EntrySubmissionError(
+            const error = makeEntrySubmissionError(
                 'Server error',
                 500
             );
@@ -41,19 +41,19 @@ describe('Error Handling System', () => {
 
     describe('Error Message Generation', () => {
         it('generates appropriate message for photo retrieval errors', () => {
-            const error = new PhotoRetrievalError('JSON parse failed');
+            const error = makePhotoRetrievalError('JSON parse failed');
             const message = getUserFriendlyErrorMessage(error);
             expect(message).toContain('corrupted');
         });
 
         it('generates appropriate message for network errors', () => {
-            const error = new EntrySubmissionError('fetch failed');
+            const error = makeEntrySubmissionError('fetch failed');
             const message = getUserFriendlyErrorMessage(error);
             expect(message).toContain('Network');
         });
 
         it('generates appropriate message for validation errors', () => {
-            const error = new EntrySubmissionError('Invalid input', 400);
+            const error = makeEntrySubmissionError('Invalid input', 400);
             const message = getUserFriendlyErrorMessage(error);
             expect(message).toContain('Invalid data');
         });
@@ -67,13 +67,13 @@ describe('Error Handling System', () => {
 
     describe('Type Guards', () => {
         it('correctly identifies PhotoRetrievalError', () => {
-            const error = new PhotoRetrievalError('test');
+            const error = makePhotoRetrievalError('test');
             expect(isPhotoRetrievalError(error)).toBe(true);
             expect(isEntrySubmissionError(error)).toBe(false);
         });
 
         it('correctly identifies EntrySubmissionError', () => {
-            const error = new EntrySubmissionError('test');
+            const error = makeEntrySubmissionError('test');
             expect(isEntrySubmissionError(error)).toBe(true);
             expect(isPhotoRetrievalError(error)).toBe(false);
         });


### PR DESCRIPTION
## Summary
- stop re-exporting error classes in `errors.js`
- document `Camera` component
- update camera modules to use factory functions and type guards
- adjust API and utils for encapsulation
- update tests for new error factories

## Testing
- `npm test`
- `npm run static-analysis`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686d7672eff4832ea0515e43153672c0