### PR TITLE
Add timer capability

### DIFF
--- a/backend/src/capabilities/root.js
+++ b/backend/src/capabilities/root.js
@@ -20,6 +20,7 @@
 /** @typedef {import('../schedule').Scheduler} Scheduler */
 /** @typedef {import('../ai/transcription').AITranscription} AITranscription */
 /** @typedef {import('../datetime').Datetime} Datetime */
+/** @typedef {import('../timer').Timer} Timer */
 
 
 /**
@@ -41,6 +42,7 @@
  * @property {Scheduler} scheduler - A scheduler instance.
  * @property {AITranscription} aiTranscription - An AI transcription instance.
  * @property {Datetime} datetime - Datetime utilities.
+ * @property {Timer} timer - Timer utilities.
  */
 
 const memconst = require("../memconst");
@@ -62,6 +64,7 @@ const notifierCapability = require("../notifications");
 const schedulerCapability = require("../schedule");
 const aiTranscriptionCapability = require("../ai/transcription");
 const datetimeCapability = require("../datetime");
+const timerCapability = require("../timer");
 
 /**
  * This structure collects maximum capabilities that any part of Volodyslav can access.
@@ -72,10 +75,12 @@ const datetimeCapability = require("../datetime");
 const make = memconst(() => {
     const environment = environmentCapability.make();
     const datetime = datetimeCapability.make();
+    const timer = timerCapability.make();
     /** @type {Capabilities} */
     const ret = {
         seed: random.seed.make(),
         datetime,
+        timer,
         deleter: deleterCapability.make(),
         scanner: dirscanner.make(),
         copier: copierCapability.make(),
@@ -83,7 +88,7 @@ const make = memconst(() => {
         writer: writerCapability.make(),
         reader: readerCapability.make(),
         appender: appendCapability.make(),
-        checker: checkerCapability.make({ datetime }),
+        checker: checkerCapability.make({ datetime, timer }),
         git: gitCapability,
         environment,
         exiter: exiterCapability.make(),

--- a/backend/src/filesystem/checker.js
+++ b/backend/src/filesystem/checker.js
@@ -131,13 +131,14 @@ async function instantiate(path) {
  * 2. Its size hasn't changed between two checks separated by a delay
  *
  * @param {Datetime} datetime - Datetime capability.
+ * @param {import('../timer').Timer} timer - Timer capability.
  * @param {ExistingFile} file - The path to the file to check.
  * @param {object} options - Stability check options.
  * @param {number} [options.minAgeMs=300000] - Minimum age in milliseconds (default: 5 minutes).
  * @param {number} [options.sizeCheckDelayMs=30000] - Delay between size checks in milliseconds (default: 30 seconds).
  * @returns {Promise<boolean>} - A promise that resolves with true if the file is stable, false otherwise.
  */
-async function isFileStable(datetime, file, options = {}) {
+async function isFileStable(datetime, timer, file, options = {}) {
     const { minAgeMs = 300000, sizeCheckDelayMs = 30000 } = options; // 5 minutes, 30 seconds default
 
     try {
@@ -155,7 +156,7 @@ async function isFileStable(datetime, file, options = {}) {
         const initialSize = initialStats.size;
 
         // Wait a short time and check size again
-        await new Promise((resolve) => setTimeout(resolve, sizeCheckDelayMs));
+        await timer.wait(sizeCheckDelayMs);
 
         const finalStats = await fs.stat(file.path);
         const finalSize = finalStats.size;
@@ -184,15 +185,15 @@ async function isFileStable(datetime, file, options = {}) {
  * @returns {FileChecker} - A FileChecker instance.
  */
 /**
- * @param {{ datetime: import('../datetime').Datetime }} deps
- */
+ * @param {{ datetime: import('../datetime').Datetime, timer: import('../timer').Timer }} deps
+*/
 function make(deps) {
     return {
         fileExists,
         instantiate,
         /** @type {(file: ExistingFile, options?: {minAgeMs?: number, sizeCheckDelayMs?: number}) => Promise<boolean>} */
         isFileStable: (file, options = {}) =>
-            isFileStable(deps.datetime, file, options),
+            isFileStable(deps.datetime, deps.timer, file, options),
     };
 }
 

--- a/backend/src/retryer/core.js
+++ b/backend/src/retryer/core.js
@@ -5,7 +5,6 @@
  * of the same callback while allowing for retry with configurable delays.
  */
 
-const { sleep } = require("../time_duration");
 
 /**
  * Error thrown when retryer operations fail.
@@ -37,6 +36,7 @@ function isRetryerError(object) {
 /**
  * @typedef {object} RetryerCapabilities
  * @property {import('../logger').Logger} logger - Logger for retry operations
+ * @property {import('../timer').Timer} timer - Timer utilities
  */
 
 /**
@@ -163,7 +163,7 @@ async function withRetry(capabilities, callback) {
                     `Callback requested retry after ${result.toString()}`
                 );
                 
-                await sleep(result);
+                await capabilities.timer.wait(result.toMilliseconds());
                 attempt++;
                 
             } catch (error) {

--- a/backend/src/time_duration/utils.js
+++ b/backend/src/time_duration/utils.js
@@ -4,24 +4,24 @@
 
 /**
  * Sleeps for the specified duration.
+ * @param {import('../timer').Timer} timer - Timer capability.
  * @param {import('./structure').TimeDuration} duration - How long to sleep
  * @returns {Promise<void>}
  */
-function sleep(duration) {
-    return new Promise(resolve => {
-        setTimeout(resolve, duration.toMilliseconds());
-    });
+function sleep(timer, duration) {
+    return timer.wait(duration.toMilliseconds());
 }
 
 /**
  * Creates a timeout promise that rejects after the specified duration.
+ * @param {import('../timer').Timer} timer - Timer capability.
  * @param {import('./structure').TimeDuration} duration - How long to wait before timeout
  * @param {string} [message] - Optional timeout message
  * @returns {Promise<never>}
  */
-function timeout(duration, message = "Operation timed out") {
+function timeout(timer, duration, message = "Operation timed out") {
     return new Promise((_, reject) => {
-        setTimeout(() => {
+        timer.setTimeout(() => {
             reject(new Error(message));
         }, duration.toMilliseconds());
     });
@@ -31,14 +31,15 @@ function timeout(duration, message = "Operation timed out") {
  * Races a promise against a timeout.
  * @template T
  * @param {Promise<T>} promise - The promise to race
+ * @param {import('../timer').Timer} timer - Timer capability.
  * @param {import('./structure').TimeDuration} duration - Timeout duration
  * @param {string} [message] - Optional timeout message
  * @returns {Promise<T>}
  */
-function withTimeout(promise, duration, message) {
+function withTimeout(promise, timer, duration, message) {
     return Promise.race([
         promise,
-        timeout(duration, message)
+        timeout(timer, duration, message)
     ]);
 }
 

--- a/backend/src/timer.js
+++ b/backend/src/timer.js
@@ -1,0 +1,44 @@
+/**
+ * Timer capability providing timeout-related functions.
+ * @typedef {object} Timer
+ * @property {(callback: () => void, ms: number) => NodeJS.Timeout} setTimeout - Schedule a callback.
+ * @property {(id: NodeJS.Timeout) => void} clearTimeout - Cancel a scheduled callback.
+ * @property {(ms: number) => Promise<void>} wait - Wait for the specified milliseconds.
+ */
+
+/**
+ * @param {() => void} callback
+ * @param {number} ms
+ * @returns {NodeJS.Timeout}
+ */
+function setTimeoutWrapper(callback, ms) {
+    return setTimeout(callback, ms);
+}
+
+/**
+ * @param {NodeJS.Timeout} id
+ */
+function clearTimeoutWrapper(id) {
+    clearTimeout(id);
+}
+
+/**
+ * @param {number} ms
+ * @returns {Promise<void>}
+ */
+function wait(ms) {
+    return new Promise((resolve) => setTimeoutWrapper(resolve, ms));
+}
+
+/**
+ * @returns {Timer}
+ */
+function make() {
+    return {
+        setTimeout: setTimeoutWrapper,
+        clearTimeout: clearTimeoutWrapper,
+        wait,
+    };
+}
+
+module.exports = { make };

--- a/backend/tests/logger.test.js
+++ b/backend/tests/logger.test.js
@@ -3,6 +3,7 @@ const path = require("path");
 const { make } = require("../src/logger");
 const { getMockedRootCapabilities } = require("./spies");
 const { stubEnvironment, stubDatetime } = require("./stubs");
+const { make: makeTimer } = require("../src/timer");
 
 describe("logger capability", () => {
     it("writes info, warn, error, and debug to file", async () => {
@@ -19,7 +20,7 @@ describe("logger capability", () => {
         logger.logWarning({ bar: 2 }, "warn message");
         logger.logError({ baz: 3 }, "error message");
         logger.logDebug({ qux: 4 }, "debug message");
-        await new Promise((r) => setTimeout(r, 1000));
+        await capabilities.timer.wait(1000);
         const content = fs.readFileSync(logFilePath, "utf8");
         expect(content).toMatch(/info message/);
         expect(content).toMatch(/warn message/);
@@ -35,8 +36,9 @@ describe("logger capability", () => {
         };
         try {
             const logger = make();
+            const timer = makeTimer();
             logger.logError({}, "should fallback");
-            await new Promise((r) => setTimeout(r, 50));
+            await timer.wait(50);
             expect(called).toBe(true);
         } finally {
             console.error = origError;
@@ -54,7 +56,7 @@ describe("logger capability", () => {
         await logger.setup();
         logger.logInfo({}, "info should not appear");
         logger.logError({}, "error should appear");
-        await new Promise((r) => setTimeout(r, 1000));
+        await capabilities.timer.wait(1000);
         const content = fs.readFileSync(logFilePath, "utf8");
         expect(content).not.toMatch(/info should not appear/);
         expect(content).toMatch(/error should appear/);

--- a/backend/tests/memconst.test.js
+++ b/backend/tests/memconst.test.js
@@ -1,4 +1,5 @@
 const memconst = require('../src/memconst');
+const { make: makeTimer } = require('../src/timer');
 
 describe('memconst', () => {
   test('should memoize a synchronous function call', () => {
@@ -104,8 +105,9 @@ describe('memconst', () => {
 
   test('should work with real async functions and delays', async () => {
     // Setup
+    const timer = makeTimer();
     const delayedFn = jest.fn(
-      () => new Promise(resolve => setTimeout(() => resolve('delayed-value'), 100))
+      () => new Promise(resolve => timer.setTimeout(() => resolve('delayed-value'), 100))
     );
     const memoized = memconst(delayedFn);
 

--- a/frontend/src/timer.js
+++ b/frontend/src/timer.js
@@ -1,0 +1,39 @@
+/**
+ * Timer capability for browser environments.
+ * @typedef {object} Timer
+ * @property {(callback: () => void, ms: number) => number} setTimeout - Schedule a callback.
+ * @property {(id: number) => void} clearTimeout - Cancel a scheduled callback.
+ * @property {(ms: number) => Promise<void>} wait - Wait for the specified milliseconds.
+ */
+
+/**
+ * @param {() => void} callback
+ * @param {number} ms
+ * @returns {number}
+ */
+function setTimeoutWrapper(callback, ms) {
+    return window.setTimeout(callback, ms);
+}
+
+/**
+ * @param {number} id
+ */
+function clearTimeoutWrapper(id) {
+    window.clearTimeout(id);
+}
+
+/**
+ * @param {number} ms
+ * @returns {Promise<void>}
+ */
+function wait(ms) {
+    return new Promise((resolve) => setTimeoutWrapper(resolve, ms));
+}
+
+export function make() {
+    return {
+        setTimeout: setTimeoutWrapper,
+        clearTimeout: clearTimeoutWrapper,
+        wait,
+    };
+}

--- a/frontend/tests/Camera.test.jsx
+++ b/frontend/tests/Camera.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { make as makeTimer } from '../src/timer.js';
 
 // Mock Chakra UI useToast
 const mockToast = jest.fn();
@@ -17,6 +18,7 @@ import Camera from '../src/Camera/Camera.jsx';
 
 describe('Camera component', () => {
     let getUserMediaMock;
+    const timer = makeTimer();
 
     beforeAll(() => {
         // Mock navigator.mediaDevices.getUserMedia
@@ -75,7 +77,7 @@ describe('Camera component', () => {
                     objectStore: jest.fn().mockImplementation(() => ({
                         put: jest.fn().mockImplementation((data, key) => {
                             mockStore.set(key, data);
-                            setTimeout(() => {
+                            timer.setTimeout(() => {
                                 if (typeof transaction.oncomplete === 'function') {
                                     transaction.oncomplete();
                                 }
@@ -100,7 +102,7 @@ describe('Camera component', () => {
         };
         const mockOpen = jest.fn().mockImplementation(() => {
             const req = {};
-            setTimeout(() => {
+            timer.setTimeout(() => {
                 if (typeof req.onupgradeneeded === 'function') {
                     req.result = mockDB;
                     req.onupgradeneeded({ target: req });
@@ -195,7 +197,7 @@ describe('Camera component', () => {
         await waitFor(() => screen.getByAltText('Preview'));
         
         // Wait a bit for the blob to be processed
-        await new Promise(resolve => setTimeout(resolve, 100));
+        await timer.wait(100);
         
         fireEvent.click(screen.getByText('Done'));
 

--- a/frontend/tests/photoStorage.integration.test.js
+++ b/frontend/tests/photoStorage.integration.test.js
@@ -4,6 +4,9 @@
  */
 
 import { storePhotos, retrievePhotos } from '../src/DescriptionEntry/photoStorage.js';
+import { make as makeTimer } from '../src/timer.js';
+
+const timer = makeTimer();
 
 // Mock IndexedDB for testing
 const mockIndexedDB = (() => {
@@ -14,7 +17,7 @@ const mockIndexedDB = (() => {
                 objectStore: jest.fn().mockImplementation(() => ({
                     put: jest.fn().mockImplementation((data, key) => {
                         mockStore.set(key, data);
-                        setTimeout(() => {
+                        timer.setTimeout(() => {
                             if (typeof transaction.oncomplete === 'function') {
                                 transaction.oncomplete();
                             }
@@ -24,7 +27,7 @@ const mockIndexedDB = (() => {
                         const request = {
                             result: mockStore.get(key)
                         };
-                        setTimeout(() => {
+                        timer.setTimeout(() => {
                             if (typeof request.onsuccess === 'function') {
                                 request.onsuccess();
                             }
@@ -46,7 +49,7 @@ const mockIndexedDB = (() => {
     return {
         open: jest.fn().mockImplementation(() => {
             const req = {};
-            setTimeout(() => {
+            timer.setTimeout(() => {
                 if (typeof req.onupgradeneeded === 'function') {
                     req.result = mockDB;
                     req.onupgradeneeded({ target: req });

--- a/frontend/tests/photoStorage.test.js
+++ b/frontend/tests/photoStorage.test.js
@@ -3,6 +3,9 @@
  */
 
 import { storePhotos, retrievePhotos, removePhotos, clearAllPhotos } from '../src/DescriptionEntry/photoStorage.js';
+import { make as makeTimer } from '../src/timer.js';
+
+const timer = makeTimer();
 
 // Mock IndexedDB
 const mockIndexedDB = (() => {
@@ -13,7 +16,7 @@ const mockIndexedDB = (() => {
                 objectStore: jest.fn().mockImplementation(() => ({
                     put: jest.fn().mockImplementation((data, key) => {
                         mockStore.set(key, data);
-                        setTimeout(() => {
+                        timer.setTimeout(() => {
                             if (typeof transaction.oncomplete === 'function') {
                                 transaction.oncomplete();
                             }
@@ -23,7 +26,7 @@ const mockIndexedDB = (() => {
                         const request = {
                             result: mockStore.get(key)
                         };
-                        setTimeout(() => {
+                        timer.setTimeout(() => {
                             if (typeof request.onsuccess === 'function') {
                                 request.onsuccess();
                             }
@@ -32,7 +35,7 @@ const mockIndexedDB = (() => {
                     }),
                     delete: jest.fn().mockImplementation((key) => {
                         mockStore.delete(key);
-                        setTimeout(() => {
+                        timer.setTimeout(() => {
                             if (typeof transaction.oncomplete === 'function') {
                                 transaction.oncomplete();
                             }
@@ -40,7 +43,7 @@ const mockIndexedDB = (() => {
                     }),
                     clear: jest.fn().mockImplementation(() => {
                         mockStore.clear();
-                        setTimeout(() => {
+                        timer.setTimeout(() => {
                             if (typeof transaction.oncomplete === 'function') {
                                 transaction.oncomplete();
                             }
@@ -61,7 +64,7 @@ const mockIndexedDB = (() => {
     return {
         open: jest.fn().mockImplementation(() => {
             const req = {};
-            setTimeout(() => {
+            timer.setTimeout(() => {
                 if (typeof req.onupgradeneeded === 'function') {
                     req.result = mockDB;
                     req.onupgradeneeded({ target: req });


### PR DESCRIPTION
## Summary
- create timer capability for scheduling and delays
- use timer capability inside filesystem checker and retryer
- update time duration utilities to accept timer
- replace direct `setTimeout` in tests with timer usage

## Testing
- `npm test`
- `npm run static-analysis`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68707adc5a6c832eb711da071001b69b