### PR TITLE
Abstract Date usage through capability

### DIFF
--- a/backend/src/date_value.js
+++ b/backend/src/date_value.js
@@ -1,0 +1,72 @@
+class DateValueClass {
+    /** @type {Date} */
+    #value;
+
+    /** @type {undefined} */
+    __brand;
+
+    /**
+     * @param {Date} value
+     */
+    constructor(value) {
+        this.#value = value;
+        if (this.__brand !== undefined) {
+            throw new Error('DateValue is a nominal type and should not be instantiated directly');
+        }
+    }
+
+    getFullYear() { return this.#value.getFullYear(); }
+    getMonth() { return this.#value.getMonth(); }
+    getDate() { return this.#value.getDate(); }
+    getTime() { return this.#value.getTime(); }
+    getUTCFullYear() { return this.#value.getUTCFullYear(); }
+    getUTCMonth() { return this.#value.getUTCMonth(); }
+    getUTCDate() { return this.#value.getUTCDate(); }
+    getUTCHours() { return this.#value.getUTCHours(); }
+    getUTCMinutes() { return this.#value.getUTCMinutes(); }
+    getUTCSeconds() { return this.#value.getUTCSeconds(); }
+    toISOString() { return this.#value.toISOString(); }
+    /**
+     * @param {...any} args
+     * @returns {string}
+     */
+    toLocaleDateString(...args) {
+        return this.#value.toLocaleDateString(...args);
+    }
+}
+
+/** @typedef {DateValueClass} DateValue */
+
+/**
+ * @param {number} timestamp
+ * @returns {DateValue}
+ */
+function fromTimestamp(timestamp) {
+    return new DateValueClass(new Date(timestamp));
+}
+
+/**
+ * @param {string} isoString
+ * @returns {DateValue}
+ */
+function fromISOString(isoString) {
+    const d = new Date(isoString);
+    if (isNaN(d.getTime())) {
+        throw new Error(`Invalid date string: ${isoString}`);
+    }
+    return new DateValueClass(d);
+}
+
+/**
+ * @param {unknown} object
+ * @returns {object is DateValue}
+ */
+function isDateValue(object) {
+    return object instanceof DateValueClass;
+}
+
+module.exports = {
+    fromTimestamp,
+    fromISOString,
+    isDateValue,
+};

--- a/backend/src/datetime.js
+++ b/backend/src/datetime.js
@@ -1,7 +1,17 @@
+const dateValue = require("./date_value");
+
 /**
- * Datetime capability for retrieving the current timestamp.
+ * Datetime capability for retrieving the current timestamp and constructing
+ * date objects.
+ *
  * @typedef {object} Datetime
  * @property {() => number} now - Returns the current epoch milliseconds.
+ * @property {(timestamp: number) => dateValue.DateValue} fromTimestamp -
+ *  Creates a date from an epoch timestamp.
+ * @property {(isoString: string) => dateValue.DateValue} fromString -
+ *  Creates a date from an ISO string.
+ * @property {(object: unknown) => object is dateValue.DateValue} isDate -
+ *  Type guard for DateValue.
  */
 
 function now() {
@@ -9,10 +19,31 @@ function now() {
 }
 
 /**
+ * @param {number} timestamp
+ * @returns {dateValue.DateValue}
+ */
+function fromTimestamp(timestamp) {
+    return dateValue.fromTimestamp(timestamp);
+}
+
+/**
+ * @param {string} isoString
+ * @returns {dateValue.DateValue}
+ */
+function fromString(isoString) {
+    return dateValue.fromISOString(isoString);
+}
+
+/**
  * @returns {Datetime}
  */
 function make() {
-    return { now };
+    return {
+        now,
+        fromTimestamp,
+        fromString,
+        isDate: dateValue.isDateValue,
+    };
 }
 
 module.exports = { make };

--- a/backend/src/diary.js
+++ b/backend/src/diary.js
@@ -33,6 +33,7 @@ const creatorMake = require("./creator");
  * @property {Environment} environment - An environment instance.
  * @property {Logger} logger - A logger instance.
  * @property {import('./filesystem/reader').FileReader} reader - A file reader instance.
+ * @property {import('./datetime').Datetime} datetime - Datetime utilities.
  */
 
 /**
@@ -95,7 +96,10 @@ async function processDiaryAudios(capabilities) {
     function makeAsset(file) {
         const filepath = file.path;
         const filename = path.basename(filepath);
-        const date = formatFileTimestamp(filename);
+        const date = formatFileTimestamp(
+            { datetime: capabilities.datetime },
+            filename
+        );
         const id = eventId.make(capabilities);
 
         /** @type {import('./event/structure').Event} */

--- a/backend/src/entry.js
+++ b/backend/src/entry.js
@@ -84,7 +84,9 @@ function isEntryValidationError(object) {
 async function createEntry(capabilities, entryData, files = []) {
     const creator = await creatorMake(capabilities);
     const id = eventId.make(capabilities);
-    const date = new Date(capabilities.datetime.now());
+    const date = capabilities.datetime.fromTimestamp(
+        capabilities.datetime.now()
+    );
 
     /** @type {import('./event/structure').Event} */
     const event = {
@@ -160,8 +162,8 @@ async function getEntries(capabilities, pagination) {
 
     // Sort entries by date
     const sortedEntries = [...entries].sort((a, b) => {
-        const dateA = new Date(a.date).getTime();
-        const dateB = new Date(b.date).getTime();
+        const dateA = a.date.getTime();
+        const dateB = b.date.getTime();
         return order === 'dateAscending' ? dateA - dateB : dateB - dateA;
     });
 

--- a/backend/src/event/date.js
+++ b/backend/src/event/date.js
@@ -5,15 +5,17 @@ const timezone = require("dayjs/plugin/timezone");
 dayjs.extend(utc);
 dayjs.extend(timezone);
 
+/** @typedef {import('../date_value').DateValue} DateValue */
+
 /**
  * Formats a date to the local timezone.
- * @param {Date} date - The date to format.
+ * @param {DateValue} date - The date to format.
  * @returns {string} - The formatted date string in the format YYYY-MM-DDTHH:mm:ssZZ.
  */
 function format(date) {
     // Format: YYYY-MM-DDTHH:mm:ssZZ (local timezone, e.g. 2025-05-22T15:30:00+0200)
     const tzName = Intl.DateTimeFormat().resolvedOptions().timeZone;
-    return dayjs(date).tz(tzName).format("YYYY-MM-DDTHH:mm:ssZZ");
+    return dayjs(date.toISOString()).tz(tzName).format("YYYY-MM-DDTHH:mm:ssZZ");
 }
 
 module.exports = {

--- a/backend/src/event/serialization.js
+++ b/backend/src/event/serialization.js
@@ -27,7 +27,7 @@ const {
  * @typedef Event
  * @type {Object}
  * @property {import('./id').EventId} id - Unique identifier for the event.
- * @property {Date} date - The date of the event.
+ * @property {import('../date_value').DateValue} date - The date of the event.
  * @property {string} original - The original input of the event.
  * @property {string} input - The processed input of the event.
  * @property {Modifiers} modifiers - Modifiers applied to the event.
@@ -60,14 +60,15 @@ function serialize(event) {
 }
 
 /**
+ * @param {{ datetime: import('../datetime').Datetime }} capabilities
  * @param {SerializedEvent} serializedEvent - The serialized event object from JSON.
  * @returns {Event} - The deserialized event object.
  */
-function deserialize(serializedEvent) {
+function deserialize(capabilities, serializedEvent) {
     return {
         ...serializedEvent,
         id: eventId.fromString(serializedEvent.id),
-        date: new Date(serializedEvent.date),
+        date: capabilities.datetime.fromString(serializedEvent.date),
         modifiers: serializedEvent.modifiers || {},
     };
 }
@@ -79,7 +80,12 @@ function deserialize(serializedEvent) {
  * @param {unknown} obj - The object to attempt to deserialize
  * @returns {Event | TryDeserializeError} - The deserialized Event or error object
  */
-function tryDeserialize(obj) {
+/**
+ * @param {{ datetime: import('../datetime').Datetime }} capabilities
+ * @param {unknown} obj - The object to attempt to deserialize
+ * @returns {Event | TryDeserializeError}
+ */
+function tryDeserialize(capabilities, obj) {
     try {
         if (!obj || typeof obj !== "object" || Array.isArray(obj)) {
             return makeInvalidStructureError(
@@ -145,7 +151,7 @@ function tryDeserialize(obj) {
             modifiers[key] = value;
         }
 
-        const dateObj = new Date(date);
+        const dateObj = capabilities.datetime.fromString(date);
         if (isNaN(dateObj.getTime())) {
             return makeInvalidValueError("date", date, "not a valid date string");
         }

--- a/backend/src/event/structure.js
+++ b/backend/src/event/structure.js
@@ -19,7 +19,7 @@ const {
  * @typedef Event
  * @type {Object}
  * @property {import('./id').EventId} id - Unique identifier for the event.
- * @property {Date} date - The date of the event.
+ * @property {import('../date_value').DateValue} date - The date of the event.
  * @property {string} original - The original input of the event.
  * @property {string} input - The processed input of the event.
  * @property {Modifiers} modifiers - Modifiers applied to the event.

--- a/backend/src/event_log_storage/class.js
+++ b/backend/src/event_log_storage/class.js
@@ -245,7 +245,10 @@ class EventLogStorageClass {
             const validEvents = [];
 
             for (const obj of objects) {
-                const result = event.tryDeserialize(obj);
+                const result = event.tryDeserialize(
+                    { datetime: this.capabilities.datetime },
+                    obj
+                );
                 if (event.isTryDeserializeError(result)) {
                     this.capabilities.logger.logWarning(
                         {

--- a/backend/src/event_log_storage/types.js
+++ b/backend/src/event_log_storage/types.js
@@ -25,6 +25,7 @@
  * @property {Environment} environment - An environment instance.
  * @property {Logger} logger - A logger instance.
  * @property {import('../filesystem/reader').FileReader} reader - A file reader instance.
+ * @property {import('../datetime').Datetime} datetime - Datetime utilities.
  */
 
 /**
@@ -47,6 +48,7 @@
  * @property {FileDeleter} deleter - A file deleter instance
  * @property {Environment} environment - An environment instance (for targetPath)
  * @property {Logger} logger - A logger instance
+ * @property {import('../datetime').Datetime} datetime - Datetime utilities
  */
 
 /**
@@ -69,6 +71,7 @@
  * @property {Command} git - A Git command instance
  * @property {Environment} environment - An environment instance
  * @property {Logger} logger - A logger instance
+ * @property {import('../datetime').Datetime} datetime - Datetime utilities
  */
 
 module.exports = {};

--- a/backend/src/format_time_stamp.js
+++ b/backend/src/format_time_stamp.js
@@ -24,10 +24,17 @@ function isFilenameDoesNotEncodeDate(object) {
 }
 
 /**
- * @param {string} filename
- * @returns {Date}
+/**
+ * @typedef {import('./date_value').DateValue} DateValue
+ * @typedef {import('./datetime').Datetime} Datetime
  */
-function formatFileTimestamp(filename) {
+
+/**
+ * @param {{ datetime: Datetime }} capabilities
+ * @param {string} filename
+ * @returns {DateValue}
+ */
+function formatFileTimestamp(capabilities, filename) {
     // 1) extract the basic‐ISO timestamp (YYYYMMDDThhmmssZ)
     const m = filename.match(/^(\d{8}T\d{6}Z)[.].*/);
     if (!m)
@@ -40,8 +47,8 @@ function formatFileTimestamp(filename) {
 
     const basic = m[1];
 
-    // 2) get Date object from basic timestamp
-    const dateObject = format_time_stamp(basic);
+    // 2) get DateValue from basic timestamp
+    const dateObject = format_time_stamp(capabilities, basic);
 
     if (dateObject === undefined) {
         // This should ideally not be hit if 'basic' is from the regex match above
@@ -55,10 +62,11 @@ function formatFileTimestamp(filename) {
 }
 
 /**
+ * @param {{ datetime: Datetime }} capabilities
  * @param {string | undefined} basic - String in YYYYMMDDThhmmssZ format
- * @returns {Date | undefined}
+ * @returns {DateValue | undefined}
  */
-function format_time_stamp(basic) {
+function format_time_stamp(capabilities, basic) {
     if (basic === undefined) {
         return undefined;
     }
@@ -75,7 +83,7 @@ function format_time_stamp(basic) {
     }
 
     const match = isoUTC.match(/(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})Z/);
-    const d = new Date(isoUTC);
+    const d = capabilities.datetime.fromString(isoUTC);
     if (
         !match ||
         isNaN(d.getTime()) ||

--- a/backend/tests/diary.test.js
+++ b/backend/tests/diary.test.js
@@ -74,7 +74,10 @@ describe("processDiaryAudios", () => {
             const objects = await readObjects(capabilities, dataFile);
             expect(objects).toHaveLength(filenames.length);
             objects.forEach((obj, i) => {
-                const date = formatFileTimestamp(filenames[i]);
+                const date = formatFileTimestamp(
+                    { datetime: capabilities.datetime },
+                    filenames[i]
+                );
                 expect(obj).toEqual({
                     id: obj.id,
                     date: dateFormatter.format(date),
@@ -91,7 +94,10 @@ describe("processDiaryAudios", () => {
         // Assets copied into correct structure
         const assetsBase = capabilities.environment.eventLogAssetsDirectory();
         for (const name of filenames) {
-            const date = formatFileTimestamp(name);
+            const date = formatFileTimestamp(
+                { datetime: capabilities.datetime },
+                name
+            );
             const year = date.getFullYear();
             const month = String(date.getMonth() + 1).padStart(2, "0");
             const day = String(date.getDate()).padStart(2, "0");

--- a/backend/tests/entry.create.test.js
+++ b/backend/tests/entry.create.test.js
@@ -31,7 +31,7 @@ describe("createEntry (integration, with real capabilities)", () => {
         expect(event.type).toBe(entryData.type);
         expect(event.description).toBe(entryData.description);
         expect(event.modifiers).toEqual(entryData.modifiers);
-        expect(event.date).toEqual(new Date(fixedTime));
+        expect(event.date.getTime()).toBe(fixedTime);
         expect(event.id).toBeDefined();
         expect(event.creator).toBeDefined();
         expect(capabilities.logger.logInfo).toHaveBeenCalledWith(

--- a/backend/tests/event_structure.test.js
+++ b/backend/tests/event_structure.test.js
@@ -12,7 +12,7 @@ describe('event.tryDeserialize', () => {
       creator: { name: 'n', uuid: 'u', version: 'v' },
       modifiers: 0
     };
-    const result = event.tryDeserialize(obj);
+    const result = event.tryDeserialize({ datetime: require('../src/datetime').make() }, obj);
     expect(event.isInvalidTypeError(result)).toBe(true);
     expect(result.message).toContain("Invalid type for field 'modifiers'");
     expect(result.field).toBe('modifiers');

--- a/backend/tests/format_time_stamp.test.js
+++ b/backend/tests/format_time_stamp.test.js
@@ -1,28 +1,35 @@
 const { formatFileTimestamp } = require('../src/format_time_stamp');
+const datetime = require('../src/datetime');
 
 describe('formatFileTimestamp', () => {
   it('returns a Date object for valid filename', () => {
     const filename = '20250503T203813Z.txt';
-    const date = formatFileTimestamp(filename);
-    expect(date).toBeInstanceOf(Date);
+    const dt = datetime.make();
+    const date = formatFileTimestamp({ datetime: dt }, filename);
+    expect(dt.isDate(date)).toBe(true);
     expect(date.toISOString()).toBe('2025-05-03T20:38:13.000Z');
   });
 
   it('handles midnight UTC correctly', () => {
     const filename = '20200101T000000Z.txt';
-    const date = formatFileTimestamp(filename);
+    const date = formatFileTimestamp({ datetime: datetime.make() }, filename);
     expect(date.toISOString()).toBe('2020-01-01T00:00:00.000Z');
   });
 
   it('throws an error for filename without valid prefix', async () => {
-    await expect(async () => formatFileTimestamp('invalidfile.txt')).rejects.toThrow(
+    await expect(async () =>
+      formatFileTimestamp({ datetime: datetime.make() }, 'invalidfile.txt')
+    ).rejects.toThrow(
       'Filename "invalidfile.txt" does not start with YYYYMMDDThhmmssZ'
     );
   });
 
   it('throws an error for invalid calendar date', async () => {
     await expect(async () =>
-      formatFileTimestamp('20250230T000000Z.txt')
+      formatFileTimestamp(
+        { datetime: datetime.make() },
+        '20250230T000000Z.txt'
+      )
     ).rejects.toThrow('Failed to parse valid Date from timestamp string: 20250230T000000Z');
   });
 });

--- a/backend/tests/stubs.js
+++ b/backend/tests/stubs.js
@@ -97,7 +97,11 @@ function stubScheduler(capabilities) {
 }
 
 function stubDatetime(capabilities) {
+    const real = require("../src/date_value");
     capabilities.datetime.now = jest.fn(() => Date.now());
+    capabilities.datetime.fromTimestamp = real.fromTimestamp;
+    capabilities.datetime.fromString = real.fromISOString;
+    capabilities.datetime.isDate = real.isDateValue;
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary
- add `date_value` nominal class to encapsulate JS Date
- extend `datetime` capability with helpers for `DateValue`
- refactor modules to construct dates via capability
- adapt diary utilities and event deserialization to new API
- update tests and stubs for `DateValue`

## Testing
- `npm test`
- `npm run static-analysis`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6870880936c0832ea4dbb38fe2f37914