### PR TITLE
Abstract Date with DateTime capability

### DIFF
--- a/backend/src/datetime.js
+++ b/backend/src/datetime.js
@@ -1,18 +1,109 @@
 /**
- * Datetime capability for retrieving the current timestamp.
+ * Datetime capability for working with dates.
  * @typedef {object} Datetime
- * @property {() => number} now - Returns the current epoch milliseconds.
+ * @property {() => DateTime} now - Returns the current datetime.
+ * @property {(ms: number) => DateTime} fromEpochMs - Creates a DateTime from milliseconds.
+ * @property {(iso: string) => DateTime} fromISOString - Creates a DateTime from ISO string.
+ * @property {(dt: DateTime) => number} toEpochMs - Converts DateTime to epoch milliseconds.
+ * @property {(dt: DateTime) => string} toISOString - Converts DateTime to ISO string.
+ * @property {(dt: DateTime) => Date} toNativeDate - Converts DateTime to native Date.
  */
 
+class DateTime {
+    /** @type {undefined} */
+    __brand = undefined;
+
+    /**
+     * @param {Date} date
+     */
+    constructor(date) {
+        this._date = date;
+        if (this.__brand !== undefined) {
+            throw new Error("DateTime is nominal");
+        }
+    }
+
+    /**
+     * @returns {number}
+     */
+    getTime() {
+        return this._date.getTime();
+    }
+
+    /**
+     * @returns {string}
+     */
+    toISOString() {
+        return this._date.toISOString();
+    }
+
+    /**
+     * @returns {Date}
+     */
+    toDate() {
+        return new Date(this._date.getTime());
+    }
+}
+
 function now() {
-    return Date.now();
+    return new DateTime(new Date());
+}
+
+/**
+ * @param {number} ms
+ * @returns {DateTime}
+ */
+function fromEpochMs(ms) {
+    return new DateTime(new Date(ms));
+}
+
+/**
+ * @param {string} iso
+ * @returns {DateTime}
+ */
+function fromISOString(iso) {
+    return new DateTime(new Date(iso));
+}
+
+/**
+ * @param {DateTime} dt
+ * @returns {number}
+ */
+function toEpochMs(dt) {
+    return dt.getTime();
+}
+
+/**
+ * @param {DateTime} dt
+ * @returns {string}
+ */
+function toISOString(dt) {
+    return dt.toISOString();
+}
+
+/**
+ * @param {DateTime} dt
+ * @returns {Date}
+ */
+function toNativeDate(dt) {
+    return dt.toDate();
 }
 
 /**
  * @returns {Datetime}
  */
 function make() {
-    return { now };
+    return {
+        now,
+        fromEpochMs,
+        fromISOString,
+        toEpochMs,
+        toISOString,
+        toNativeDate,
+    };
 }
 
-module.exports = { make };
+module.exports = {
+    make,
+    DateTime,
+};

--- a/backend/src/diary.js
+++ b/backend/src/diary.js
@@ -33,6 +33,7 @@ const creatorMake = require("./creator");
  * @property {Environment} environment - An environment instance.
  * @property {Logger} logger - A logger instance.
  * @property {import('./filesystem/reader').FileReader} reader - A file reader instance.
+ * @property {import('./datetime').Datetime} datetime - Datetime utilities.
  */
 
 /**
@@ -95,7 +96,7 @@ async function processDiaryAudios(capabilities) {
     function makeAsset(file) {
         const filepath = file.path;
         const filename = path.basename(filepath);
-        const date = formatFileTimestamp(filename);
+        const date = formatFileTimestamp(filename, capabilities.datetime);
         const id = eventId.make(capabilities);
 
         /** @type {import('./event/structure').Event} */

--- a/backend/src/entry.js
+++ b/backend/src/entry.js
@@ -84,7 +84,7 @@ function isEntryValidationError(object) {
 async function createEntry(capabilities, entryData, files = []) {
     const creator = await creatorMake(capabilities);
     const id = eventId.make(capabilities);
-    const date = new Date(capabilities.datetime.now());
+    const date = capabilities.datetime.now();
 
     /** @type {import('./event/structure').Event} */
     const event = {
@@ -160,8 +160,8 @@ async function getEntries(capabilities, pagination) {
 
     // Sort entries by date
     const sortedEntries = [...entries].sort((a, b) => {
-        const dateA = new Date(a.date).getTime();
-        const dateB = new Date(b.date).getTime();
+        const dateA = capabilities.datetime.toEpochMs(a.date);
+        const dateB = capabilities.datetime.toEpochMs(b.date);
         return order === 'dateAscending' ? dateA - dateB : dateB - dateA;
     });
 

--- a/backend/src/event/asset.js
+++ b/backend/src/event/asset.js
@@ -8,6 +8,7 @@ const path = require("path");
 /**
  * @typedef {object} Capabilities
  * @property {Environment} environment - An environment instance.
+ * @property {import('../datetime').Datetime} datetime - Datetime utilities.
  */
 
 class AssetClass {
@@ -58,7 +59,7 @@ function make(event, file) {
  */
 function targetPath(capabilities, asset) {
     const baseDir = capabilities.environment.eventLogAssetsDirectory();
-    const date = asset.event.date;
+    const date = capabilities.datetime.toNativeDate(asset.event.date);
     const year = date.getFullYear();
     const month = String(date.getMonth() + 1).padStart(2, "0");
     const day = String(date.getDate()).padStart(2, "0");

--- a/backend/src/event/date.js
+++ b/backend/src/event/date.js
@@ -5,15 +5,18 @@ const timezone = require("dayjs/plugin/timezone");
 dayjs.extend(utc);
 dayjs.extend(timezone);
 
+const datetime = require("../datetime");
+
 /**
  * Formats a date to the local timezone.
- * @param {Date} date - The date to format.
+ * @param {import('../datetime').DateTime} date - The date to format.
  * @returns {string} - The formatted date string in the format YYYY-MM-DDTHH:mm:ssZZ.
  */
 function format(date) {
     // Format: YYYY-MM-DDTHH:mm:ssZZ (local timezone, e.g. 2025-05-22T15:30:00+0200)
     const tzName = Intl.DateTimeFormat().resolvedOptions().timeZone;
-    return dayjs(date).tz(tzName).format("YYYY-MM-DDTHH:mm:ssZZ");
+    const native = datetime.make().toNativeDate(date);
+    return dayjs(native).tz(tzName).format("YYYY-MM-DDTHH:mm:ssZZ");
 }
 
 module.exports = {

--- a/backend/src/event/serialization.js
+++ b/backend/src/event/serialization.js
@@ -1,5 +1,6 @@
 const { format } = require("./date");
 const eventId = require("./id");
+const datetime = require("../datetime");
 const {
     makeMissingFieldError,
     makeInvalidTypeError,
@@ -27,7 +28,7 @@ const {
  * @typedef Event
  * @type {Object}
  * @property {import('./id').EventId} id - Unique identifier for the event.
- * @property {Date} date - The date of the event.
+ * @property {import('../datetime').DateTime} date - The date of the event.
  * @property {string} original - The original input of the event.
  * @property {string} input - The processed input of the event.
  * @property {Modifiers} modifiers - Modifiers applied to the event.
@@ -67,7 +68,7 @@ function deserialize(serializedEvent) {
     return {
         ...serializedEvent,
         id: eventId.fromString(serializedEvent.id),
-        date: new Date(serializedEvent.date),
+        date: datetime.make().fromISOString(serializedEvent.date),
         modifiers: serializedEvent.modifiers || {},
     };
 }
@@ -145,8 +146,9 @@ function tryDeserialize(obj) {
             modifiers[key] = value;
         }
 
-        const dateObj = new Date(date);
-        if (isNaN(dateObj.getTime())) {
+        const dtCap = datetime.make();
+        const dateObj = dtCap.fromISOString(date);
+        if (isNaN(dtCap.toEpochMs(dateObj))) {
             return makeInvalidValueError("date", date, "not a valid date string");
         }
 

--- a/backend/src/event/structure.js
+++ b/backend/src/event/structure.js
@@ -19,7 +19,7 @@ const {
  * @typedef Event
  * @type {Object}
  * @property {import('./id').EventId} id - Unique identifier for the event.
- * @property {Date} date - The date of the event.
+ * @property {import('../datetime').DateTime} date - The date of the event.
  * @property {string} original - The original input of the event.
  * @property {string} input - The processed input of the event.
  * @property {Modifiers} modifiers - Modifiers applied to the event.

--- a/backend/src/event_log_storage/types.js
+++ b/backend/src/event_log_storage/types.js
@@ -39,6 +39,7 @@
  * @property {FileCreator} creator - A file creator instance
  * @property {FileCopier} copier - A file copier instance
  * @property {Environment} environment - An environment instance (for targetPath)
+ * @property {import('../datetime').Datetime} datetime - Datetime utilities
  */
 
 /**
@@ -47,6 +48,7 @@
  * @property {FileDeleter} deleter - A file deleter instance
  * @property {Environment} environment - An environment instance (for targetPath)
  * @property {Logger} logger - A logger instance
+ * @property {import('../datetime').Datetime} datetime - Datetime utilities
  */
 
 /**
@@ -54,6 +56,7 @@
  * @typedef {object} ReadEntriesCapabilities
  * @property {import('../filesystem/reader').FileReader} reader - A file reader instance
  * @property {Logger} logger - A logger instance
+ * @property {import('../datetime').Datetime} datetime - Datetime utilities
  */
 
 /**
@@ -69,6 +72,7 @@
  * @property {Command} git - A Git command instance
  * @property {Environment} environment - An environment instance
  * @property {Logger} logger - A logger instance
+ * @property {import('../datetime').Datetime} datetime - Datetime utilities
  */
 
 module.exports = {};

--- a/backend/src/filesystem/checker.js
+++ b/backend/src/filesystem/checker.js
@@ -143,7 +143,7 @@ async function isFileStable(datetime, file, options = {}) {
     try {
         // First check: get initial file stats
         const initialStats = await fs.stat(file.path);
-        const now = datetime.now();
+        const now = datetime.toEpochMs(datetime.now());
         const fileModifiedTime = initialStats.mtime.getTime();
         const ageMs = now - fileModifiedTime;
 

--- a/backend/src/format_time_stamp.js
+++ b/backend/src/format_time_stamp.js
@@ -4,6 +4,8 @@
  * in the format YYYYMMDDThhmmssZ followed by a dot and an extension.
  */
 
+const datetime = require("./datetime");
+
 class FilenameDoesNotEncodeDate extends Error {
     /**
      * @param {string} message
@@ -25,9 +27,10 @@ function isFilenameDoesNotEncodeDate(object) {
 
 /**
  * @param {string} filename
- * @returns {Date}
- */
-function formatFileTimestamp(filename) {
+ * @param {import('./datetime').Datetime} [dt]
+ * @returns {import('./datetime').DateTime}
+*/
+function formatFileTimestamp(filename, dt = datetime.make()) {
     // 1) extract the basic‐ISO timestamp (YYYYMMDDThhmmssZ)
     const m = filename.match(/^(\d{8}T\d{6}Z)[.].*/);
     if (!m)
@@ -41,7 +44,7 @@ function formatFileTimestamp(filename) {
     const basic = m[1];
 
     // 2) get Date object from basic timestamp
-    const dateObject = format_time_stamp(basic);
+    const dateObject = format_time_stamp(basic, dt);
 
     if (dateObject === undefined) {
         // This should ideally not be hit if 'basic' is from the regex match above
@@ -56,9 +59,10 @@ function formatFileTimestamp(filename) {
 
 /**
  * @param {string | undefined} basic - String in YYYYMMDDThhmmssZ format
- * @returns {Date | undefined}
- */
-function format_time_stamp(basic) {
+ * @param {import('./datetime').Datetime} dt
+ * @returns {import('./datetime').DateTime | undefined}
+*/
+function format_time_stamp(basic, dt) {
     if (basic === undefined) {
         return undefined;
     }
@@ -75,16 +79,16 @@ function format_time_stamp(basic) {
     }
 
     const match = isoUTC.match(/(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})Z/);
-    const d = new Date(isoUTC);
+    const d = dt.fromISOString(isoUTC);
     if (
         !match ||
-        isNaN(d.getTime()) ||
-        d.getUTCFullYear() !== Number(match[1]) ||
-        d.getUTCMonth() + 1 !== Number(match[2]) ||
-        d.getUTCDate() !== Number(match[3]) ||
-        d.getUTCHours() !== Number(match[4]) ||
-        d.getUTCMinutes() !== Number(match[5]) ||
-        d.getUTCSeconds() !== Number(match[6])
+        isNaN(dt.toEpochMs(d)) ||
+        dt.toNativeDate(d).getUTCFullYear() !== Number(match[1]) ||
+        dt.toNativeDate(d).getUTCMonth() + 1 !== Number(match[2]) ||
+        dt.toNativeDate(d).getUTCDate() !== Number(match[3]) ||
+        dt.toNativeDate(d).getUTCHours() !== Number(match[4]) ||
+        dt.toNativeDate(d).getUTCMinutes() !== Number(match[5]) ||
+        dt.toNativeDate(d).getUTCSeconds() !== Number(match[6])
     ) {
         return undefined;
     }

--- a/backend/tests/api_ordering_basic.test.js
+++ b/backend/tests/api_ordering_basic.test.js
@@ -29,7 +29,7 @@ describe("API Ordering Integration Tests", () => {
             const { app, capabilities } = await makeTestApp();
 
             // Create entries with different dates by controlling datetime.now()
-            const baseTime = new Date("2023-01-01T10:00:00Z").getTime();
+            const baseTime = capabilities.datetime.fromISOString("2023-01-01T10:00:00Z").getTime();
             const entries = [
                 { rawInput: "test - Oldest entry" },
                 { rawInput: "test - Newest entry" },
@@ -37,19 +37,25 @@ describe("API Ordering Integration Tests", () => {
             ];
 
             // Mock datetime to return different times for each entry
-            capabilities.datetime.now.mockReturnValueOnce(baseTime); // Oldest
+            capabilities.datetime.now.mockReturnValueOnce(
+                capabilities.datetime.fromEpochMs(baseTime)
+            ); // Oldest
             await request(app)
                 .post("/api/entries")
                 .send(entries[0])
                 .set("Content-Type", "application/json");
 
-            capabilities.datetime.now.mockReturnValueOnce(baseTime + 2 * 24 * 60 * 60 * 1000); // Newest
+            capabilities.datetime.now.mockReturnValueOnce(
+                capabilities.datetime.fromEpochMs(baseTime + 2 * 24 * 60 * 60 * 1000)
+            ); // Newest
             await request(app)
                 .post("/api/entries")
                 .send(entries[1])
                 .set("Content-Type", "application/json");
 
-            capabilities.datetime.now.mockReturnValueOnce(baseTime + 24 * 60 * 60 * 1000); // Middle
+            capabilities.datetime.now.mockReturnValueOnce(
+                capabilities.datetime.fromEpochMs(baseTime + 24 * 60 * 60 * 1000)
+            ); // Middle
             await request(app)
                 .post("/api/entries")
                 .send(entries[2])
@@ -61,7 +67,7 @@ describe("API Ordering Integration Tests", () => {
             expect(res.body.results).toHaveLength(3);
 
             // Verify the order is descending (newest first)
-            const dates = res.body.results.map(entry => new Date(entry.date));
+            const dates = res.body.results.map(entry => capabilities.datetime.fromISOString(entry.date));
             for (let i = 1; i < dates.length; i++) {
                 expect(dates[i - 1].getTime()).toBeGreaterThanOrEqual(dates[i].getTime());
             }
@@ -73,19 +79,23 @@ describe("API Ordering Integration Tests", () => {
             const { app, capabilities } = await makeTestApp();
 
             // Create entries with different dates by controlling datetime.now()
-            const baseTime = new Date("2023-01-01T10:00:00Z").getTime();
+            const baseTime = capabilities.datetime.fromISOString("2023-01-01T10:00:00Z").getTime();
             const entries = [
                 { rawInput: "test - First" },
                 { rawInput: "test - Second" },
             ];
 
-            capabilities.datetime.now.mockReturnValueOnce(baseTime);
+            capabilities.datetime.now.mockReturnValueOnce(
+                capabilities.datetime.fromEpochMs(baseTime)
+            );
             await request(app)
                 .post("/api/entries")
                 .send(entries[0])
                 .set("Content-Type", "application/json");
 
-            capabilities.datetime.now.mockReturnValueOnce(baseTime + 24 * 60 * 60 * 1000);
+            capabilities.datetime.now.mockReturnValueOnce(
+                capabilities.datetime.fromEpochMs(baseTime + 24 * 60 * 60 * 1000)
+            );
             await request(app)
                 .post("/api/entries")
                 .send(entries[1])
@@ -97,8 +107,8 @@ describe("API Ordering Integration Tests", () => {
 
             // Verify entries are in descending order
             for (let i = 1; i < res.body.results.length; i++) {
-                const currentDate = new Date(res.body.results[i].date);
-                const previousDate = new Date(res.body.results[i - 1].date);
+                const currentDate = capabilities.datetime.fromISOString(res.body.results[i].date);
+                const previousDate = capabilities.datetime.fromISOString(res.body.results[i - 1].date);
                 expect(previousDate.getTime()).toBeGreaterThanOrEqual(currentDate.getTime());
             }
         });
@@ -107,19 +117,23 @@ describe("API Ordering Integration Tests", () => {
             const { app, capabilities } = await makeTestApp();
 
             // Create entries with different dates by controlling datetime.now()
-            const baseTime = new Date("2023-01-01T10:00:00Z").getTime();
+            const baseTime = capabilities.datetime.fromISOString("2023-01-01T10:00:00Z").getTime();
             const entries = [
                 { rawInput: "test - Second" },
                 { rawInput: "test - First" },
             ];
 
-            capabilities.datetime.now.mockReturnValueOnce(baseTime + 24 * 60 * 60 * 1000); // Second (newer)
+            capabilities.datetime.now.mockReturnValueOnce(
+                capabilities.datetime.fromEpochMs(baseTime + 24 * 60 * 60 * 1000)
+            ); // Second (newer)
             await request(app)
                 .post("/api/entries")
                 .send(entries[0])
                 .set("Content-Type", "application/json");
 
-            capabilities.datetime.now.mockReturnValueOnce(baseTime); // First (older)
+            capabilities.datetime.now.mockReturnValueOnce(
+                capabilities.datetime.fromEpochMs(baseTime)
+            ); // First (older)
             await request(app)
                 .post("/api/entries")
                 .send(entries[1])
@@ -131,14 +145,14 @@ describe("API Ordering Integration Tests", () => {
 
             // Verify entries are in ascending order
             for (let i = 1; i < res.body.results.length; i++) {
-                const currentDate = new Date(res.body.results[i].date);
-                const previousDate = new Date(res.body.results[i - 1].date);
+                const currentDate = capabilities.datetime.fromISOString(res.body.results[i].date);
+                const previousDate = capabilities.datetime.fromISOString(res.body.results[i - 1].date);
                 expect(currentDate.getTime()).toBeGreaterThanOrEqual(previousDate.getTime());
             }
         });
 
         it("defaults to dateDescending for invalid order parameter", async () => {
-            const { app } = await makeTestApp();
+            const { app, capabilities } = await makeTestApp();
 
             // Create a test entry
             const requestBody = {
@@ -158,7 +172,7 @@ describe("API Ordering Integration Tests", () => {
             expect(res.body.results.length).toBeGreaterThan(0);
 
             // Extract all dates and verify they are in descending order
-            const dates = res.body.results.map(entry => new Date(entry.date));
+            const dates = res.body.results.map(entry => capabilities.datetime.fromISOString(entry.date));
             for (let i = 1; i < dates.length; i++) {
                 expect(dates[i - 1].getTime()).toBeGreaterThanOrEqual(dates[i].getTime());
             }

--- a/backend/tests/diary.test.js
+++ b/backend/tests/diary.test.js
@@ -74,7 +74,7 @@ describe("processDiaryAudios", () => {
             const objects = await readObjects(capabilities, dataFile);
             expect(objects).toHaveLength(filenames.length);
             objects.forEach((obj, i) => {
-                const date = formatFileTimestamp(filenames[i]);
+                const date = formatFileTimestamp(filenames[i], capabilities.datetime);
                 expect(obj).toEqual({
                     id: obj.id,
                     date: dateFormatter.format(date),
@@ -91,10 +91,11 @@ describe("processDiaryAudios", () => {
         // Assets copied into correct structure
         const assetsBase = capabilities.environment.eventLogAssetsDirectory();
         for (const name of filenames) {
-            const date = formatFileTimestamp(name);
-            const year = date.getFullYear();
-            const month = String(date.getMonth() + 1).padStart(2, "0");
-            const day = String(date.getDate()).padStart(2, "0");
+            const date = formatFileTimestamp(name, capabilities.datetime);
+            const native = capabilities.datetime.toNativeDate(date);
+            const year = native.getFullYear();
+            const month = String(native.getMonth() + 1).padStart(2, "0");
+            const day = String(native.getDate()).padStart(2, "0");
             // Expect one id directory under the date folder
             const idDirs = await fs.readdir(
                 path.join(assetsBase, `${year}-${month}`, day)

--- a/backend/tests/entries_get.test.js
+++ b/backend/tests/entries_get.test.js
@@ -165,7 +165,7 @@ describe("GET /api/entries with ordering", () => {
         const { app, capabilities } = await makeTestApp();
 
         // Create entries with different dates by controlling datetime.now()
-        const baseTime = new Date("2023-01-01T10:00:00Z").getTime();
+        const baseTime = capabilities.datetime.fromISOString("2023-01-01T10:00:00Z").getTime();
         const entries = [
             { rawInput: "type1 - Description 1" },
             { rawInput: "type2 - Description 3" },
@@ -173,19 +173,25 @@ describe("GET /api/entries with ordering", () => {
         ];
 
         // Mock datetime to return different times for each entry
-        capabilities.datetime.now.mockReturnValueOnce(baseTime); // Oldest
+        capabilities.datetime.now.mockReturnValueOnce(
+            capabilities.datetime.fromEpochMs(baseTime)
+        ); // Oldest
         await request(app)
             .post("/api/entries")
             .send(entries[0])
             .set("Content-Type", "application/json");
 
-        capabilities.datetime.now.mockReturnValueOnce(baseTime + 2 * 24 * 60 * 60 * 1000); // Newest
+        capabilities.datetime.now.mockReturnValueOnce(
+            capabilities.datetime.fromEpochMs(baseTime + 2 * 24 * 60 * 60 * 1000)
+        ); // Newest
         await request(app)
             .post("/api/entries")
             .send(entries[1])
             .set("Content-Type", "application/json");
 
-        capabilities.datetime.now.mockReturnValueOnce(baseTime + 24 * 60 * 60 * 1000); // Middle
+        capabilities.datetime.now.mockReturnValueOnce(
+            capabilities.datetime.fromEpochMs(baseTime + 24 * 60 * 60 * 1000)
+        ); // Middle
         await request(app)
             .post("/api/entries")
             .send(entries[2])
@@ -196,7 +202,7 @@ describe("GET /api/entries with ordering", () => {
         expect(res.statusCode).toBe(200);
         expect(res.body.results).toHaveLength(3);
         // Should be in descending date order (newest first)
-        const dates = res.body.results.map(entry => new Date(entry.date));
+        const dates = res.body.results.map(entry => capabilities.datetime.fromISOString(entry.date));
         for (let i = 1; i < dates.length; i++) {
             expect(dates[i - 1].getTime()).toBeGreaterThanOrEqual(dates[i].getTime());
         }

--- a/backend/tests/entries_post.basic.test.js
+++ b/backend/tests/entries_post.basic.test.js
@@ -32,8 +32,8 @@ describe("POST /api/entries", () => {
         //   -d '{"rawInput":"httptype [foo bar] HTTP description"}'
 
         const { app, capabilities } = await makeTestApp();
-        const fixedTime = new Date("2025-05-23T12:00:00.000Z").getTime();
-        capabilities.datetime.now.mockReturnValue(fixedTime);
+        const fixedTime = capabilities.datetime.fromISOString("2025-05-23T12:00:00.000Z").getTime();
+        capabilities.datetime.now.mockReturnValue(capabilities.datetime.fromEpochMs(fixedTime));
 
         const requestBody = {
             rawInput: "httptype [foo bar] HTTP description",

--- a/backend/tests/entries_post_shortcuts.complex.test.js
+++ b/backend/tests/entries_post_shortcuts.complex.test.js
@@ -5,8 +5,8 @@ describe("POST /api/entries - rawInput transformation and shortcuts", () => {
     it("demonstrates complex multi-step transformation workflow", async () => {
         // Test a real-world scenario with multiple recursive transformations
         const { app, capabilities } = await makeTestApp();
-        const fixedTime = new Date("2025-05-23T12:00:00.000Z").getTime();
-        capabilities.datetime.now.mockReturnValue(fixedTime);
+        const fixedTime = capabilities.datetime.fromISOString("2025-05-23T12:00:00.000Z").getTime();
+        capabilities.datetime.now.mockReturnValue(capabilities.datetime.fromEpochMs(fixedTime));
 
         // Create complex config with shorthand expansions using transaction system
         const { transaction } = require("../src/event_log_storage");
@@ -86,8 +86,8 @@ describe("POST /api/entries - rawInput transformation and shortcuts", () => {
     it("verifies end-to-end transformation with real application setup", async () => {
         // This test simulates the real application environment to check if transformations work
         const { app, capabilities } = await makeTestApp();
-        const fixedTime = new Date("2025-05-23T12:00:00.000Z").getTime();
-        capabilities.datetime.now.mockReturnValue(fixedTime);
+        const fixedTime = capabilities.datetime.fromISOString("2025-05-23T12:00:00.000Z").getTime();
+        capabilities.datetime.now.mockReturnValue(capabilities.datetime.fromEpochMs(fixedTime));
 
         // Create a config with a simple shortcut using transaction system
         const { transaction } = require("../src/event_log_storage");

--- a/backend/tests/entries_post_shortcuts.config.test.js
+++ b/backend/tests/entries_post_shortcuts.config.test.js
@@ -6,8 +6,8 @@ const path = require("path");
 describe("POST /api/entries - rawInput transformation and shortcuts", () => {
     it("works without shortcuts when config file doesn't exist", async () => {
         const { app, capabilities } = await makeTestApp();
-        const fixedTime = new Date("2025-05-23T12:00:00.000Z").getTime();
-        capabilities.datetime.now.mockReturnValue(fixedTime);
+        const fixedTime = capabilities.datetime.fromISOString("2025-05-23T12:00:00.000Z").getTime();
+        capabilities.datetime.now.mockReturnValue(capabilities.datetime.fromEpochMs(fixedTime));
 
         const requestBody = {
             rawInput: "WORK [loc office] - No shortcuts here",
@@ -31,8 +31,8 @@ describe("POST /api/entries - rawInput transformation and shortcuts", () => {
 
     it("works with empty shortcuts config", async () => {
         const { app, capabilities } = await makeTestApp();
-        const fixedTime = new Date("2025-05-23T12:00:00.000Z").getTime();
-        capabilities.datetime.now.mockReturnValue(fixedTime);
+        const fixedTime = capabilities.datetime.fromISOString("2025-05-23T12:00:00.000Z").getTime();
+        capabilities.datetime.now.mockReturnValue(capabilities.datetime.fromEpochMs(fixedTime));
 
         // Create config with empty shortcuts using transaction system
         const { transaction } = require("../src/event_log_storage");
@@ -65,8 +65,8 @@ describe("POST /api/entries - rawInput transformation and shortcuts", () => {
 
     it("handles malformed config gracefully", async () => {
         const { app, capabilities } = await makeTestApp();
-        const fixedTime = new Date("2025-05-23T12:00:00.000Z").getTime();
-        capabilities.datetime.now.mockReturnValue(fixedTime);
+        const fixedTime = capabilities.datetime.fromISOString("2025-05-23T12:00:00.000Z").getTime();
+        capabilities.datetime.now.mockReturnValue(capabilities.datetime.fromEpochMs(fixedTime));
 
         // Create malformed config
         const configPath = capabilities.environment.eventLogRepository() + "/config.json";
@@ -99,8 +99,8 @@ describe("POST /api/entries - rawInput transformation and shortcuts", () => {
         // This test verifies what happens when there's no config file - 
         // this is likely what's happening in your real application
         const { app, capabilities } = await makeTestApp();
-        const fixedTime = new Date("2025-05-23T12:00:00.000Z").getTime();
-        capabilities.datetime.now.mockReturnValue(fixedTime);
+        const fixedTime = capabilities.datetime.fromISOString("2025-05-23T12:00:00.000Z").getTime();
+        capabilities.datetime.now.mockReturnValue(capabilities.datetime.fromEpochMs(fixedTime));
 
         // Ensure no config file exists
         const eventLogRepo = capabilities.environment.eventLogRepository();

--- a/backend/tests/entries_post_shortcuts.transform.test.js
+++ b/backend/tests/entries_post_shortcuts.transform.test.js
@@ -9,8 +9,8 @@ describe("POST /api/entries - rawInput transformation and shortcuts", () => {
         //   -d '{"rawInput":"w [loc o] - Fixed the parser"}'
 
         const { app, capabilities } = await makeTestApp();
-        const fixedTime = new Date("2025-05-23T12:00:00.000Z").getTime();
-        capabilities.datetime.now.mockReturnValue(fixedTime);
+        const fixedTime = capabilities.datetime.fromISOString("2025-05-23T12:00:00.000Z").getTime();
+        capabilities.datetime.now.mockReturnValue(capabilities.datetime.fromEpochMs(fixedTime));
 
         // Create a config with shortcuts using transaction system
         const { transaction } = require("../src/event_log_storage");
@@ -46,8 +46,8 @@ describe("POST /api/entries - rawInput transformation and shortcuts", () => {
 
     it("applies recursive shortcuts correctly", async () => {
         const { app, capabilities } = await makeTestApp();
-        const fixedTime = new Date("2025-05-23T12:00:00.000Z").getTime();
-        capabilities.datetime.now.mockReturnValue(fixedTime);
+        const fixedTime = capabilities.datetime.fromISOString("2025-05-23T12:00:00.000Z").getTime();
+        capabilities.datetime.now.mockReturnValue(capabilities.datetime.fromEpochMs(fixedTime));
 
         // Create config with recursive shortcuts using transaction system
         const { transaction } = require("../src/event_log_storage");
@@ -84,8 +84,8 @@ describe("POST /api/entries - rawInput transformation and shortcuts", () => {
 
     it("preserves word boundaries in shortcuts", async () => {
         const { app, capabilities } = await makeTestApp();
-        const fixedTime = new Date("2025-05-23T12:00:00.000Z").getTime();
-        capabilities.datetime.now.mockReturnValue(fixedTime);
+        const fixedTime = capabilities.datetime.fromISOString("2025-05-23T12:00:00.000Z").getTime();
+        capabilities.datetime.now.mockReturnValue(capabilities.datetime.fromEpochMs(fixedTime));
 
         // Create config with word boundary shortcuts using transaction system
         const { transaction } = require("../src/event_log_storage");
@@ -120,8 +120,8 @@ describe("POST /api/entries - rawInput transformation and shortcuts", () => {
 
     it("applies shortcuts to modifiers as well as type", async () => {
         const { app, capabilities } = await makeTestApp();
-        const fixedTime = new Date("2025-05-23T12:00:00.000Z").getTime();
-        capabilities.datetime.now.mockReturnValue(fixedTime);
+        const fixedTime = capabilities.datetime.fromISOString("2025-05-23T12:00:00.000Z").getTime();
+        capabilities.datetime.now.mockReturnValue(capabilities.datetime.fromEpochMs(fixedTime));
 
         // Create config with shortcuts for locations using transaction system
         const { transaction } = require("../src/event_log_storage");
@@ -161,8 +161,8 @@ describe("POST /api/entries - rawInput transformation and shortcuts", () => {
 
     it("normalizes whitespace during transformation", async () => {
         const { app, capabilities } = await makeTestApp();
-        const fixedTime = new Date("2025-05-23T12:00:00.000Z").getTime();
-        capabilities.datetime.now.mockReturnValue(fixedTime);
+        const fixedTime = capabilities.datetime.fromISOString("2025-05-23T12:00:00.000Z").getTime();
+        capabilities.datetime.now.mockReturnValue(capabilities.datetime.fromEpochMs(fixedTime));
 
         const requestBody = {
             rawInput: "    WORK   [loc    office]    -    Description with  extra   spaces  ",

--- a/backend/tests/entry.create.test.js
+++ b/backend/tests/entry.create.test.js
@@ -15,7 +15,9 @@ describe("createEntry (integration, with real capabilities)", () => {
     it("creates an event log entry with correct data (no file)", async () => {
         const capabilities = await getTestCapabilities();
         const fixedTime = new Date("2023-10-26T10:00:00.000Z").getTime();
-        capabilities.datetime.now.mockReturnValue(fixedTime);
+        capabilities.datetime.now.mockReturnValue(
+            capabilities.datetime.fromEpochMs(fixedTime)
+        );
         
         const entryData = {
             original: "Raw original text",
@@ -31,7 +33,7 @@ describe("createEntry (integration, with real capabilities)", () => {
         expect(event.type).toBe(entryData.type);
         expect(event.description).toBe(entryData.description);
         expect(event.modifiers).toEqual(entryData.modifiers);
-        expect(event.date).toEqual(new Date(fixedTime));
+        expect(capabilities.datetime.toEpochMs(event.date)).toBe(fixedTime);
         expect(event.id).toBeDefined();
         expect(event.creator).toBeDefined();
         expect(capabilities.logger.logInfo).toHaveBeenCalledWith(
@@ -129,8 +131,9 @@ describe("createEntry (integration, with real capabilities)", () => {
         const before = Date.now();
         const event = await createEntry(capabilities, entryData);
         const after = Date.now();
-        expect(event.date.getTime()).toBeGreaterThanOrEqual(before);
-        expect(event.date.getTime()).toBeLessThanOrEqual(after);
+        const eventTime = capabilities.datetime.toEpochMs(event.date);
+        expect(eventTime).toBeGreaterThanOrEqual(before);
+        expect(eventTime).toBeLessThanOrEqual(after);
     });
 
     it("creates an event log entry with empty modifiers if not provided", async () => {

--- a/backend/tests/entry.get.test.js
+++ b/backend/tests/entry.get.test.js
@@ -35,9 +35,11 @@ describe("getEntries ordering functionality", () => {
         const capabilities = await getTestCapabilities();
         
         // Create entries with different dates by controlling datetime.now()
-        const baseTime = new Date("2023-01-01T10:00:00Z").getTime();
+        const baseTime = capabilities.datetime.fromISOString("2023-01-01T10:00:00Z").getTime();
         
-        capabilities.datetime.now.mockReturnValueOnce(baseTime);
+        capabilities.datetime.now.mockReturnValueOnce(
+            capabilities.datetime.fromEpochMs(baseTime)
+        );
         const entry1Data = {
             original: "First entry",
             input: "First entry",
@@ -45,7 +47,9 @@ describe("getEntries ordering functionality", () => {
             description: "First entry description",
         };
         
-        capabilities.datetime.now.mockReturnValueOnce(baseTime + 24 * 60 * 60 * 1000); // +1 day
+        capabilities.datetime.now.mockReturnValueOnce(
+            capabilities.datetime.fromEpochMs(baseTime + 24 * 60 * 60 * 1000)
+        ); // +1 day
         const entry2Data = {
             original: "Second entry",
             input: "Second entry", 
@@ -53,7 +57,9 @@ describe("getEntries ordering functionality", () => {
             description: "Second entry description",
         };
         
-        capabilities.datetime.now.mockReturnValueOnce(baseTime + 2 * 24 * 60 * 60 * 1000); // +2 days
+        capabilities.datetime.now.mockReturnValueOnce(
+            capabilities.datetime.fromEpochMs(baseTime + 2 * 24 * 60 * 60 * 1000)
+        ); // +2 days
         const entry3Data = {
             original: "Third entry",
             input: "Third entry",
@@ -79,9 +85,11 @@ describe("getEntries ordering functionality", () => {
         const capabilities = await getTestCapabilities();
         
         // Create entries with different dates by controlling datetime.now()
-        const baseTime = new Date("2023-01-01T10:00:00Z").getTime();
+        const baseTime = capabilities.datetime.fromISOString("2023-01-01T10:00:00Z").getTime();
         
-        capabilities.datetime.now.mockReturnValueOnce(baseTime);
+        capabilities.datetime.now.mockReturnValueOnce(
+            capabilities.datetime.fromEpochMs(baseTime)
+        );
         const entry1Data = {
             original: "First entry",
             input: "First entry",
@@ -89,7 +97,9 @@ describe("getEntries ordering functionality", () => {
             description: "First entry description",
         };
         
-        capabilities.datetime.now.mockReturnValueOnce(baseTime + 24 * 60 * 60 * 1000); // +1 day
+        capabilities.datetime.now.mockReturnValueOnce(
+            capabilities.datetime.fromEpochMs(baseTime + 24 * 60 * 60 * 1000)
+        ); // +1 day
         const entry2Data = {
             original: "Second entry",
             input: "Second entry",
@@ -116,9 +126,11 @@ describe("getEntries ordering functionality", () => {
     it("sorts entries by date descending when explicitly specified", async () => {
         const capabilities = await getTestCapabilities();
         
-        const baseTime = new Date("2023-01-01T10:00:00Z").getTime();
+        const baseTime = capabilities.datetime.fromISOString("2023-01-01T10:00:00Z").getTime();
         
-        capabilities.datetime.now.mockReturnValueOnce(baseTime);
+        capabilities.datetime.now.mockReturnValueOnce(
+            capabilities.datetime.fromEpochMs(baseTime)
+        );
         const entry1Data = {
             original: "First entry",
             input: "First entry",
@@ -126,7 +138,9 @@ describe("getEntries ordering functionality", () => {
             description: "First entry description",
         };
         
-        capabilities.datetime.now.mockReturnValueOnce(baseTime + 24 * 60 * 60 * 1000); // +1 day
+        capabilities.datetime.now.mockReturnValueOnce(
+            capabilities.datetime.fromEpochMs(baseTime + 24 * 60 * 60 * 1000)
+        ); // +1 day
         const entry2Data = {
             original: "Second entry", 
             input: "Second entry",
@@ -174,9 +188,11 @@ describe("getEntries ordering functionality", () => {
         const capabilities = await getTestCapabilities();
         
         // Create 5 entries with different dates by controlling datetime.now()
-        const baseTime = new Date("2023-01-01T10:00:00Z").getTime();
+        const baseTime = capabilities.datetime.fromISOString("2023-01-01T10:00:00Z").getTime();
         for (let i = 1; i <= 5; i++) {
-            capabilities.datetime.now.mockReturnValueOnce(baseTime + (i - 1) * 24 * 60 * 60 * 1000);
+            capabilities.datetime.now.mockReturnValueOnce(
+                capabilities.datetime.fromEpochMs(baseTime + (i - 1) * 24 * 60 * 60 * 1000)
+            );
             await createEntry(capabilities, {
                 original: `Entry ${i}`,
                 input: `Entry ${i}`,

--- a/backend/tests/event_log_storage.assets.test.js
+++ b/backend/tests/event_log_storage.assets.test.js
@@ -28,7 +28,7 @@ describe("event_log_storage", () => {
         await stubEventLogRepository(capabilities);
         const testEvent = {
             id: { identifier: "assetEvent" },
-            date: new Date("2025-05-13"),
+            date: capabilities.datetime.fromISOString("2025-05-13"),
         };
 
         // Create a temporary asset file.
@@ -68,7 +68,7 @@ describe("event_log_storage", () => {
         await stubEventLogRepository(capabilities);
         const testEvent = {
             id: { identifier: "cleanupEvent" },
-            date: new Date("2025-05-14"),
+            date: capabilities.datetime.fromISOString("2025-05-14"),
         };
         const assetPath = "/some/failure.txt";
         const asset = {
@@ -96,7 +96,7 @@ describe("event_log_storage", () => {
 
         const testEvent = {
             id: { identifier: "assetEventWithDirs" },
-            date: new Date("2025-05-13"),
+            date: capabilities.datetime.fromISOString("2025-05-13"),
         };
 
         // Create a temporary asset file.
@@ -139,7 +139,7 @@ describe("event_log_storage", () => {
 
         const testEvent = {
             id: { identifier: "mixedAssetsEvent" },
-            date: new Date("2025-05-13"),
+            date: capabilities.datetime.fromISOString("2025-05-13"),
             type: "test_event",
             description: "Mixed assets test event",
         };

--- a/backend/tests/event_log_storage.config.test.js
+++ b/backend/tests/event_log_storage.config.test.js
@@ -126,7 +126,7 @@ describe("event_log_storage", () => {
 
         const testEvent = {
             id: { identifier: "config-and-event" },
-            date: new Date("2025-05-20"),
+            date: capabilities.datetime.fromISOString("2025-05-20"),
             original: "test with config",
             input: "test with config",
             type: "config_test",

--- a/backend/tests/event_log_storage.delete.test.js
+++ b/backend/tests/event_log_storage.delete.test.js
@@ -26,7 +26,7 @@ describe("event_log_storage deletion", () => {
 
         const e1 = {
             id: { identifier: "delete1" },
-            date: new Date("2025-05-12"),
+            date: capabilities.datetime.fromISOString("2025-05-12"),
             original: "first",
             input: "first",
             type: "test",
@@ -35,7 +35,7 @@ describe("event_log_storage deletion", () => {
         };
         const e2 = {
             id: { identifier: "delete2" },
-            date: new Date("2025-05-13"),
+            date: capabilities.datetime.fromISOString("2025-05-13"),
             original: "second",
             input: "second",
             type: "test",
@@ -68,7 +68,7 @@ describe("event_log_storage deletion", () => {
 
         const e1 = {
             id: { identifier: "todel1" },
-            date: new Date("2025-05-14"),
+            date: capabilities.datetime.fromISOString("2025-05-14"),
             original: "one",
             input: "one",
             type: "test",
@@ -77,7 +77,7 @@ describe("event_log_storage deletion", () => {
         };
         const e2 = {
             id: { identifier: "todel2" },
-            date: new Date("2025-05-15"),
+            date: capabilities.datetime.fromISOString("2025-05-15"),
             original: "two",
             input: "two",
             type: "test",
@@ -107,7 +107,7 @@ describe("event_log_storage deletion", () => {
 
         const e1 = {
             id: { identifier: "solo" },
-            date: new Date("2025-05-16"),
+            date: capabilities.datetime.fromISOString("2025-05-16"),
             original: "solo",
             input: "solo",
             type: "test",
@@ -138,7 +138,7 @@ describe("event_log_storage deletion", () => {
 
         const e = {
             id: { identifier: "iter" },
-            date: new Date("2025-06-01"),
+            date: capabilities.datetime.fromISOString("2025-06-01"),
             original: "i",
             input: "i",
             type: "test",
@@ -166,7 +166,7 @@ describe("event_log_storage deletion", () => {
 
         const e1 = {
             id: { identifier: "multi1" },
-            date: new Date("2025-06-02"),
+            date: capabilities.datetime.fromISOString("2025-06-02"),
             original: "m1",
             input: "m1",
             type: "test",
@@ -175,7 +175,7 @@ describe("event_log_storage deletion", () => {
         };
         const e2 = {
             id: { identifier: "multi2" },
-            date: new Date("2025-06-03"),
+            date: capabilities.datetime.fromISOString("2025-06-03"),
             original: "m2",
             input: "m2",
             type: "test",

--- a/backend/tests/event_log_storage.entries.test.js
+++ b/backend/tests/event_log_storage.entries.test.js
@@ -28,7 +28,7 @@ describe("event_log_storage", () => {
         // First transaction: create initial entries
         const firstEvent = {
             id: { identifier: "existing1" },
-            date: new Date("2025-05-01"),
+            date: capabilities.datetime.fromISOString("2025-05-01"),
             original: "first input",
             input: "processed first input",
             modifiers: { test: "first" },
@@ -44,7 +44,7 @@ describe("event_log_storage", () => {
         // Second transaction: verify we can read existing entries and add more
         const secondEvent = {
             id: { identifier: "new1" },
-            date: new Date("2025-05-15"),
+            date: capabilities.datetime.fromISOString("2025-05-15"),
             original: "new input",
             input: "processed new input",
             modifiers: { test: "new" },
@@ -84,7 +84,7 @@ describe("event_log_storage", () => {
         // First create an initial entry
         const initialEvent = {
             id: { identifier: "cache-test" },
-            date: new Date("2025-05-24"),
+            date: capabilities.datetime.fromISOString("2025-05-24"),
             original: "cache test",
             input: "cache test input",
             type: "cache_test",
@@ -120,7 +120,7 @@ describe("event_log_storage", () => {
             storage.addEntry(
                 {
                     id: { identifier: "cache-test-2" },
-                    date: new Date("2025-05-25"),
+                    date: capabilities.datetime.fromISOString("2025-05-25"),
                     original: "cache test 2",
                     input: "cache test input 2",
                     type: "cache_test",

--- a/backend/tests/event_log_storage.transactions.test.js
+++ b/backend/tests/event_log_storage.transactions.test.js
@@ -27,7 +27,7 @@ describe("event_log_storage", () => {
 
         const testEvent = {
             id: { identifier: "test123" },
-            date: new Date("2025-05-12"),
+            date: capabilities.datetime.fromISOString("2025-05-12"),
             original: "test input",
             input: "processed test input",
             modifiers: { test: "modifier" },
@@ -58,7 +58,7 @@ describe("event_log_storage", () => {
 
         const testEvent = {
             id: { identifier: "test123" },
-            date: new Date("2025-05-12"),
+            date: capabilities.datetime.fromISOString("2025-05-12"),
             original: "test input",
             input: "processed test input",
             modifiers: { test: "modifier" },
@@ -84,7 +84,7 @@ describe("event_log_storage", () => {
 
         const event1 = {
             id: { identifier: "event1" },
-            date: new Date("2025-05-12"),
+            date: capabilities.datetime.fromISOString("2025-05-12"),
             original: "first input",
             input: "processed first input",
             modifiers: { foo: "bar" },
@@ -93,7 +93,7 @@ describe("event_log_storage", () => {
         };
         const event2 = {
             id: { identifier: "event2" },
-            date: new Date("2025-05-12"),
+            date: capabilities.datetime.fromISOString("2025-05-12"),
             original: "second input",
             input: "processed second input",
             modifiers: { baz: "qux" },

--- a/backend/tests/event_log_storage_assets.test.js
+++ b/backend/tests/event_log_storage_assets.test.js
@@ -29,7 +29,7 @@ describe("event_log_storage", () => {
         await stubEventLogRepository(capabilities);
         const testEvent = {
             id: { identifier: "assetEvent" },
-            date: new Date("2025-05-13"),
+            date: capabilities.datetime.fromISOString("2025-05-13"),
         };
 
         // Create a temporary asset file.
@@ -69,7 +69,7 @@ describe("event_log_storage", () => {
         await stubEventLogRepository(capabilities);
         const testEvent = {
             id: { identifier: "cleanupEvent" },
-            date: new Date("2025-05-14"),
+            date: capabilities.datetime.fromISOString("2025-05-14"),
         };
         const assetPath = "/some/failure.txt";
         const asset = {
@@ -97,7 +97,7 @@ describe("event_log_storage", () => {
 
         const testEvent = {
             id: { identifier: "assetEventWithDirs" },
-            date: new Date("2025-05-13"),
+            date: capabilities.datetime.fromISOString("2025-05-13"),
         };
 
         // Create a temporary asset file.
@@ -140,7 +140,7 @@ describe("event_log_storage", () => {
 
         const testEvent = {
             id: { identifier: "mixedAssetsEvent" },
-            date: new Date("2025-05-13"),
+            date: capabilities.datetime.fromISOString("2025-05-13"),
             type: "test_event",
             description: "Mixed assets test event",
         };

--- a/backend/tests/event_log_storage_config.test.js
+++ b/backend/tests/event_log_storage_config.test.js
@@ -130,7 +130,7 @@ describe("event_log_storage", () => {
 
         const testEvent = {
             id: { identifier: "config-and-event" },
-            date: new Date("2025-05-20"),
+            date: capabilities.datetime.fromISOString("2025-05-20"),
             original: "test with config",
             input: "test with config",
             type: "config_test",

--- a/backend/tests/event_log_storage_entries.test.js
+++ b/backend/tests/event_log_storage_entries.test.js
@@ -28,7 +28,7 @@ describe("event_log_storage", () => {
 
         const testEvent = {
             id: { identifier: "test123" },
-            date: new Date("2025-05-12"),
+            date: capabilities.datetime.fromISOString("2025-05-12"),
             original: "test input",
             input: "processed test input",
             modifiers: { test: "modifier" },
@@ -59,7 +59,7 @@ describe("event_log_storage", () => {
 
         const testEvent = {
             id: { identifier: "test123" },
-            date: new Date("2025-05-12"),
+            date: capabilities.datetime.fromISOString("2025-05-12"),
             original: "test input",
             input: "processed test input",
             modifiers: { test: "modifier" },
@@ -85,7 +85,7 @@ describe("event_log_storage", () => {
 
         const event1 = {
             id: { identifier: "event1" },
-            date: new Date("2025-05-12"),
+            date: capabilities.datetime.fromISOString("2025-05-12"),
             original: "first input",
             input: "processed first input",
             modifiers: { foo: "bar" },
@@ -94,7 +94,7 @@ describe("event_log_storage", () => {
         };
         const event2 = {
             id: { identifier: "event2" },
-            date: new Date("2025-05-12"),
+            date: capabilities.datetime.fromISOString("2025-05-12"),
             original: "second input",
             input: "processed second input",
             modifiers: { baz: "qux" },

--- a/backend/tests/event_log_storage_get_entries.test.js
+++ b/backend/tests/event_log_storage_get_entries.test.js
@@ -29,7 +29,7 @@ describe("event_log_storage", () => {
         // First transaction: create initial entries
         const firstEvent = {
             id: { identifier: "existing1" },
-            date: new Date("2025-05-01"),
+            date: capabilities.datetime.fromISOString("2025-05-01"),
             original: "first input",
             input: "processed first input",
             modifiers: { test: "first" },
@@ -45,7 +45,7 @@ describe("event_log_storage", () => {
         // Second transaction: verify we can read existing entries and add more
         const secondEvent = {
             id: { identifier: "new1" },
-            date: new Date("2025-05-15"),
+            date: capabilities.datetime.fromISOString("2025-05-15"),
             original: "new input",
             input: "processed new input",
             modifiers: { test: "new" },
@@ -85,7 +85,7 @@ describe("event_log_storage", () => {
         // First create an initial entry
         const initialEvent = {
             id: { identifier: "cache-test" },
-            date: new Date("2025-05-24"),
+            date: capabilities.datetime.fromISOString("2025-05-24"),
             original: "cache test",
             input: "cache test input",
             type: "cache_test",
@@ -121,7 +121,7 @@ describe("event_log_storage", () => {
             storage.addEntry(
                 {
                     id: { identifier: "cache-test-2" },
-                    date: new Date("2025-05-25"),
+                    date: capabilities.datetime.fromISOString("2025-05-25"),
                     original: "cache test 2",
                     input: "cache test input 2",
                     type: "cache_test",

--- a/backend/tests/format_time_stamp.test.js
+++ b/backend/tests/format_time_stamp.test.js
@@ -3,26 +3,30 @@ const { formatFileTimestamp } = require('../src/format_time_stamp');
 describe('formatFileTimestamp', () => {
   it('returns a Date object for valid filename', () => {
     const filename = '20250503T203813Z.txt';
-    const date = formatFileTimestamp(filename);
-    expect(date).toBeInstanceOf(Date);
-    expect(date.toISOString()).toBe('2025-05-03T20:38:13.000Z');
+    const dt = require('../src/datetime').make();
+    const date = formatFileTimestamp(filename, dt);
+    expect(dt.toNativeDate(date)).toBeInstanceOf(Date);
+    expect(dt.toISOString(date)).toBe('2025-05-03T20:38:13.000Z');
   });
 
   it('handles midnight UTC correctly', () => {
     const filename = '20200101T000000Z.txt';
-    const date = formatFileTimestamp(filename);
-    expect(date.toISOString()).toBe('2020-01-01T00:00:00.000Z');
+    const dt = require('../src/datetime').make();
+    const date = formatFileTimestamp(filename, dt);
+    expect(dt.toISOString(date)).toBe('2020-01-01T00:00:00.000Z');
   });
 
   it('throws an error for filename without valid prefix', async () => {
-    await expect(async () => formatFileTimestamp('invalidfile.txt')).rejects.toThrow(
+    const dt = require('../src/datetime').make();
+    await expect(async () => formatFileTimestamp('invalidfile.txt', dt)).rejects.toThrow(
       'Filename "invalidfile.txt" does not start with YYYYMMDDThhmmssZ'
     );
   });
 
   it('throws an error for invalid calendar date', async () => {
+    const dt = require('../src/datetime').make();
     await expect(async () =>
-      formatFileTimestamp('20250230T000000Z.txt')
+      formatFileTimestamp('20250230T000000Z.txt', dt)
     ).rejects.toThrow('Failed to parse valid Date from timestamp string: 20250230T000000Z');
   });
 });

--- a/backend/tests/stubs.js
+++ b/backend/tests/stubs.js
@@ -97,7 +97,9 @@ function stubScheduler(capabilities) {
 }
 
 function stubDatetime(capabilities) {
-    capabilities.datetime.now = jest.fn(() => Date.now());
+    capabilities.datetime.now = jest.fn(() =>
+        capabilities.datetime.fromEpochMs(Date.now())
+    );
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary
- introduce `DateTime` nominal class and update datetime capability
- refactor code to depend on capability for all date operations
- adjust asset paths, diary processing, and format functions
- update tests for new DateTime abstraction

## Testing
- `npm test`
- `npm run static-analysis`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6870904857b4832e96c63e52ead4240b