### PR TITLE
Add Sleeper capability and remove raw timeouts

### DIFF
--- a/backend/src/capabilities/root.js
+++ b/backend/src/capabilities/root.js
@@ -20,6 +20,7 @@
 /** @typedef {import('../schedule').Scheduler} Scheduler */
 /** @typedef {import('../ai/transcription').AITranscription} AITranscription */
 /** @typedef {import('../datetime').Datetime} Datetime */
+/** @typedef {import('../sleeper').Sleeper} Sleeper */
 
 
 /**
@@ -41,6 +42,7 @@
  * @property {Scheduler} scheduler - A scheduler instance.
  * @property {AITranscription} aiTranscription - An AI transcription instance.
  * @property {Datetime} datetime - Datetime utilities.
+ * @property {Sleeper} sleeper - A sleeper instance.
  */
 
 const memconst = require("../memconst");
@@ -62,6 +64,7 @@ const notifierCapability = require("../notifications");
 const schedulerCapability = require("../schedule");
 const aiTranscriptionCapability = require("../ai/transcription");
 const datetimeCapability = require("../datetime");
+const sleeperCapability = require("../sleeper");
 
 /**
  * This structure collects maximum capabilities that any part of Volodyslav can access.
@@ -72,6 +75,7 @@ const datetimeCapability = require("../datetime");
 const make = memconst(() => {
     const environment = environmentCapability.make();
     const datetime = datetimeCapability.make();
+    const sleeper = sleeperCapability.make();
     /** @type {Capabilities} */
     const ret = {
         seed: random.seed.make(),
@@ -83,7 +87,7 @@ const make = memconst(() => {
         writer: writerCapability.make(),
         reader: readerCapability.make(),
         appender: appendCapability.make(),
-        checker: checkerCapability.make({ datetime }),
+        checker: checkerCapability.make({ datetime, sleeper }),
         git: gitCapability,
         environment,
         exiter: exiterCapability.make(),
@@ -91,6 +95,7 @@ const make = memconst(() => {
         notifier: notifierCapability.make(),
         scheduler: schedulerCapability.make(),
         aiTranscription: aiTranscriptionCapability.make({ environment }),
+        sleeper,
     };
 
     return ret;

--- a/backend/src/retryer/core.js
+++ b/backend/src/retryer/core.js
@@ -5,7 +5,6 @@
  * of the same callback while allowing for retry with configurable delays.
  */
 
-const { sleep } = require("../time_duration");
 
 /**
  * Error thrown when retryer operations fail.
@@ -37,6 +36,7 @@ function isRetryerError(object) {
 /**
  * @typedef {object} RetryerCapabilities
  * @property {import('../logger').Logger} logger - Logger for retry operations
+ * @property {import('../sleeper').Sleeper} sleeper - Sleeper capability
  */
 
 /**
@@ -163,7 +163,7 @@ async function withRetry(capabilities, callback) {
                     `Retryer scheduling retry after ${result.toString()}`
                 );
 
-                await sleep(result);
+                await capabilities.sleeper.sleep(result.toMilliseconds());
                 attempt++;
 
             } catch (error) {

--- a/backend/src/sleeper.js
+++ b/backend/src/sleeper.js
@@ -1,0 +1,27 @@
+/**
+ * Sleeper capability for pausing execution.
+ */
+
+/**
+ * @typedef {object} Sleeper
+ * @property {(ms: number) => Promise<void>} sleep - Pause for the given milliseconds.
+ */
+
+/**
+ * Pauses execution for the specified milliseconds.
+ * @param {number} ms - Milliseconds to sleep.
+ * @returns {Promise<void>} Resolves after the delay.
+ */
+function sleep(ms) {
+    return new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+}
+
+function make() {
+    return { sleep };
+}
+
+module.exports = {
+    make,
+};

--- a/backend/src/time_duration/utils.js
+++ b/backend/src/time_duration/utils.js
@@ -2,28 +2,30 @@
  * Utility functions for working with TimeDuration instances.
  */
 
+/** @typedef {import('../sleeper').Sleeper} Sleeper */
+
 /**
  * Sleeps for the specified duration.
+ * @param {Sleeper} sleeper - Sleeper capability.
  * @param {import('./structure').TimeDuration} duration - How long to sleep
  * @returns {Promise<void>}
  */
-function sleep(duration) {
-    return new Promise(resolve => {
-        setTimeout(resolve, duration.toMilliseconds());
-    });
+function sleep(sleeper, duration) {
+    return sleeper.sleep(duration.toMilliseconds());
 }
 
 /**
  * Creates a timeout promise that rejects after the specified duration.
+ * @param {Sleeper} sleeper - Sleeper capability.
  * @param {import('./structure').TimeDuration} duration - How long to wait before timeout
  * @param {string} [message] - Optional timeout message
  * @returns {Promise<never>}
  */
-function timeout(duration, message = "Operation timed out") {
+function timeout(sleeper, duration, message = "Operation timed out") {
     return new Promise((_, reject) => {
-        setTimeout(() => {
+        sleeper.sleep(duration.toMilliseconds()).then(() => {
             reject(new Error(message));
-        }, duration.toMilliseconds());
+        });
     });
 }
 
@@ -31,14 +33,15 @@ function timeout(duration, message = "Operation timed out") {
  * Races a promise against a timeout.
  * @template T
  * @param {Promise<T>} promise - The promise to race
+ * @param {Sleeper} sleeper - Sleeper capability.
  * @param {import('./structure').TimeDuration} duration - Timeout duration
  * @param {string} [message] - Optional timeout message
  * @returns {Promise<T>}
  */
-function withTimeout(promise, duration, message) {
+function withTimeout(promise, sleeper, duration, message) {
     return Promise.race([
         promise,
-        timeout(duration, message)
+        timeout(sleeper, duration, message)
     ]);
 }
 

--- a/backend/tests/logger.test.js
+++ b/backend/tests/logger.test.js
@@ -3,6 +3,7 @@ const path = require("path");
 const { make } = require("../src/logger");
 const { getMockedRootCapabilities } = require("./spies");
 const { stubEnvironment, stubDatetime } = require("./stubs");
+const { make: makeSleeper } = require("../src/sleeper");
 
 describe("logger capability", () => {
     it("writes info, warn, error, and debug to file", async () => {
@@ -19,7 +20,7 @@ describe("logger capability", () => {
         logger.logWarning({ bar: 2 }, "warn message");
         logger.logError({ baz: 3 }, "error message");
         logger.logDebug({ qux: 4 }, "debug message");
-        await new Promise((r) => setTimeout(r, 1000));
+        await capabilities.sleeper.sleep(1000);
         const content = fs.readFileSync(logFilePath, "utf8");
         expect(content).toMatch(/info message/);
         expect(content).toMatch(/warn message/);
@@ -35,8 +36,9 @@ describe("logger capability", () => {
         };
         try {
             const logger = make();
+            const sleeper = makeSleeper();
             logger.logError({}, "should fallback");
-            await new Promise((r) => setTimeout(r, 50));
+            await sleeper.sleep(50);
             expect(called).toBe(true);
         } finally {
             console.error = origError;
@@ -54,7 +56,7 @@ describe("logger capability", () => {
         await logger.setup();
         logger.logInfo({}, "info should not appear");
         logger.logError({}, "error should appear");
-        await new Promise((r) => setTimeout(r, 1000));
+        await capabilities.sleeper.sleep(1000);
         const content = fs.readFileSync(logFilePath, "utf8");
         expect(content).not.toMatch(/info should not appear/);
         expect(content).toMatch(/error should appear/);

--- a/backend/tests/memconst.test.js
+++ b/backend/tests/memconst.test.js
@@ -104,9 +104,11 @@ describe('memconst', () => {
 
   test('should work with real async functions and delays', async () => {
     // Setup
-    const delayedFn = jest.fn(
-      () => new Promise(resolve => setTimeout(() => resolve('delayed-value'), 100))
-    );
+    const sleeper = require('../src/sleeper').make();
+    const delayedFn = jest.fn(async () => {
+      await sleeper.sleep(100);
+      return 'delayed-value';
+    });
     const memoized = memconst(delayedFn);
 
     // Execute

--- a/backend/tests/retryer_timing.test.js
+++ b/backend/tests/retryer_timing.test.js
@@ -171,7 +171,7 @@ describe("Retryer - Timing and logging", () => {
             withRetry(capabilities, callback);
 
             // Give it a moment to process and log
-            await new Promise(resolve => setTimeout(resolve, 50));
+            await capabilities.sleeper.sleep(50);
 
             expect(callCount).toBe(1);
             expect(capabilities.logger.logDebug).toHaveBeenCalledWith(

--- a/backend/tests/stubs.js
+++ b/backend/tests/stubs.js
@@ -96,6 +96,12 @@ function stubScheduler(capabilities) {
         });
 }
 
+function stubSleeper(capabilities) {
+    capabilities.sleeper.sleep = jest.fn((ms) =>
+        new Promise((resolve) => setTimeout(resolve, ms))
+    );
+}
+
 function stubDatetime(capabilities) {
     capabilities.datetime.now = jest.fn(() =>
         capabilities.datetime.fromEpochMs(Date.now())
@@ -108,6 +114,7 @@ module.exports = {
     stubAiTranscriber,
     stubNotifier,
     stubScheduler,
+    stubSleeper,
     stubDatetime,
     stubEventLogRepository,
 };

--- a/frontend/tests/Camera.test.jsx
+++ b/frontend/tests/Camera.test.jsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { make as makeSleeper } from '../../backend/src/sleeper.js';
+
+const sleeper = makeSleeper();
 
 // Mock Chakra UI useToast
 const mockToast = jest.fn();
@@ -75,11 +78,11 @@ describe('Camera component', () => {
                     objectStore: jest.fn().mockImplementation(() => ({
                         put: jest.fn().mockImplementation((data, key) => {
                             mockStore.set(key, data);
-                            setTimeout(() => {
+                            sleeper.sleep(0).then(() => {
                                 if (typeof transaction.oncomplete === 'function') {
                                     transaction.oncomplete();
                                 }
-                            }, 0);
+                            });
                         }),
                         get: jest.fn().mockImplementation((key) => ({
                             result: mockStore.get(key)
@@ -100,7 +103,7 @@ describe('Camera component', () => {
         };
         const mockOpen = jest.fn().mockImplementation(() => {
             const req = {};
-            setTimeout(() => {
+            sleeper.sleep(0).then(() => {
                 if (typeof req.onupgradeneeded === 'function') {
                     req.result = mockDB;
                     req.onupgradeneeded({ target: req });
@@ -109,7 +112,7 @@ describe('Camera component', () => {
                     req.result = mockDB;
                     req.onsuccess({ target: req });
                 }
-            }, 0);
+            });
             return req;
         });
         Object.defineProperty(window, 'indexedDB', {
@@ -195,7 +198,7 @@ describe('Camera component', () => {
         await waitFor(() => screen.getByAltText('Preview'));
         
         // Wait a bit for the blob to be processed
-        await new Promise(resolve => setTimeout(resolve, 100));
+        await sleeper.sleep(100);
         
         fireEvent.click(screen.getByText('Done'));
 

--- a/frontend/tests/photoStorage.integration.test.js
+++ b/frontend/tests/photoStorage.integration.test.js
@@ -4,6 +4,9 @@
  */
 
 import { storePhotos, retrievePhotos } from '../src/DescriptionEntry/photoStorage.js';
+import { make as makeSleeper } from '../../backend/src/sleeper.js';
+
+const sleeper = makeSleeper();
 
 // Mock IndexedDB for testing
 const mockIndexedDB = (() => {
@@ -14,21 +17,21 @@ const mockIndexedDB = (() => {
                 objectStore: jest.fn().mockImplementation(() => ({
                     put: jest.fn().mockImplementation((data, key) => {
                         mockStore.set(key, data);
-                        setTimeout(() => {
+                        sleeper.sleep(0).then(() => {
                             if (typeof transaction.oncomplete === 'function') {
                                 transaction.oncomplete();
                             }
-                        }, 0);
+                        });
                     }),
                     get: jest.fn().mockImplementation((key) => {
                         const request = {
                             result: mockStore.get(key)
                         };
-                        setTimeout(() => {
+                        sleeper.sleep(0).then(() => {
                             if (typeof request.onsuccess === 'function') {
                                 request.onsuccess();
                             }
-                        }, 0);
+                        });
                         return request;
                     })
                 })),
@@ -46,7 +49,7 @@ const mockIndexedDB = (() => {
     return {
         open: jest.fn().mockImplementation(() => {
             const req = {};
-            setTimeout(() => {
+            sleeper.sleep(0).then(() => {
                 if (typeof req.onupgradeneeded === 'function') {
                     req.result = mockDB;
                     req.onupgradeneeded({ target: req });
@@ -55,7 +58,7 @@ const mockIndexedDB = (() => {
                     req.result = mockDB;
                     req.onsuccess({ target: req });
                 }
-            }, 0);
+            });
             return req;
         }),
         mockStore

--- a/frontend/tests/photoStorage.test.js
+++ b/frontend/tests/photoStorage.test.js
@@ -3,6 +3,9 @@
  */
 
 import { storePhotos, retrievePhotos, removePhotos, clearAllPhotos } from '../src/DescriptionEntry/photoStorage.js';
+import { make as makeSleeper } from '../../backend/src/sleeper.js';
+
+const sleeper = makeSleeper();
 
 // Mock IndexedDB
 const mockIndexedDB = (() => {
@@ -13,38 +16,38 @@ const mockIndexedDB = (() => {
                 objectStore: jest.fn().mockImplementation(() => ({
                     put: jest.fn().mockImplementation((data, key) => {
                         mockStore.set(key, data);
-                        setTimeout(() => {
+                        sleeper.sleep(0).then(() => {
                             if (typeof transaction.oncomplete === 'function') {
                                 transaction.oncomplete();
                             }
-                        }, 0);
+                        });
                     }),
                     get: jest.fn().mockImplementation((key) => {
                         const request = {
                             result: mockStore.get(key)
                         };
-                        setTimeout(() => {
+                        sleeper.sleep(0).then(() => {
                             if (typeof request.onsuccess === 'function') {
                                 request.onsuccess();
                             }
-                        }, 0);
+                        });
                         return request;
                     }),
                     delete: jest.fn().mockImplementation((key) => {
                         mockStore.delete(key);
-                        setTimeout(() => {
+                        sleeper.sleep(0).then(() => {
                             if (typeof transaction.oncomplete === 'function') {
                                 transaction.oncomplete();
                             }
-                        }, 0);
+                        });
                     }),
                     clear: jest.fn().mockImplementation(() => {
                         mockStore.clear();
-                        setTimeout(() => {
+                        sleeper.sleep(0).then(() => {
                             if (typeof transaction.oncomplete === 'function') {
                                 transaction.oncomplete();
                             }
-                        }, 0);
+                        });
                     })
                 })),
                 oncomplete: null,
@@ -61,7 +64,7 @@ const mockIndexedDB = (() => {
     return {
         open: jest.fn().mockImplementation(() => {
             const req = {};
-            setTimeout(() => {
+            sleeper.sleep(0).then(() => {
                 if (typeof req.onupgradeneeded === 'function') {
                     req.result = mockDB;
                     req.onupgradeneeded({ target: req });
@@ -70,7 +73,7 @@ const mockIndexedDB = (() => {
                     req.result = mockDB;
                     req.onsuccess({ target: req });
                 }
-            }, 0);
+            });
             return req;
         }),
         mockStore


### PR DESCRIPTION
## Summary
- introduce a `Sleeper` capability for delaying execution
- wire new capability into root capabilities
- refactor modules that used `setTimeout` to use the `Sleeper`
- update tests to rely on the capability instead of raw timeouts

## Testing
- `npm test`
- `npm run static-analysis`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68709961db4c832e9f07f6dd5f30bbdb