### PR TITLE
Fix schedule tasks tests to avoid lingering cron jobs

### DIFF
--- a/backend/tests/schedule.tasks.test.js
+++ b/backend/tests/schedule.tasks.test.js
@@ -4,7 +4,13 @@
 
 const { everyHour, daily, allTasks, scheduleAll } = require("../src/schedule/tasks");
 const { getMockedRootCapabilities } = require("./spies");
-const { stubLogger, stubEnvironment, stubAiTranscriber, stubNotifier } = require("./stubs");
+const {
+    stubLogger,
+    stubEnvironment,
+    stubAiTranscriber,
+    stubNotifier,
+    stubScheduler,
+} = require("./stubs");
 
 function getTestCapabilities() {
     const capabilities = getMockedRootCapabilities();
@@ -12,6 +18,7 @@ function getTestCapabilities() {
     stubEnvironment(capabilities);
     stubAiTranscriber(capabilities);
     stubNotifier(capabilities);
+    stubScheduler(capabilities);
     return capabilities;
 }
 


### PR DESCRIPTION
## Summary
- ensure scheduler is stubbed in schedule.tasks.test.js

## Testing
- `npm test`
- `npm run static-analysis`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687301b0e740832ead8c990e95983dd5