### PR TITLE
Fix upload field name mismatch

### DIFF
--- a/backend/src/routes/upload.js
+++ b/backend/src/routes/upload.js
@@ -24,7 +24,7 @@ const { fromRequest, markDone } = require('../request_identifier');
 function makeRouter(capabilities) {
     const uploadMiddleware = upload.makeUpload(capabilities);
     const router = express.Router();
-    router.post('/upload', uploadMiddleware.array('photos'), async (req, res) => {
+    router.post('/upload', uploadMiddleware.array('files'), async (req, res) => {
         let reqId;
         try {
             reqId = fromRequest(req);

--- a/backend/tests/upload.test.js
+++ b/backend/tests/upload.test.js
@@ -29,7 +29,7 @@ describe("POST /api/upload", () => {
         const reqId = "testreq";
         const res = await request(app)
             .post(`/api/upload?request_identifier=${reqId}`)
-            .attach("photos", Buffer.from("test content"), "test1.jpg");
+            .attach("files", Buffer.from("test content"), "test1.jpg");
 
         expect(res.statusCode).toBe(200);
         expect(res.body).toEqual({ success: true, files: ["test1.jpg"] });
@@ -47,7 +47,7 @@ describe("POST /api/upload", () => {
         const reqId1 = "testreq1";
         const res1 = await request(app)
             .post(`/api/upload?request_identifier=${reqId1}`)
-            .attach("photos", Buffer.from("first"), "first.jpg");
+            .attach("files", Buffer.from("first"), "first.jpg");
 
         expect(res1.statusCode).toBe(200);
         expect(res1.body).toEqual({ success: true, files: ["first.jpg"] });
@@ -60,7 +60,7 @@ describe("POST /api/upload", () => {
         const reqId2 = "testreq2";
         const res2 = await request(app)
             .post(`/api/upload?request_identifier=${reqId2}`)
-            .attach("photos", Buffer.from("second"), "second.jpg");
+            .attach("files", Buffer.from("second"), "second.jpg");
 
         expect(res2.statusCode).toBe(200);
         expect(res2.body).toEqual({ success: true, files: ["second.jpg"] });


### PR DESCRIPTION
## Summary
- fix upload route to expect files under `files` field
- update upload tests accordingly

## Testing
- `npm test`
- `npm run static-analysis`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687e98a548dc832ea0ef6ba3a52156e5