### PR TITLE
feat: extend runtime state to support persisted tasks

### DIFF
--- a/backend/src/runtime_state_storage/errors.js
+++ b/backend/src/runtime_state_storage/errors.js
@@ -1,0 +1,160 @@
+/**
+ * Error classes for runtime state deserialization.
+ */
+
+class TryDeserializeError extends Error {
+    /**
+     * @param {string} message
+     * @param {string} field
+     * @param {unknown} value
+     * @param {string} expectedType
+     */
+    constructor(message, field, value, expectedType) {
+        super(message);
+        this.name = "TryDeserializeError";
+        this.field = field;
+        this.value = value;
+        this.expectedType = expectedType;
+    }
+}
+
+class MissingFieldError extends TryDeserializeError {
+    /**
+     * @param {string} field
+     */
+    constructor(field) {
+        super(`Missing required field: ${field}`, field, undefined, "any");
+        this.name = "MissingFieldError";
+    }
+}
+
+class InvalidTypeError extends TryDeserializeError {
+    /**
+     * @param {string} field
+     * @param {unknown} value
+     * @param {string} expectedType
+     */
+    constructor(field, value, expectedType) {
+        const actualType = Array.isArray(value) ? "array" : typeof value;
+        super(`Invalid type for field '${field}': expected ${expectedType}, got ${actualType}`, field, value, expectedType);
+        this.name = "InvalidTypeError";
+        this.actualType = actualType;
+    }
+}
+
+class InvalidStructureError extends TryDeserializeError {
+    /**
+     * @param {string} message
+     * @param {unknown} value
+     */
+    constructor(message, value) {
+        super(message, "root", value, "object");
+        this.name = "InvalidStructureError";
+    }
+}
+
+class TasksFieldInvalidStructureError extends TryDeserializeError {
+    /**
+     * @param {unknown} value
+     */
+    constructor(value) {
+        super("Tasks field must be an array", "tasks", value, "array");
+        this.name = "TasksFieldInvalidStructureError";
+    }
+}
+
+class UnsupportedVersionError extends TryDeserializeError {
+    /**
+     * @param {number} version
+     */
+    constructor(version) {
+        super(`Unsupported runtime state version: ${version}`, "version", version, "2");
+        this.name = "UnsupportedVersionError";
+        this.version = version;
+    }
+}
+
+class TryDeserializeTaskError extends TryDeserializeError {
+    /**
+     * @param {string} message
+     * @param {string} field
+     * @param {unknown} value
+     * @param {string} expectedType
+     * @param {number} index
+     */
+    constructor(message, field, value, expectedType, index) {
+        super(message, field, value, expectedType);
+        this.name = "TryDeserializeTaskError";
+        this.taskIndex = index;
+    }
+}
+
+class TaskMissingFieldError extends TryDeserializeTaskError {
+    /**
+     * @param {string} field
+     * @param {number} index
+     */
+    constructor(field, index) {
+        super(`Missing required field '${field}' in task`, field, undefined, "any", index);
+        this.name = "TaskMissingFieldError";
+    }
+}
+
+class TaskInvalidTypeError extends TryDeserializeTaskError {
+    /**
+     * @param {string} field
+     * @param {unknown} value
+     * @param {string} expectedType
+     * @param {number} index
+     */
+    constructor(field, value, expectedType, index) {
+        const actualType = Array.isArray(value) ? "array" : typeof value;
+        super(`Invalid type for field '${field}': expected ${expectedType}, got ${actualType}`, field, value, expectedType, index);
+        this.name = "TaskInvalidTypeError";
+        this.actualType = actualType;
+    }
+}
+
+class TaskInvalidValueError extends TryDeserializeTaskError {
+    /**
+     * @param {string} field
+     * @param {unknown} value
+     * @param {string} expectedType
+     * @param {number} index
+     */
+    constructor(field, value, expectedType, index) {
+        super(`Invalid value for field '${field}'`, field, value, expectedType, index);
+        this.name = "TaskInvalidValueError";
+    }
+}
+
+/**
+ * @param {unknown} object
+ * @returns {object is TryDeserializeError}
+ */
+function isTryDeserializeError(object) {
+    return object instanceof TryDeserializeError;
+}
+
+/**
+ * @param {unknown} object
+ * @returns {object is TryDeserializeTaskError}
+ */
+function isTryDeserializeTaskError(object) {
+    return object instanceof TryDeserializeTaskError;
+}
+
+module.exports = {
+    TryDeserializeError,
+    MissingFieldError,
+    InvalidTypeError,
+    InvalidStructureError,
+    TasksFieldInvalidStructureError,
+    UnsupportedVersionError,
+    TryDeserializeTaskError,
+    TaskMissingFieldError,
+    TaskInvalidTypeError,
+    TaskInvalidValueError,
+    isTryDeserializeError,
+    isTryDeserializeTaskError,
+};

--- a/backend/src/runtime_state_storage/types.js
+++ b/backend/src/runtime_state_storage/types.js
@@ -28,7 +28,21 @@
 /**
  * Runtime state stored in the persistent storage.
  * @typedef {object} RuntimeState
+ * @property {number} version - Schema version
  * @property {import('../datetime').DateTime} startTime - When the Volodyslav process started
+ * @property {TaskRecord[]} tasks - Persisted task records
+ */
+
+/**
+ * A record describing a scheduled task persisted in runtime state.
+ * @typedef {object} TaskRecord
+ * @property {string} name - Task name (unique)
+ * @property {string} cronExpression - Cron expression string
+ * @property {number} retryDelayMs - Retry delay in milliseconds
+ * @property {import('../datetime').DateTime} [lastSuccessTime]
+ * @property {import('../datetime').DateTime} [lastFailureTime]
+ * @property {import('../datetime').DateTime} [lastAttemptTime]
+ * @property {import('../datetime').DateTime} [pendingRetryUntil]
  */
 
 /**

--- a/backend/tests/runtime_state_storage_class.test.js
+++ b/backend/tests/runtime_state_storage_class.test.js
@@ -3,6 +3,7 @@
  */
 
 const { make: makeRuntimeStateStorage } = require("../src/runtime_state_storage/class");
+const { RUNTIME_STATE_VERSION } = require("../src/runtime_state_storage/structure");
 const { getMockedRootCapabilities } = require("./spies");
 const { stubEnvironment, stubLogger, stubDatetime } = require("./stubs");
 
@@ -26,7 +27,7 @@ describe("runtime_state_storage/class", () => {
         const capabilities = getTestCapabilities();
         const storage = makeRuntimeStateStorage(capabilities);
         const startTime = capabilities.datetime.now();
-        const state = { startTime };
+        const state = { version: RUNTIME_STATE_VERSION, startTime, tasks: [] };
 
         storage.setState(state);
         expect(storage.getNewState()).toEqual(state);
@@ -110,7 +111,9 @@ describe("runtime_state_storage/class", () => {
         storage.stateFile = mockFile;
         
         const validState = {
-            startTime: "2025-01-01T10:00:00.000Z"
+            version: RUNTIME_STATE_VERSION,
+            startTime: "2025-01-01T10:00:00.000Z",
+            tasks: []
         };
         
         capabilities.reader.readFileAsText = jest.fn().mockResolvedValue(
@@ -119,7 +122,9 @@ describe("runtime_state_storage/class", () => {
         
         const result = await storage.getExistingState();
         expect(result).toMatchObject({
-            startTime: expect.any(Object)
+            version: RUNTIME_STATE_VERSION,
+            startTime: expect.any(Object),
+            tasks: []
         });
     });
 
@@ -128,7 +133,7 @@ describe("runtime_state_storage/class", () => {
         const storage = makeRuntimeStateStorage(capabilities);
         
         const startTime = capabilities.datetime.now();
-        const state = { startTime };
+        const state = { version: RUNTIME_STATE_VERSION, startTime, tasks: [] };
         storage.setState(state);
         
         const result = await storage.getCurrentState();
@@ -144,7 +149,9 @@ describe("runtime_state_storage/class", () => {
         storage.stateFile = mockFile;
         
         const existingState = {
-            startTime: "2025-01-01T10:00:00.000Z"
+            version: RUNTIME_STATE_VERSION,
+            startTime: "2025-01-01T10:00:00.000Z",
+            tasks: []
         };
         
         capabilities.reader.readFileAsText = jest.fn().mockResolvedValue(
@@ -153,7 +160,9 @@ describe("runtime_state_storage/class", () => {
         
         const result = await storage.getCurrentState();
         expect(result).toMatchObject({
-            startTime: expect.any(Object)
+            version: RUNTIME_STATE_VERSION,
+            startTime: expect.any(Object),
+            tasks: []
         });
     });
 
@@ -166,7 +175,9 @@ describe("runtime_state_storage/class", () => {
         
         const result = await storage.getCurrentState();
         expect(result).toMatchObject({
-            startTime: expect.any(Object)
+            version: RUNTIME_STATE_VERSION,
+            startTime: expect.any(Object),
+            tasks: []
         });
     });
 });

--- a/backend/tests/runtime_state_storage_structure.test.js
+++ b/backend/tests/runtime_state_storage_structure.test.js
@@ -15,13 +15,17 @@ describe("runtime_state_storage/structure", () => {
     describe("tryDeserialize", () => {
         test("deserializes valid runtime state object", () => {
             const validObject = {
-                startTime: "2025-01-01T10:00:00.000Z"
+                version: structure.RUNTIME_STATE_VERSION,
+                startTime: "2025-01-01T10:00:00.000Z",
+                tasks: []
             };
 
             const result = structure.tryDeserialize(validObject);
             expect(structure.isTryDeserializeError(result)).toBe(false);
-            expect(result).toMatchObject({
-                startTime: expect.any(Object)
+            expect(result.state).toMatchObject({
+                version: structure.RUNTIME_STATE_VERSION,
+                startTime: expect.any(Object),
+                tasks: []
             });
         });
 
@@ -47,9 +51,7 @@ describe("runtime_state_storage/structure", () => {
         });
 
         test("returns error for non-string startTime", () => {
-            const invalidObject = {
-                startTime: 123
-            };
+            const invalidObject = { startTime: 123 };
             const result = structure.tryDeserialize(invalidObject);
             expect(structure.isTryDeserializeError(result)).toBe(true);
             expect(result).toBeInstanceOf(structure.InvalidTypeError);
@@ -58,9 +60,7 @@ describe("runtime_state_storage/structure", () => {
         });
 
         test("returns error for invalid ISO string", () => {
-            const invalidObject = {
-                startTime: "not-a-valid-date"
-            };
+            const invalidObject = { startTime: "not-a-valid-date" };
             const result = structure.tryDeserialize(invalidObject);
             expect(structure.isTryDeserializeError(result)).toBe(true);
             expect(result).toBeInstanceOf(structure.InvalidTypeError);
@@ -72,11 +72,13 @@ describe("runtime_state_storage/structure", () => {
     describe("serialize", () => {
         test("serializes runtime state to plain object", () => {
             const startTime = datetime.fromISOString("2025-01-01T10:00:00.000Z");
-            const state = { startTime };
+            const state = { version: structure.RUNTIME_STATE_VERSION, startTime, tasks: [] };
 
             const result = structure.serialize(state);
             expect(result).toEqual({
-                startTime: "2025-01-01T10:00:00.000Z"
+                version: structure.RUNTIME_STATE_VERSION,
+                startTime: "2025-01-01T10:00:00.000Z",
+                tasks: []
             });
         });
     });
@@ -88,7 +90,9 @@ describe("runtime_state_storage/structure", () => {
 
             const result = structure.makeDefault(datetime);
             expect(result).toEqual({
-                startTime: now
+                version: structure.RUNTIME_STATE_VERSION,
+                startTime: now,
+                tasks: []
             });
             expect(datetime.now).toHaveBeenCalledTimes(1);
         });

--- a/backend/tests/runtime_state_storage_transactions.test.js
+++ b/backend/tests/runtime_state_storage_transactions.test.js
@@ -3,6 +3,7 @@
  */
 
 const { transaction } = require("../src/runtime_state_storage");
+const { RUNTIME_STATE_VERSION } = require("../src/runtime_state_storage/structure");
 const { getMockedRootCapabilities } = require("./spies");
 const { stubEnvironment, stubLogger, stubDatetime } = require("./stubs");
 
@@ -23,7 +24,7 @@ describe("runtime_state_storage/transaction", () => {
         const capabilities = getTestCapabilities();
 
         const startTime = capabilities.datetime.fromISOString("2025-01-01T10:00:00.000Z");
-        const testState = { startTime };
+        const testState = { version: RUNTIME_STATE_VERSION, startTime, tasks: [] };
 
         await transaction(capabilities, async (runtimeStateStorage) => {
             runtimeStateStorage.setState(testState);
@@ -33,7 +34,9 @@ describe("runtime_state_storage/transaction", () => {
         await transaction(capabilities, async (runtimeStateStorage) => {
             const storedState = await runtimeStateStorage.getExistingState();
             expect(storedState).toMatchObject({
-                startTime: expect.any(Object)
+                version: RUNTIME_STATE_VERSION,
+                startTime: expect.any(Object),
+                tasks: []
             });
             // Check that the stored time matches what we set
             expect(capabilities.datetime.toISOString(storedState.startTime)).toBe("2025-01-01T10:00:00.000Z");
@@ -47,7 +50,7 @@ describe("runtime_state_storage/transaction", () => {
         capabilities.git.call = jest.fn().mockRejectedValue(new Error("Git operation failed"));
 
         const startTime = capabilities.datetime.now();
-        const testState = { startTime };
+        const testState = { version: RUNTIME_STATE_VERSION, startTime, tasks: [] };
 
         await expect(
             transaction(capabilities, async (runtimeStateStorage) => {
@@ -73,7 +76,7 @@ describe("runtime_state_storage/transaction", () => {
 
         const result = await transaction(capabilities, async (runtimeStateStorage) => {
             const startTime = capabilities.datetime.now();
-            runtimeStateStorage.setState({ startTime });
+            runtimeStateStorage.setState({ version: RUNTIME_STATE_VERSION, startTime, tasks: [] });
             return expectedResult;
         });
 
@@ -84,7 +87,7 @@ describe("runtime_state_storage/transaction", () => {
         const capabilities = getTestCapabilities();
 
         const startTime = capabilities.datetime.fromISOString("2025-01-01T10:00:00.000Z");
-        const initialState = { startTime };
+        const initialState = { version: RUNTIME_STATE_VERSION, startTime, tasks: [] };
 
         // First transaction: set initial state
         await transaction(capabilities, async (runtimeStateStorage) => {
@@ -98,7 +101,9 @@ describe("runtime_state_storage/transaction", () => {
         });
 
         expect(result).toMatchObject({
-            startTime: expect.any(Object)
+            version: RUNTIME_STATE_VERSION,
+            startTime: expect.any(Object),
+            tasks: []
         });
         expect(capabilities.datetime.toISOString(result.startTime)).toBe("2025-01-01T10:00:00.000Z");
     });
@@ -114,7 +119,9 @@ describe("runtime_state_storage/transaction", () => {
 
         expect(result.existing).toBeNull();
         expect(result.current).toMatchObject({
-            startTime: expect.any(Object)
+            version: RUNTIME_STATE_VERSION,
+            startTime: expect.any(Object),
+            tasks: []
         });
     });
 
@@ -126,12 +133,12 @@ describe("runtime_state_storage/transaction", () => {
 
         // Set initial state
         await transaction(capabilities, async (runtimeStateStorage) => {
-            runtimeStateStorage.setState({ startTime: initialTime });
+            runtimeStateStorage.setState({ version: RUNTIME_STATE_VERSION, startTime: initialTime, tasks: [] });
         });
 
         // Update state
         await transaction(capabilities, async (runtimeStateStorage) => {
-            runtimeStateStorage.setState({ startTime: updatedTime });
+            runtimeStateStorage.setState({ version: RUNTIME_STATE_VERSION, startTime: updatedTime, tasks: [] });
         });
 
         // Verify update
@@ -150,12 +157,12 @@ describe("runtime_state_storage/transaction", () => {
 
         // Set initial state
         await transaction(capabilities, async (runtimeStateStorage) => {
-            runtimeStateStorage.setState({ startTime: existingTime });
+            runtimeStateStorage.setState({ version: RUNTIME_STATE_VERSION, startTime: existingTime, tasks: [] });
         });
 
         // In new transaction, getCurrentState should return new state when set
         const result = await transaction(capabilities, async (runtimeStateStorage) => {
-            runtimeStateStorage.setState({ startTime: newTime });
+            runtimeStateStorage.setState({ version: RUNTIME_STATE_VERSION, startTime: newTime, tasks: [] });
             return await runtimeStateStorage.getCurrentState();
         });
 


### PR DESCRIPTION
## Summary
- add versioned runtime state schema with persisted tasks
- include task-specific deserialization errors and validation helpers
- update runtime state storage tests for new schema
- centralize runtime state schema version in a dedicated constant

## Testing
- `npm test`
- `npm run static-analysis`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897e8095bb4832e8f20b525a2dcb6d6