### PR TITLE
Use git stubs in scheduler tests to restore stability

### DIFF
--- a/backend/tests/failure_retry_persistence.test.js
+++ b/backend/tests/failure_retry_persistence.test.js
@@ -5,7 +5,7 @@
 const { makePollingScheduler } = require("../src/cron/polling_scheduler");
 const { fromMilliseconds } = require("../src/time_duration");
 const { getMockedRootCapabilities } = require("./spies");
-const { stubEnvironment, stubLogger, stubDatetime, stubSleeper } = require("./stubs");
+const { stubEnvironment, stubLogger, stubDatetime, stubSleeper, stubGit } = require("./stubs");
 
 function getTestCapabilities() {
     const capabilities = getMockedRootCapabilities();
@@ -13,6 +13,7 @@ function getTestCapabilities() {
     stubLogger(capabilities);
     stubDatetime(capabilities);
     stubSleeper(capabilities);
+    stubGit(capabilities);
     return capabilities;
 }
 

--- a/backend/tests/missed_cron_catchup_persistence.test.js
+++ b/backend/tests/missed_cron_catchup_persistence.test.js
@@ -6,13 +6,14 @@ const { makePollingScheduler } = require("../src/cron/polling_scheduler");
 const { transaction } = require("../src/runtime_state_storage");
 const { fromMilliseconds } = require("../src/time_duration");
 const { getMockedRootCapabilities } = require("./spies");
-const { stubEnvironment, stubLogger, stubDatetime } = require("./stubs");
+const { stubEnvironment, stubLogger, stubDatetime, stubGit } = require("./stubs");
 
 function getTestCapabilities() {
     const capabilities = getMockedRootCapabilities();
     stubEnvironment(capabilities);
     stubLogger(capabilities);
     stubDatetime(capabilities);
+    stubGit(capabilities);
     return capabilities;
 }
 

--- a/backend/tests/polling_scheduler_algorithm_edge_cases.test.js
+++ b/backend/tests/polling_scheduler_algorithm_edge_cases.test.js
@@ -6,7 +6,7 @@
 const { makePollingScheduler } = require("../src/cron/polling_scheduler");
 const { fromMilliseconds } = require("../src/time_duration");
 const { getMockedRootCapabilities } = require("./spies");
-const { stubEnvironment, stubLogger, stubDatetime, stubSleeper } = require("./stubs");
+const { stubEnvironment, stubLogger, stubDatetime, stubSleeper, stubGit } = require("./stubs");
 
 function caps() {
     const capabilities = getMockedRootCapabilities();
@@ -14,6 +14,7 @@ function caps() {
     stubLogger(capabilities);
     stubDatetime(capabilities);
     stubSleeper(capabilities);
+    stubGit(capabilities);
     return capabilities;
 }
 

--- a/backend/tests/polling_scheduler_cancel.test.js
+++ b/backend/tests/polling_scheduler_cancel.test.js
@@ -1,13 +1,14 @@
 const { make } = require("../src/cron");
 const { fromMilliseconds } = require("../src/time_duration");
 const { getMockedRootCapabilities } = require("./spies");
-const { stubEnvironment, stubLogger, stubDatetime } = require("./stubs");
+const { stubEnvironment, stubLogger, stubDatetime, stubGit } = require("./stubs");
 
 function caps() {
     const capabilities = getMockedRootCapabilities();
     stubEnvironment(capabilities);
     stubLogger(capabilities);
     stubDatetime(capabilities);
+    stubGit(capabilities);
     return capabilities;
 }
 

--- a/backend/tests/polling_scheduler_dst_transitions.test.js
+++ b/backend/tests/polling_scheduler_dst_transitions.test.js
@@ -9,7 +9,7 @@
 const { makePollingScheduler } = require("../src/cron/polling_scheduler");
 const { fromMilliseconds } = require("../src/time_duration");
 const { getMockedRootCapabilities } = require("./spies");
-const { stubEnvironment, stubLogger, stubDatetime, stubSleeper } = require("./stubs");
+const { stubEnvironment, stubLogger, stubDatetime, stubSleeper, stubGit } = require("./stubs");
 
 function caps() {
     const capabilities = getMockedRootCapabilities();
@@ -17,6 +17,7 @@ function caps() {
     stubLogger(capabilities);
     stubDatetime(capabilities);
     stubSleeper(capabilities);
+    stubGit(capabilities);
     return capabilities;
 }
 

--- a/backend/tests/polling_scheduler_edge_cases_comprehensive.test.js
+++ b/backend/tests/polling_scheduler_edge_cases_comprehensive.test.js
@@ -6,7 +6,7 @@
 const { makePollingScheduler } = require("../src/cron/polling_scheduler");
 const { fromMilliseconds } = require("../src/time_duration");
 const { getMockedRootCapabilities } = require("./spies");
-const { stubEnvironment, stubLogger, stubDatetime, stubSleeper } = require("./stubs");
+const { stubEnvironment, stubLogger, stubDatetime, stubSleeper, stubGit } = require("./stubs");
 
 function caps() {
     const capabilities = getMockedRootCapabilities();
@@ -14,6 +14,7 @@ function caps() {
     stubLogger(capabilities);
     stubDatetime(capabilities);
     stubSleeper(capabilities);
+    stubGit(capabilities);
     return capabilities;
 }
 

--- a/backend/tests/polling_scheduler_frequency_validation.test.js
+++ b/backend/tests/polling_scheduler_frequency_validation.test.js
@@ -6,13 +6,14 @@
 const { makePollingScheduler } = require("../src/cron/polling_scheduler");
 const { fromMilliseconds } = require("../src/time_duration");
 const { getMockedRootCapabilities } = require("./spies");
-const { stubEnvironment, stubLogger, stubDatetime } = require("./stubs");
+const { stubEnvironment, stubLogger, stubDatetime, stubGit } = require("./stubs");
 
 function caps() {
     const capabilities = getMockedRootCapabilities();
     stubEnvironment(capabilities);
     stubLogger(capabilities);
     stubDatetime(capabilities);
+    stubGit(capabilities);
     return capabilities;
 }
 

--- a/backend/tests/polling_scheduler_integration_edge_cases.test.js
+++ b/backend/tests/polling_scheduler_integration_edge_cases.test.js
@@ -6,7 +6,7 @@
 const { makePollingScheduler } = require("../src/cron/polling_scheduler");
 const { fromMilliseconds } = require("../src/time_duration");
 const { getMockedRootCapabilities } = require("./spies");
-const { stubEnvironment, stubLogger, stubDatetime, stubSleeper } = require("./stubs");
+const { stubEnvironment, stubLogger, stubDatetime, stubSleeper, stubGit } = require("./stubs");
 
 function caps() {
     const capabilities = getMockedRootCapabilities();
@@ -14,6 +14,7 @@ function caps() {
     stubLogger(capabilities);
     stubDatetime(capabilities);
     stubSleeper(capabilities);
+    stubGit(capabilities);
     return capabilities;
 }
 

--- a/backend/tests/polling_scheduler_parallel_execution.test.js
+++ b/backend/tests/polling_scheduler_parallel_execution.test.js
@@ -6,7 +6,7 @@
 const { makePollingScheduler } = require("../src/cron/polling_scheduler");
 const { fromMilliseconds } = require("../src/time_duration");
 const { getMockedRootCapabilities } = require("./spies");
-const { stubEnvironment, stubLogger, stubDatetime, stubSleeper } = require("./stubs");
+const { stubEnvironment, stubLogger, stubDatetime, stubSleeper, stubGit } = require("./stubs");
 
 function caps() {
     const capabilities = getMockedRootCapabilities();
@@ -14,6 +14,7 @@ function caps() {
     stubLogger(capabilities);
     stubDatetime(capabilities);
     stubSleeper(capabilities);
+    stubGit(capabilities);
     return capabilities;
 }
 

--- a/backend/tests/polling_scheduler_persistence_errors.test.js
+++ b/backend/tests/polling_scheduler_persistence_errors.test.js
@@ -7,7 +7,7 @@
 const { makePollingScheduler } = require("../src/cron/polling_scheduler");
 const { fromMilliseconds } = require("../src/time_duration");
 const { getMockedRootCapabilities } = require("./spies");
-const { stubEnvironment, stubLogger, stubDatetime, stubSleeper } = require("./stubs");
+const { stubEnvironment, stubLogger, stubDatetime, stubSleeper, stubGit } = require("./stubs");
 
 function caps() {
     const capabilities = getMockedRootCapabilities();
@@ -15,6 +15,7 @@ function caps() {
     stubLogger(capabilities);
     stubDatetime(capabilities);
     stubSleeper(capabilities);
+    stubGit(capabilities);
     return capabilities;
 }
 

--- a/backend/tests/polling_scheduler_precedence_verification.test.js
+++ b/backend/tests/polling_scheduler_precedence_verification.test.js
@@ -6,13 +6,14 @@
 const { makePollingScheduler } = require("../src/cron/polling_scheduler");
 const { fromMilliseconds } = require("../src/time_duration");
 const { getMockedRootCapabilities } = require("./spies");
-const { stubEnvironment, stubLogger, stubDatetime } = require("./stubs");
+const { stubEnvironment, stubLogger, stubDatetime, stubGit } = require("./stubs");
 
 function caps() {
     const capabilities = getMockedRootCapabilities();
     stubEnvironment(capabilities);
     stubLogger(capabilities);
     stubDatetime(capabilities);
+    stubGit(capabilities);
     return capabilities;
 }
 

--- a/backend/tests/polling_scheduler_reentrant_protection.test.js
+++ b/backend/tests/polling_scheduler_reentrant_protection.test.js
@@ -6,7 +6,7 @@
 const { makePollingScheduler } = require("../src/cron/polling_scheduler");
 const { fromMilliseconds } = require("../src/time_duration");
 const { getMockedRootCapabilities } = require("./spies");
-const { stubEnvironment, stubLogger, stubDatetime, stubSleeper } = require("./stubs");
+const { stubEnvironment, stubLogger, stubDatetime, stubSleeper, stubGit } = require("./stubs");
 
 function caps() {
     const capabilities = getMockedRootCapabilities();
@@ -14,6 +14,7 @@ function caps() {
     stubLogger(capabilities);
     stubDatetime(capabilities);
     stubSleeper(capabilities);
+    stubGit(capabilities);
     return capabilities;
 }
 

--- a/backend/tests/polling_scheduler_retry.test.js
+++ b/backend/tests/polling_scheduler_retry.test.js
@@ -1,7 +1,7 @@
 const { make } = require("../src/cron");
 const { fromMilliseconds } = require("../src/time_duration");
 const { getMockedRootCapabilities } = require("./spies");
-const { stubEnvironment, stubLogger, stubDatetime, stubSleeper } = require("./stubs");
+const { stubEnvironment, stubLogger, stubDatetime, stubSleeper, stubGit } = require("./stubs");
 
 function caps() {
     const capabilities = getMockedRootCapabilities();
@@ -9,6 +9,7 @@ function caps() {
     stubLogger(capabilities);
     stubDatetime(capabilities);
     stubSleeper(capabilities);
+    stubGit(capabilities);
     return capabilities;
 }
 

--- a/backend/tests/polling_scheduler_retry_semantics.test.js
+++ b/backend/tests/polling_scheduler_retry_semantics.test.js
@@ -6,13 +6,14 @@
 const { makePollingScheduler } = require("../src/cron/polling_scheduler");
 const { fromMilliseconds } = require("../src/time_duration");
 const { getMockedRootCapabilities } = require("./spies");
-const { stubEnvironment, stubLogger, stubDatetime } = require("./stubs");
+const { stubEnvironment, stubLogger, stubDatetime, stubGit } = require("./stubs");
 
 function caps() {
     const capabilities = getMockedRootCapabilities();
     stubEnvironment(capabilities);
     stubLogger(capabilities);
     stubDatetime(capabilities);
+    stubGit(capabilities);
     return capabilities;
 }
 

--- a/backend/tests/polling_scheduler_runs_cron.test.js
+++ b/backend/tests/polling_scheduler_runs_cron.test.js
@@ -1,13 +1,14 @@
 const { make } = require("../src/cron");
 const { fromMilliseconds } = require("../src/time_duration");
 const { getMockedRootCapabilities } = require("./spies");
-const { stubEnvironment, stubLogger, stubDatetime } = require("./stubs");
+const { stubEnvironment, stubLogger, stubDatetime, stubGit } = require("./stubs");
 
 function createCapabilities() {
     const capabilities = getMockedRootCapabilities();
     stubEnvironment(capabilities);
     stubLogger(capabilities);
     stubDatetime(capabilities);
+    stubGit(capabilities);
     return capabilities;
 }
 

--- a/backend/tests/polling_scheduler_scanning_optimization.test.js
+++ b/backend/tests/polling_scheduler_scanning_optimization.test.js
@@ -6,7 +6,7 @@
 const { makePollingScheduler } = require("../src/cron/polling_scheduler");
 const { fromMilliseconds } = require("../src/time_duration");
 const { getMockedRootCapabilities } = require("./spies");
-const { stubEnvironment, stubLogger, stubDatetime, stubSleeper } = require("./stubs");
+const { stubEnvironment, stubLogger, stubDatetime, stubSleeper, stubGit } = require("./stubs");
 
 function caps() {
     const capabilities = getMockedRootCapabilities();
@@ -14,6 +14,7 @@ function caps() {
     stubLogger(capabilities);
     stubDatetime(capabilities);
     stubSleeper(capabilities);
+    stubGit(capabilities);
     return capabilities;
 }
 

--- a/backend/tests/polling_scheduler_skip_running.test.js
+++ b/backend/tests/polling_scheduler_skip_running.test.js
@@ -1,13 +1,14 @@
 const { make } = require("../src/cron");
 const { fromMilliseconds } = require("../src/time_duration");
 const { getMockedRootCapabilities } = require("./spies");
-const { stubEnvironment, stubLogger, stubDatetime } = require("./stubs");
+const { stubEnvironment, stubLogger, stubDatetime, stubGit } = require("./stubs");
 
 function caps() {
     const capabilities = getMockedRootCapabilities();
     stubEnvironment(capabilities);
     stubLogger(capabilities);
     stubDatetime(capabilities);
+    stubGit(capabilities);
     return capabilities;
 }
 

--- a/backend/tests/polling_scheduler_state_management_edge_cases.test.js
+++ b/backend/tests/polling_scheduler_state_management_edge_cases.test.js
@@ -6,7 +6,7 @@
 const { makePollingScheduler } = require("../src/cron/polling_scheduler");
 const { fromMilliseconds } = require("../src/time_duration");
 const { getMockedRootCapabilities } = require("./spies");
-const { stubEnvironment, stubLogger, stubDatetime, stubSleeper } = require("./stubs");
+const { stubEnvironment, stubLogger, stubDatetime, stubSleeper, stubGit } = require("./stubs");
 
 function caps() {
     const capabilities = getMockedRootCapabilities();
@@ -14,6 +14,7 @@ function caps() {
     stubLogger(capabilities);
     stubDatetime(capabilities);
     stubSleeper(capabilities);
+    stubGit(capabilities);
     return capabilities;
 }
 

--- a/backend/tests/polling_scheduler_validate_and_gettasks.test.js
+++ b/backend/tests/polling_scheduler_validate_and_gettasks.test.js
@@ -1,13 +1,14 @@
 const { make, validate, ScheduleInvalidNameError } = require("../src/cron");
 const { fromMilliseconds, COMMON } = require("../src/time_duration");
 const { getMockedRootCapabilities } = require("./spies");
-const { stubEnvironment, stubLogger, stubDatetime } = require("./stubs");
+const { stubEnvironment, stubLogger, stubDatetime, stubGit } = require("./stubs");
 
 function caps() {
     const capabilities = getMockedRootCapabilities();
     stubEnvironment(capabilities);
     stubLogger(capabilities);
     stubDatetime(capabilities);
+    stubGit(capabilities);
     return capabilities;
 }
 

--- a/backend/tests/runtime_state_migration.test.js
+++ b/backend/tests/runtime_state_migration.test.js
@@ -35,7 +35,7 @@ describe("runtime state migration", () => {
         
         // Schedule a task to trigger state loading and persistence
         const retryDelay = fromMilliseconds(1000);
-        scheduler.schedule("test-task", "0 * * * *", () => {}, retryDelay);
+        await scheduler.schedule("test-task", "0 * * * *", () => {}, retryDelay);
         
         // Allow sufficient time for async operations to complete
         await new Promise(resolve => setTimeout(resolve, 200));

--- a/backend/tests/spies.js
+++ b/backend/tests/spies.js
@@ -2,8 +2,9 @@ const rootCapabilities = require("../src/capabilities/root");
 
 /**
  * Recursively wraps functions in an object with jest.fn spies, preserving behavior.
- * @param {*} real - The real capabilities object or function
- * @returns {*} - A mocked version with same shape where functions are replaced by jest spies
+ * @template T
+ * @param {T} real - The real capabilities object or function
+ * @returns {T} - A mocked version with same shape where functions are replaced by jest spies
  */
 function mockCapabilities(real) {
     if (typeof real === "function") {

--- a/backend/tests/spies.js
+++ b/backend/tests/spies.js
@@ -11,9 +11,13 @@ function mockCapabilities(real) {
         return jest.fn((...args) => real(...args));
     }
     if (real && typeof real === "object") {
+        const mocked = Array.isArray(real)
+            ? []
+            : Object.create(Object.getPrototypeOf(real));
         for (const key of Object.keys(real)) {
-            real[key] = mockCapabilities(real[key]);
+            mocked[key] = mockCapabilities(real[key]);
         }
+        return mocked;
     }
 
     return real;

--- a/backend/tests/spies.js
+++ b/backend/tests/spies.js
@@ -6,21 +6,15 @@ const rootCapabilities = require("../src/capabilities/root");
  * @returns {*} - A mocked version with same shape where functions are replaced by jest spies
  */
 function mockCapabilities(real) {
-    // Wrap standalone functions with jest.fn to spy on calls
     if (typeof real === "function") {
         return jest.fn((...args) => real(...args));
     }
     if (real && typeof real === "object") {
-        // Preserve prototype so instances keep their type
-        const mocked = Array.isArray(real)
-            ? []
-            : Object.create(Object.getPrototypeOf(real));
         for (const key of Object.keys(real)) {
-            mocked[key] = mockCapabilities(real[key]);
+            real[key] = mockCapabilities(real[key]);
         }
-        return mocked;
     }
-    // Return primitives unchanged
+
     return real;
 }
 

--- a/backend/tests/stubs.js
+++ b/backend/tests/stubs.js
@@ -122,6 +122,20 @@ function stubDatetime(capabilities) {
     };
 }
 
+/**
+ * Stubs git-related capabilities to avoid real subprocess execution.
+ */
+function stubGit(capabilities) {
+    if (capabilities.git) {
+        capabilities.git.call = jest.fn().mockResolvedValue({ stdout: "", stderr: "" });
+        capabilities.git.ensureAvailable = jest.fn().mockResolvedValue(undefined);
+    }
+    if (capabilities.volodyslavDailyTasks) {
+        capabilities.volodyslavDailyTasks.call = jest.fn().mockResolvedValue({ stdout: "", stderr: "" });
+        capabilities.volodyslavDailyTasks.ensureAvailable = jest.fn().mockResolvedValue(undefined);
+    }
+}
+
 module.exports = {
     stubEnvironment,
     stubLogger,
@@ -131,4 +145,5 @@ module.exports = {
     stubSleeper,
     stubDatetime,
     stubEventLogRepository,
+    stubGit,
 };


### PR DESCRIPTION
## Summary
- avoid mutating real capabilities by cloning in `mockCapabilities`
- add reusable `stubGit` helper
- use `stubGit` in polling scheduler tests and await runtime state migration scheduling

## Testing
- `npm test`
- `npm run static-analysis`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a677c70d24832ea103b91aa1f756bc