### PR TITLE
Add failing cron regression test

### DIFF
--- a/backend/tests/scheduler_stories.test.js
+++ b/backend/tests/scheduler_stories.test.js
@@ -7,6 +7,8 @@ const { Duration } = require("luxon");
 const { getMockedRootCapabilities } = require("./spies");
 const { stubEnvironment, stubLogger, stubDatetime, stubSleeper, getDatetimeControl, stubRuntimeStateStorage, stubScheduler, getSchedulerControl } = require("./stubs");
 const { fromISOString, fromHours, fromMinutes, fromMilliseconds, fromDays } = require("../src/datetime");
+const { parseCronExpression } = require("../src/scheduler/expression");
+const { getMostRecentExecution, getNextExecution } = require("../src/scheduler/calculator");
 
 function getTestCapabilities() {
     const capabilities = getMockedRootCapabilities();
@@ -1109,5 +1111,14 @@ describe("scheduler stories", () => {
         expect(slowTask.mock.calls.length).toEqual(2); // Both can execute since slow task only takes 1 second
 
         await capabilities.scheduler.stop();
+    });
+
+    test.failing("should compute next execution correctly after retrieving previous execution", () => {
+        const expr = parseCronExpression("0 0 10,20 * *");
+        const originForPrevious = fromISOString("2021-04-01T00:00:00.000Z");
+        getMostRecentExecution(expr, originForPrevious);
+        const origin = fromISOString("2021-03-01T00:00:00.000Z");
+        const next = getNextExecution(expr, origin);
+        expect(next.toISOString()).toBe("2021-03-10T00:00:00.000Z");
     });
 });


### PR DESCRIPTION
## Summary
- reproduce cron caching bug where `getMostRecentExecution` reverses cached valid days
- add `test.failing` verifying `getNextExecution` returns wrong day after previous calculation

## Testing
- `npx jest backend/tests/scheduler_stories.test.js -t "should compute next execution correctly after retrieving previous execution"`
- `npm run static-analysis`
- `npm test` *(fails: event_log_storage_entries, event_log_storage.transactions, schedule.tasks timeout)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc54a2f028832eb3433fb0ee1c6cdb