### PR TITLE
Add failing test for non-integer cron field values

### DIFF
--- a/backend/tests/scheduler_stories.test.js
+++ b/backend/tests/scheduler_stories.test.js
@@ -71,6 +71,22 @@ describe("scheduler stories", () => {
         await capabilities.scheduler.stop();
     });
 
+    test.failing("should reject non-integer cron field values", async () => {
+        const capabilities = getTestCapabilities();
+        const timeControl = getDatetimeControl(capabilities);
+        const schedulerControl = getSchedulerControl(capabilities);
+        const retryDelay = Duration.fromMillis(5000);
+        timeControl.setDateTime(fromISOString("2021-01-01T00:00:00.000Z"));
+        schedulerControl.setPollingInterval(fromMilliseconds(1));
+        try {
+            await expect(capabilities.scheduler.initialize([
+                ["invalid-decimal", "1.5 * * * *", jest.fn(), retryDelay]
+            ])).rejects.toThrow();
+        } finally {
+            await capabilities.scheduler.stop();
+        }
+    });
+
     test("should handle multiple tasks with different schedules", async () => {
         const capabilities = getTestCapabilities();
         const timeControl = getDatetimeControl(capabilities);


### PR DESCRIPTION
## Summary
- add failing test demonstrating scheduler accepts cron expressions with decimal values

## Testing
- `npx jest backend/tests/scheduler_stories.test.js --testNamePattern="should reject non-integer cron field values"`
- `npm test` *(fails: backend/src/logger/log_methods.js(46,69): error TS2345)*
- `npm run static-analysis` *(fails: backend/src/logger/log_methods.js(46,69): error TS2345)*
- `npm run build` *(fails: backend/src/logger/log_methods.js(46,69): error TS2345)*


------
https://chatgpt.com/codex/tasks/task_e_68bc5498eb24832ebf75ea01944d0366