### PR TITLE
test: document leading zero cron bug

### DIFF
--- a/backend/tests/scheduler_stories.test.js
+++ b/backend/tests/scheduler_stories.test.js
@@ -1137,4 +1137,8 @@ describe("scheduler stories", () => {
         const next = getNextExecution(expr, fromISOString("2021-01-01T00:00:00.000Z"));
         expect(toISOString(next)).toBe("2021-01-30T00:00:00.000Z");
     });
+
+    test.failing("should parse cron expressions with leading zeros", () => {
+        expect(() => parseCronExpression("0 0 01 * *")).not.toThrow();
+    });
 });


### PR DESCRIPTION
## Summary
- add failing scheduler story verifying cron parsing rejects leading zeros

## Testing
- `npx jest backend/tests/scheduler_stories.test.js -t "leading zeros"`
- `npm test` *(fails: Argument of type '{ error: any; }' is not assignable to parameter of type 'undefined')*
- `npm run static-analysis` *(fails: Argument of type '{ error: any; }' is not assignable to parameter of type 'undefined')*
- `npm run build` *(fails: Argument of type '{ error: any; }' is not assignable to parameter of type 'undefined')*

------
https://chatgpt.com/codex/tasks/task_e_68bd02e066d8832e8290849ca0413395