### PR TITLE
test: add failing test for previous execution error message

### DIFF
--- a/backend/tests/scheduler_stories.test.js
+++ b/backend/tests/scheduler_stories.test.js
@@ -1137,4 +1137,10 @@ describe("scheduler stories", () => {
         const next = getNextExecution(expr, fromISOString("2021-01-01T00:00:00.000Z"));
         expect(toISOString(next)).toBe("2021-01-30T00:00:00.000Z");
     });
+
+    test.failing("getMostRecentExecution uses 'previous' wording when no prior execution exists", () => {
+        const expr = parseCronExpression("0 0 31 2 *");
+        expect(() => getMostRecentExecution(expr, fromISOString("2021-03-01T00:00:00.000Z")))
+            .toThrow("No valid previous execution time found");
+    });
 });


### PR DESCRIPTION
## Summary
- add failing test ensuring getMostRecentExecution reports the correct error wording when no prior cron execution exists

## Testing
- `npx jest backend/tests/scheduler_stories.test.js`
- `npm test` *(fails: backend/src/logger/log_methods.js(46,69): error TS2345: Argument of type '{ error: any; }' is not assignable to parameter of type 'undefined'.)*
- `npm run build` *(fails: backend/src/logger/log_methods.js(46,69): error TS2345: Argument of type '{ error: any; }' is not assignable to parameter of type 'undefined'.)*

------
https://chatgpt.com/codex/tasks/task_e_68bd02e066d8832e8290849ca0413395