### PR TITLE
test: document bug in task deserialization

### DIFF
--- a/backend/tests/scheduler_stories.test.js
+++ b/backend/tests/scheduler_stories.test.js
@@ -8,6 +8,7 @@ const { getMockedRootCapabilities } = require("./spies");
 const { stubEnvironment, stubLogger, stubDatetime, stubSleeper, getDatetimeControl, stubRuntimeStateStorage, stubScheduler, getSchedulerControl } = require("./stubs");
 const { fromISOString, fromHours, fromMinutes, fromMilliseconds, fromDays, toISOString } = require("../src/datetime");
 const { parseCronExpression } = require("../src/scheduler/expression");
+const { tryDeserialize, isTaskInvalidTypeError } = require("../src/scheduler/task");
 const { getNextExecution, getMostRecentExecution } = require("../src/scheduler/calculator");
 
 function getTestCapabilities() {
@@ -1136,5 +1137,29 @@ describe("scheduler stories", () => {
         // Next execution from January 1st should be January 30th, but due to mutation becomes 31st
         const next = getNextExecution(expr, fromISOString("2021-01-01T00:00:00.000Z"));
         expect(toISOString(next)).toBe("2021-01-30T00:00:00.000Z");
+    });
+
+    test.failing("should reject null lastSuccessTime during task deserialization", () => {
+        const registrations = new Map([
+            [
+                "demo",
+                {
+                    name: "demo",
+                    parsedCron: parseCronExpression("0 * * * *"),
+                    callback: () => {},
+                    retryDelay: Duration.fromMillis(1000),
+                },
+            ],
+        ]);
+
+        const serialized = {
+            name: "demo",
+            cronExpression: "0 * * * *",
+            retryDelayMs: 1000,
+            lastSuccessTime: null,
+        };
+
+        const result = tryDeserialize(serialized, registrations);
+        expect(isTaskInvalidTypeError(result)).toBe(true);
     });
 });


### PR DESCRIPTION
## Summary
- add failing test showing task deserialization accepts null `lastSuccessTime`

## Testing
- `npm test` *(fails: event_log_storage_entries.test.js, event_log_storage.transactions.test.js timeout)*
- `npm run static-analysis`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd02e066d8832e8290849ca0413395