### PR TITLE
test: document unsatisfiable cron expression bug

### DIFF
--- a/backend/tests/scheduler_stories.test.js
+++ b/backend/tests/scheduler_stories.test.js
@@ -1180,4 +1180,20 @@ describe("scheduler stories", () => {
         const result = tryDeserialize(serialized, registrations);
         expect(isTaskInvalidTypeError(result)).toBe(true);
     });
+
+    test.failing("should reject unsatisfiable cron expressions during initialization", async () => {
+        const capabilities = getTestCapabilities();
+        const timeControl = getDatetimeControl(capabilities);
+        const schedulerControl = getSchedulerControl(capabilities);
+        timeControl.setDateTime(fromISOString("2024-01-01T00:00:00.000Z"));
+        schedulerControl.setPollingInterval(fromMilliseconds(1));
+        const retryDelay = Duration.fromMillis(5000);
+        try {
+            await expect(capabilities.scheduler.initialize([
+                ["invalid-date-task", "0 0 31 2 *", jest.fn(), retryDelay]
+            ])).rejects.toThrow();
+        } finally {
+            await capabilities.scheduler.stop();
+        }
+    });
 });


### PR DESCRIPTION
## Summary
- add failing test to document that scheduler initialization accepts impossible cron expressions like February 31st

## Testing
- `npx jest backend/tests/scheduler_stories.test.js`
- `npm test` *(fails: Argument of type '{ error: any; }' is not assignable to parameter of type 'undefined')*
- `npm run static-analysis` *(fails: Argument of type '{ error: any; }' is not assignable to parameter of type 'undefined')*
- `npm run build` *(fails: Argument of type '{ error: any; }' is not assignable to parameter of type 'undefined')*

------
https://chatgpt.com/codex/tasks/task_e_68bf02cd3c34832eb0d25ba3f70e3d35