### PR TITLE
Handle cron triggers for retrying tasks

### DIFF
--- a/backend/src/scheduler/execution/executor.js
+++ b/backend/src/scheduler/execution/executor.js
@@ -115,6 +115,7 @@ function makeTaskExecutor(capabilities, mutateTasks) {
                 const retryAt = end.advance(task.retryDelay);
                 /** @type {AwaitingRetry} */
                 const newState = {
+                    lastAttemptTime: end,
                     lastFailureTime: end,
                     pendingRetryUntil: retryAt,
                 };

--- a/backend/src/scheduler/persistence/core.js
+++ b/backend/src/scheduler/persistence/core.js
@@ -318,6 +318,7 @@ function createTaskFromDecision(decision, registration, registrations, persisted
          * @type {AwaitingRetry}
          */
         const newState = {
+            lastAttemptTime: lastMinute,
             lastFailureTime: lastMinute,
             pendingRetryUntil: lastMinute,
         };

--- a/backend/src/scheduler/task/structure.js
+++ b/backend/src/scheduler/task/structure.js
@@ -16,6 +16,7 @@
 
 /**
  * @typedef {object} AwaitingRetry
+ * @property {DateTime} lastAttemptTime - Time of the last attempt (failure)
  * @property {DateTime} lastFailureTime - Time of the last failure
  * @property {DateTime} pendingRetryUntil - Time until which the task is pending retry
  */
@@ -152,6 +153,7 @@ function createStateFromProperties(lastSuccessTime, lastFailureTime, lastAttempt
     if (pendingRetryUntil && lastFailureTime) {
         /** @type {AwaitingRetry} */
         return {
+            lastAttemptTime: lastAttemptTime ?? lastFailureTime,
             lastFailureTime,
             pendingRetryUntil
         };

--- a/backend/tests/polling_scheduler_retry_cron_regression.test.js
+++ b/backend/tests/polling_scheduler_retry_cron_regression.test.js
@@ -1,0 +1,68 @@
+const { fromISOString, fromMinutes, fromMilliseconds } = require("../src/datetime");
+const { getMockedRootCapabilities } = require("./spies");
+const {
+    stubEnvironment,
+    stubLogger,
+    stubDatetime,
+    stubSleeper,
+    stubScheduler,
+    stubRuntimeStateStorage,
+    getSchedulerControl,
+    getDatetimeControl,
+} = require("./stubs");
+
+function getTestCapabilities() {
+    const capabilities = getMockedRootCapabilities();
+    stubEnvironment(capabilities);
+    stubLogger(capabilities);
+    stubDatetime(capabilities);
+    stubSleeper(capabilities);
+    stubRuntimeStateStorage(capabilities);
+    stubScheduler(capabilities);
+    return capabilities;
+}
+
+describe("polling scheduler retry regression", () => {
+    test("cron should trigger retrying task before pending retry deadline", async () => {
+        const capabilities = getTestCapabilities();
+        const schedulerControl = getSchedulerControl(capabilities);
+        schedulerControl.setPollingInterval(fromMilliseconds(50));
+        const timeControl = getDatetimeControl(capabilities);
+
+        const retryDelay = fromMinutes(10);
+        let executions = 0;
+
+        const task = jest.fn(() => {
+            executions++;
+            if (executions === 1) {
+                throw new Error("first attempt fails");
+            }
+        });
+
+        const registrations = [[
+            "retry-cron-regression",
+            "0,5,10,15,20,25,30,35,40,45,50,55 * * * *",
+            task,
+            retryDelay,
+        ]];
+
+        timeControl.setDateTime(fromISOString("2024-01-01T00:04:30Z"));
+
+        await capabilities.scheduler.initialize(registrations);
+        await schedulerControl.waitForNextCycleEnd();
+
+        // Align to the next scheduled 5-minute mark so the task executes and fails once.
+        timeControl.advanceByDuration(fromMilliseconds(30 * 1000));
+        await schedulerControl.waitForNextCycleEnd();
+
+        expect(task).toHaveBeenCalledTimes(1);
+
+        // The retry delay is 10 minutes, but the cron tick in five minutes should trigger execution.
+        timeControl.advanceByDuration(fromMinutes(5));
+        await schedulerControl.waitForNextCycleEnd();
+
+        expect(task).toHaveBeenCalledTimes(2);
+
+        await capabilities.scheduler.stop();
+    });
+});


### PR DESCRIPTION
## Summary
- allow awaiting-retry tasks to run on cron when a newer schedule fire is available
- persist the last attempt timestamp while in retry state, including on orphan restarts
- add a regression test covering cron execution before the retry timer expires

## Testing
- npx jest backend/tests/polling_scheduler_retry_cron_regression.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e5ecad66d4832ea2a9ea4140de5d5a