### PR TITLE
Fix scheduler long-run catch-up tracking

### DIFF
--- a/backend/src/logger/log_methods.js
+++ b/backend/src/logger/log_methods.js
@@ -43,7 +43,7 @@ function logError(state, obj, msg) {
 
     state.capabilities?.notifier?.notifyAboutError(msg).catch((error) => {
         if (state.logger !== null) {
-            state.logger.error('Failed to send error notification', { error });
+            state.logger.error({ error }, 'Failed to send error notification');
         } else {
             console.error('Logger not initialized');
             console.error('Failed to send error notification', { error });

--- a/backend/src/scheduler/execution/executor.js
+++ b/backend/src/scheduler/execution/executor.js
@@ -100,7 +100,11 @@ function makeTaskExecutor(capabilities, mutateTasks) {
             await mutateThis((task) => {
                 /** @type {AwaitingRun} */
                 const newState = {
-                    lastAttemptTime: end,
+                    // Preserve the actual attempt start so that scheduling decisions
+                    // consider the point in time when the run began rather than when it
+                    // completed. This is important for long-running executions that
+                    // may cross cron boundaries.
+                    lastAttemptTime: startTime,
                     lastSuccessTime: end,
                 };
                 task.state = newState;

--- a/backend/tests/polling_scheduler_long_running_catchup.test.js
+++ b/backend/tests/polling_scheduler_long_running_catchup.test.js
@@ -1,0 +1,90 @@
+/**
+ * Tests for declarative scheduler long-running execution behavior.
+ * Ensures cron catch-up occurs immediately after lengthy runs complete.
+ */
+
+const { fromISOString, fromMilliseconds, fromHours } = require("../src/datetime");
+const { getMockedRootCapabilities } = require("./spies");
+const {
+    stubEnvironment,
+    stubLogger,
+    stubDatetime,
+    stubSleeper,
+    getDatetimeControl,
+    stubScheduler,
+    getSchedulerControl,
+    stubRuntimeStateStorage,
+} = require("./stubs");
+
+function getTestCapabilities() {
+    const capabilities = getMockedRootCapabilities();
+    stubEnvironment(capabilities);
+    stubLogger(capabilities);
+    stubDatetime(capabilities);
+    stubSleeper(capabilities);
+    stubRuntimeStateStorage(capabilities);
+    stubScheduler(capabilities);
+    return capabilities;
+}
+
+describe("declarative scheduler long-running execution catch-up", () => {
+    test("schedules follow-up cron run immediately after long execution completes", async () => {
+        const capabilities = getTestCapabilities();
+        const timeControl = getDatetimeControl(capabilities);
+        const schedulerControl = getSchedulerControl(capabilities);
+
+        schedulerControl.setPollingInterval(fromMilliseconds(100));
+        const retryDelay = fromMilliseconds(5000);
+
+        // Start away from the cron boundary to avoid immediate execution.
+        const startTime = fromISOString("2021-01-01T00:05:00.000Z");
+        timeControl.setDateTime(startTime);
+
+        /** @type {import("../src/datetime").DateTime[]} */
+        const callTimes = [];
+        /** @type {(value: void) => void} */
+        let resolveFirstRun = () => {};
+        const firstRunCompleted = new Promise((resolve) => {
+            resolveFirstRun = resolve;
+        });
+
+        const task = jest.fn(async () => {
+            callTimes.push(timeControl.getCurrentDateTime());
+
+            if (callTimes.length === 1) {
+                // Extend the run so it outlasts the next cron pulse.
+                timeControl.advanceByDuration(fromHours(1));
+                await new Promise((resolve) => setTimeout(resolve, 10));
+                resolveFirstRun();
+            }
+        });
+
+        const registrations = [["long-runner", "0 * * * *", task, retryDelay]];
+
+        await capabilities.scheduler.initialize(registrations);
+
+        try {
+            // Allow the scheduler to settle.
+            await schedulerControl.waitForNextCycleEnd();
+            expect(task).not.toHaveBeenCalled();
+
+            // Move to the next cron boundary and let the scheduler trigger the first run.
+            timeControl.advanceByDuration(fromHours(1));
+            await schedulerControl.waitForNextCycleEnd();
+            await firstRunCompleted;
+
+            // Give the scheduler a few cycles to notice the pending cron execution.
+            for (let i = 0; i < 5 && task.mock.calls.length < 2; i++) {
+                await schedulerControl.waitForNextCycleEnd();
+            }
+
+            expect(task).toHaveBeenCalledTimes(2);
+
+            const [firstStart, secondStart] = callTimes;
+            expect(secondStart.diff(firstStart).toMillis()).toBe(fromHours(1).toMillis());
+            expect(secondStart.toISOString()).toBe(timeControl.getCurrentDateTime().toISOString());
+        } finally {
+            await capabilities.scheduler.stop();
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- ensure successful runs keep their attempt timestamp at the start of execution so cron catch-up fires correctly
- add a regression test covering long-running cron tasks that should immediately schedule a follow-up run
- correct logger error reporting to satisfy the stricter TypeScript signature during notification failures

## Testing
- npm test -- polling_scheduler_long_running_catchup.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e6042401b0832eacf5a138ba7f03b6