### PR TITLE
Prevent cron execution during pending retries

### DIFF
--- a/backend/src/scheduler/execution/collector.js
+++ b/backend/src/scheduler/execution/collector.js
@@ -61,13 +61,15 @@ function evaluateTasksForExecution(tasks, scheduledTasks, now, capabilities, sch
         }
 
         // Check both cron schedule and retry timing
+        const pendingRetryUntil = getPendingRetryUntil(task);
         const lastScheduledFire = getMostRecentExecution(task.parsedCron, now);
         const hasLastAttemptTime = 'lastAttemptTime' in task.state;
-        const shouldRunCron = hasLastAttemptTime && (
+        const shouldRunCron = (
+            pendingRetryUntil === undefined || now.isAfterOrEqual(pendingRetryUntil)
+        ) && hasLastAttemptTime && (
             task.state.lastAttemptTime === null ||
             task.state.lastAttemptTime.isBefore(lastScheduledFire)
         );
-        const pendingRetryUntil = getPendingRetryUntil(task);
         const shouldRunRetry = pendingRetryUntil !== undefined && now.isAfterOrEqual(pendingRetryUntil);
         const callback = task.callback;
 


### PR DESCRIPTION
## Summary
- gate cron scheduling while a retry backoff is pending
- adjust retry semantics test to assert cron waits until the retry delay expires

## Testing
- npx jest backend/tests/polling_scheduler_retry_semantics.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e866113480832e9dc28744625f3674