### PR TITLE
Prevent cron execution during pending retry backoff

### DIFF
--- a/backend/src/scheduler/execution/collector.js
+++ b/backend/src/scheduler/execution/collector.js
@@ -61,13 +61,13 @@ function evaluateTasksForExecution(tasks, scheduledTasks, now, capabilities, sch
         }
 
         // Check both cron schedule and retry timing
+        const pendingRetryUntil = getPendingRetryUntil(task);
         const lastScheduledFire = getMostRecentExecution(task.parsedCron, now);
         const hasLastAttemptTime = 'lastAttemptTime' in task.state;
-        const shouldRunCron = hasLastAttemptTime && (
+        const shouldRunCron = pendingRetryUntil === undefined && hasLastAttemptTime && (
             task.state.lastAttemptTime === null ||
             task.state.lastAttemptTime.isBefore(lastScheduledFire)
         );
-        const pendingRetryUntil = getPendingRetryUntil(task);
         const shouldRunRetry = pendingRetryUntil !== undefined && now.isAfterOrEqual(pendingRetryUntil);
         const callback = task.callback;
 


### PR DESCRIPTION
## Summary
- block cron-triggered runs while a retry backoff is pending and defer to the retry path
- extend the retry semantics test to cover cron ticks during the backoff period

## Testing
- npx jest backend/tests/polling_scheduler_retry_semantics.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e86627c61c832ea4b3e818ad38a7e1