### PR TITLE
Reject empty scheduler registration names

### DIFF
--- a/backend/src/scheduler/registration_validation/core.js
+++ b/backend/src/scheduler/registration_validation/core.js
@@ -33,9 +33,12 @@ function validateRegistrations(registrations) {
 
         const [name, cronExpression, callback, retryDelay] = registration;
         
-        // Validate task name is a string
-        if (typeof name !== 'string') {
-            throw new RegistrationShapeError(`Registration at index ${i}: task name must be a string, got: ${typeof name}`, { index: i, name, value: name });
+        // Validate task name is a non-empty string
+        if (typeof name !== 'string' || name.length === 0) {
+            throw new RegistrationShapeError(
+                `Registration at index ${i}: task name must be a non-empty string, got: ${typeof name}`,
+                { index: i, name, value: name }
+            );
         }
 
         const qname = JSON.stringify(name);

--- a/backend/tests/scheduler_registration_validation_errors.test.js
+++ b/backend/tests/scheduler_registration_validation_errors.test.js
@@ -54,7 +54,7 @@ describe("scheduler registration validation error handling", () => {
 
         test("should throw RegistrationShapeError for wrong array length", () => {
             const capabilities = getTestCapabilities();
-            
+
             const callback = jest.fn();
             const retryDelay = fromMilliseconds(5000);
             
@@ -73,9 +73,23 @@ describe("scheduler registration validation error handling", () => {
                 .toThrow(/Registration at index 0 must be an array of length 4/);
         });
 
+        test("should reject non-string or empty task names", () => {
+            const capabilities = getTestCapabilities();
+
+            const callback = jest.fn();
+            const retryDelay = fromMilliseconds(5000);
+
+            const invalidNames = [null, undefined, 123, {}, [], ""];
+
+            invalidNames.forEach(invalidName => {
+                expect(() => validateRegistrations([[invalidName, "0 * * * *", callback, retryDelay]], capabilities))
+                    .toThrow(/task name must be a non-empty string/);
+            });
+        });
+
         test("should include registration details in error", () => {
             const capabilities = getTestCapabilities();
-            
+
             expect(() => validateRegistrations(["invalid"], capabilities))
                 .toThrow(expect.objectContaining({
                     name: "RegistrationShapeError",


### PR DESCRIPTION
## Summary
- ensure scheduler registration names must be non-empty strings
- cover empty and non-string names in scheduler registration validation tests

## Testing
- npx jest backend/tests/scheduler_registration_validation_errors.test.js backend/tests/scheduler_stories.test.js --runInBand --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e867759f14832e9c344b03cdfa9ce5