### PR TITLE
Remove JSDoc type-casts from DescriptionEntry state

### DIFF
--- a/frontend/src/DescriptionEntry/ConfigSection.jsx
+++ b/frontend/src/DescriptionEntry/ConfigSection.jsx
@@ -33,7 +33,8 @@ import { HelpTab } from "./tabs/HelpTab.jsx";
  * @returns {JSX.Element|null}
  */
 export const ConfigSection = ({ onShortcutClick, onDeleteEntry, currentInput = "", recentEntries = [], isLoadingEntries = false }) => {
-    const [config, setConfig] = useState(/** @type {Config|null} */ (null));
+    /** @type {[Config|null, import("react").Dispatch<import("react").SetStateAction<Config|null>>]} */
+    const [config, setConfig] = useState(null);
     const [isLoading, setIsLoading] = useState(true);
 
     useEffect(() => {

--- a/frontend/src/DescriptionEntry/hooks.js
+++ b/frontend/src/DescriptionEntry/hooks.js
@@ -174,9 +174,11 @@ const processCameraReturn = async (cameraReturn, setDescription, setPendingReque
 export const useDescriptionEntry = (numberOfEntries = 10) => {
     const [description, setDescription] = useState("");
     const [isSubmitting, setIsSubmitting] = useState(false);
-    const [recentEntries, setRecentEntries] = useState(/** @type {any[]} */([]));
+    /** @type {[any[], import("react").Dispatch<import("react").SetStateAction<any[]>>]} */
+    const [recentEntries, setRecentEntries] = useState([]);
     const [isLoadingEntries, setIsLoadingEntries] = useState(true);
-    const [pendingRequestIdentifier, setPendingRequestIdentifier] = useState(/** @type {string|null} */(null));
+    /** @type {[string|null, import("react").Dispatch<import("react").SetStateAction<string|null>>]} */
+    const [pendingRequestIdentifier, setPendingRequestIdentifier] = useState(null);
     const [photoCount, setPhotoCount] = useState(0);
     const toast = useToast();
 


### PR DESCRIPTION
### Motivation
- Fix violations of the repository convention that forbids type-casting by removing inline JSDoc cast expressions in React state initialization.
- Bring `useState` declarations into compliance with the project's JSDoc typing approach by using typed tuple annotations instead of `/** @type {...} */ (value)` casts.
- Keep runtime behavior unchanged while improving type safety and static-analysis friendliness.

### Description
- Replace inline JSDoc cast initializers with explicit typed state tuple annotations for `useState` in `frontend/src/DescriptionEntry/ConfigSection.jsx` and `frontend/src/DescriptionEntry/hooks.js`.
- Annotated the `config`, `recentEntries`, and `pendingRequestIdentifier` state tuples using `import("react").Dispatch` and `SetStateAction` types.
- No functional logic changes were made; only type annotation style was updated.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e22b62b24832e8cd03775b9f161f7)