### PR TITLE
Encapsulate task deserialization errors behind factory functions

### DIFF
--- a/backend/src/scheduler/task/index.js
+++ b/backend/src/scheduler/task/index.js
@@ -21,7 +21,7 @@ const {
  */
 
 /**
- * @typedef {import('./serialization_errors').TaskTryDeserializeError} TaskTryDeserializeError
+ * @typedef {import('./serialization').TaskTryDeserializeError} TaskTryDeserializeError
  */
 
 /**

--- a/backend/src/scheduler/task/serialization_errors.js
+++ b/backend/src/scheduler/task/serialization_errors.js
@@ -82,6 +82,43 @@ class TaskInvalidStructureError extends TaskTryDeserializeError {
     }
 }
 
+/**
+ * @param {string} field
+ * @returns {TaskMissingFieldError}
+ */
+function makeTaskMissingFieldError(field) {
+    return new TaskMissingFieldError(field);
+}
+
+/**
+ * @param {string} field
+ * @param {unknown} value
+ * @param {string} expectedType
+ * @returns {TaskInvalidTypeError}
+ */
+function makeTaskInvalidTypeError(field, value, expectedType) {
+    return new TaskInvalidTypeError(field, value, expectedType);
+}
+
+/**
+ * @param {string} field
+ * @param {unknown} value
+ * @param {string} reason
+ * @returns {TaskInvalidValueError}
+ */
+function makeTaskInvalidValueError(field, value, reason) {
+    return new TaskInvalidValueError(field, value, reason);
+}
+
+/**
+ * @param {string} message
+ * @param {unknown} value
+ * @returns {TaskInvalidStructureError}
+ */
+function makeTaskInvalidStructureError(message, value) {
+    return new TaskInvalidStructureError(message, value);
+}
+
 // Type guard functions
 /**
  * @param {unknown} object
@@ -124,11 +161,10 @@ function isTaskInvalidStructureError(object) {
 }
 
 module.exports = {
-    TaskTryDeserializeError,
-    TaskMissingFieldError,
-    TaskInvalidTypeError,
-    TaskInvalidValueError,
-    TaskInvalidStructureError,
+    makeTaskMissingFieldError,
+    makeTaskInvalidTypeError,
+    makeTaskInvalidValueError,
+    makeTaskInvalidStructureError,
     isTaskTryDeserializeError,
     isTaskMissingFieldError,
     isTaskInvalidTypeError,


### PR DESCRIPTION
### Motivation

- Ensure code follows the repository encapsulation conventions by avoiding exporting error classes directly and using factory functions instead. 
- Make task deserialization error types opaque to external modules to prevent external `new`/`instanceof` usage and to align with the project's factory/type-guard pattern. 
- Reduce surface area of module exports while preserving the same type-guard behavior used throughout the scheduler code. 

### Description

- Added factory functions (`makeTaskMissingFieldError`, `makeTaskInvalidTypeError`, `makeTaskInvalidValueError`, `makeTaskInvalidStructureError`) to `backend/src/scheduler/task/serialization_errors.js` and stopped exporting the classes themselves. 
- Updated `backend/src/scheduler/task/serialization.js` to use the new factories and changed the local `TaskTryDeserializeError` typedef to a `ReturnType<>` union of the factories. 
- Adjusted `backend/src/scheduler/task/index.js` to import the `TaskTryDeserializeError` typedef from the `serialization` module instead of the errors module. 

### Testing

- Ran the focused test: `npx jest backend/tests/scheduler_task_serialization_errors.test.js`, which passed. 
- Ran the full test suite: `npm test`, which completed successfully (`135` test suites, all passing). 
- Performed static checks and build verification with `npm run static-analysis` and `npm run build`, both of which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e2e21223c832e88159cb930e0e356)