### PR TITLE
Fix JSDoc typing for retry signaling and React state

### DIFF
--- a/backend/tests/retryer_core.test.js
+++ b/backend/tests/retryer_core.test.js
@@ -53,8 +53,7 @@ describe("Retryer - Core functionality", () => {
                 callCount++;
                     if (callCount < 3) {
                         // signal that we want another attempt
-                        retry();
-                        return undefined;
+                        return retry();
                     }
                     return "done";
             };
@@ -72,8 +71,7 @@ describe("Retryer - Core functionality", () => {
             const callback = async ({ _attempt, retry }) => {
                 callCount++;
                     if (callCount === 1) {
-                        retry();
-                        return undefined;
+                        return retry();
                     }
                     return "ok";
             };

--- a/frontend/src/Camera/camera_logic.js
+++ b/frontend/src/Camera/camera_logic.js
@@ -11,6 +11,27 @@ import { processPhotos } from "./process_photos.js";
  */
 
 /**
+ * @returns {Blob|null}
+ */
+function getInitialBlob() {
+    return null;
+}
+
+/**
+ * @returns {string|undefined}
+ */
+function getInitialPreviewUrl() {
+    return undefined;
+}
+
+/**
+ * @returns {Photo[]}
+ */
+function getInitialPhotos() {
+    return [];
+}
+
+/**
  * Camera logic hook handling state and photo actions.
  * @param {string} requestIdentifier
  * @param {string} returnTo
@@ -25,9 +46,15 @@ import { processPhotos } from "./process_photos.js";
  * }}
  */
 export function useCameraLogic(requestIdentifier, returnTo) {
-    const [currentBlob, setCurrentBlob] = useState(/** @type {Blob|null} */ (null));
-    const [previewUrl, setPreviewUrl] = useState(/** @type {string|undefined} */ (undefined));
-    const [photos, setPhotos] = useState(/** @type {Photo[]} */ ([]));
+    /** @type {[Blob|null, import("react").Dispatch<import("react").SetStateAction<Blob|null>>]} */
+    const blobState = useState(getInitialBlob());
+    /** @type {[string|undefined, import("react").Dispatch<import("react").SetStateAction<string|undefined>>]} */
+    const previewState = useState(getInitialPreviewUrl());
+    /** @type {[Photo[], import("react").Dispatch<import("react").SetStateAction<Photo[]>>]} */
+    const photosState = useState(getInitialPhotos());
+    const [currentBlob, setCurrentBlob] = blobState;
+    const [previewUrl, setPreviewUrl] = previewState;
+    const [photos, setPhotos] = photosState;
     const [mode, setMode] = useState("camera");
     /** @type {import('react').MutableRefObject<HTMLVideoElement|null>} */
     const videoRef = useRef(null);

--- a/frontend/src/DescriptionEntry/ConfigSection.jsx
+++ b/frontend/src/DescriptionEntry/ConfigSection.jsx
@@ -23,6 +23,13 @@ import { HelpTab } from "./tabs/HelpTab.jsx";
  */
 
 /**
+ * @returns {Config|null}
+ */
+function getInitialConfig() {
+    return null;
+}
+
+/**
  * Component that displays configuration help and shortcuts
  * @param {Object} props
  * @param {(value: string) => void} props.onShortcutClick - Called when a shortcut is clicked
@@ -33,7 +40,9 @@ import { HelpTab } from "./tabs/HelpTab.jsx";
  * @returns {JSX.Element|null}
  */
 export const ConfigSection = ({ onShortcutClick, onDeleteEntry, currentInput = "", recentEntries = [], isLoadingEntries = false }) => {
-    const [config, setConfig] = useState(/** @type {Config|null} */ (null));
+    /** @type {[Config|null, import("react").Dispatch<import("react").SetStateAction<Config|null>>]} */
+    const configState = useState(getInitialConfig());
+    const [config, setConfig] = configState;
     const [isLoading, setIsLoading] = useState(true);
 
     useEffect(() => {


### PR DESCRIPTION
### Motivation
- Remove unsafe JSDoc type-casts and bring code into compliance with the project's JSDoc typing and capabilities conventions.
- Make the retry signalling API type-safe so callbacks can request retries without unsafe `/** @type */` assertions.
- Replace inline state initialization casts in React hooks with properly typed initializers to satisfy the static analyzer.

### Description
- Add a `RetryToken` class and `UnexpectedRetryTokenError`, change `withRetry` so `retry()` returns a `RetryToken`, and export `isUnexpectedRetryTokenError` in `backend/src/retryer/core.js`.
- Update retry tests to `return retry()` instead of returning `undefined` to follow the new retry-token convention in `backend/tests/retryer_core.test.js`.
- Replace `/** @type {...} */ (null)` casts with typed initializer helpers and explicit state tuple JSDoc in `frontend/src/Camera/camera_logic.js` and `frontend/src/DescriptionEntry/ConfigSection.jsx`.
- Files modified include `backend/src/retryer/core.js`, `backend/tests/retryer_core.test.js`, `frontend/src/Camera/camera_logic.js`, and `frontend/src/DescriptionEntry/ConfigSection.jsx`.

### Testing
- Ran the full test suite with `npm test` and all test suites passed (`135` suites, `997` tests) which succeeded.
- Ran the static analysis with `npm run static-analysis` (TypeScript `tsc` + `eslint`) and it completed without errors.
- Built the project with `npm run build` and the frontend build completed successfully.
- Executed `npx jest frontend/tests/DescriptionEntry.config.test.jsx` which passed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e2e21223c832e88159cb930e0e356)