### PR TITLE
Align dependency graph error names with spec

### DIFF
--- a/backend/src/generators/dependency_graph/errors.js
+++ b/backend/src/generators/dependency_graph/errors.js
@@ -11,7 +11,7 @@ class InvalidNode extends Error {
      */
     constructor(nodeName) {
         super(`Node ${nodeName} not found in the dependency graph.`);
-        this.name = "InvalidNode";
+        this.name = "InvalidNodeError";
         this.nodeName = nodeName;
     }
 }
@@ -44,7 +44,7 @@ class InvalidSchema extends Error {
      */
     constructor(message, schemaOutput) {
         super(`Invalid schema '${schemaOutput}': ${message}`);
-        this.name = "InvalidSchema";
+        this.name = "InvalidSchemaError";
         this.schemaOutput = schemaOutput;
     }
 }

--- a/backend/tests/dependency_graph_spec.test.js
+++ b/backend/tests/dependency_graph_spec.test.js
@@ -300,7 +300,7 @@ describe("Schema validation (construction-time errors)", () => {
             error = e;
         }
         expect(error).toBeTruthy();
-        expectOneOfNames(error, ["InvalidSchema"]);
+        expectOneOfNames(error, ["InvalidSchemaError"]);
         expect(error.message).toMatch(/Duplicate variable 'b'/);
     });
 
@@ -319,7 +319,7 @@ describe("Schema validation (construction-time errors)", () => {
             error = e;
         }
         expect(error).toBeTruthy();
-        expectOneOfNames(error, ["InvalidSchema"]);
+        expectOneOfNames(error, ["InvalidSchemaError"]);
         expect(error.message).toMatch(/Duplicate variable 'x'/);
     });
 
@@ -343,7 +343,7 @@ describe("Schema validation (construction-time errors)", () => {
                 },
             ]);
         } catch (e) {
-            expectOneOfNames(e, ["InvalidSchemaError", "InvalidSchema"]);
+            expectOneOfNames(e, ["InvalidSchemaError"]);
             expectHasOwn(e, "schemaOutput");
         }
     });
@@ -459,7 +459,7 @@ describe("Expression parsing & canonicalization at API boundaries", () => {
         // In the new API, "id(-1)" is just treated as a head name
         // Since the real head is "id", this throws InvalidNode
         await expect(g.pull("id(-1)")).rejects.toMatchObject({
-            name: "InvalidNode",
+            name: "InvalidNodeError",
         });
     });
 
@@ -476,7 +476,7 @@ describe("Expression parsing & canonicalization at API boundaries", () => {
         // In the new API, "id(1.2)" is just treated as a head name
         // Since the real head is "id", this throws InvalidNode
         await expect(g.pull("id(1.2)")).rejects.toMatchObject({
-            name: "InvalidNode",
+            name: "InvalidNodeError",
         });
     });
 
@@ -493,7 +493,7 @@ describe("Expression parsing & canonicalization at API boundaries", () => {
         // In the new API, "id(01)" is just treated as a head name
         // Since the real head is "id", this throws InvalidNode
         await expect(g.pull("id(01)")).rejects.toMatchObject({
-            name: "InvalidNode",
+            name: "InvalidNodeError",
         });
     });
 });
@@ -512,9 +512,7 @@ describe("pull/set concrete-ness & node existence errors", () => {
         // In the new API, "event_context(e)" is treated as a literal head name
         // Since the real head is "event_context", this throws InvalidNode
         await expect(g.pull("event_context(e)")).rejects.toMatchObject({
-            name: expect.stringMatching(
-                /^(InvalidNodeError|InvalidNode)$/
-            ),
+            name: "InvalidNodeError",
         });
     });
 
@@ -532,9 +530,7 @@ describe("pull/set concrete-ness & node existence errors", () => {
         // Since the real head is "event_context", this throws InvalidNode
         await expect(g.set("event_context(e)", { x: 1 })).rejects.toMatchObject(
             {
-                name: expect.stringMatching(
-                    /^(InvalidNodeError|InvalidNode)$/
-                ),
+                name: "InvalidNodeError",
             }
         );
     });
@@ -546,7 +542,7 @@ describe("pull/set concrete-ness & node existence errors", () => {
         ]);
 
         await expect(g.pull("does_not_exist")).rejects.toMatchObject({
-            name: expect.stringMatching(/^(InvalidNodeError|InvalidNode)$/),
+            name: "InvalidNodeError",
         });
     });
 
@@ -557,7 +553,7 @@ describe("pull/set concrete-ness & node existence errors", () => {
         ]);
 
         await expect(g.set("does_not_exist", { x: 1 })).rejects.toMatchObject({
-            name: expect.stringMatching(/^(InvalidNodeError|InvalidNode)$/),
+            name: "InvalidNodeError",
         });
     });
 
@@ -1748,4 +1744,3 @@ describe("12. (Optional) Concurrent pulls of the same node", () => {
             expect(counter.calls).toBe(1);
         });
 });
-


### PR DESCRIPTION
### Motivation
- The dependency graph specification uses `Invalid*Error` naming for specific error classes, but the implementation used older names causing mismatches.
- Tests and external code expect the canonical `.name` fields to be `InvalidNodeError` and `InvalidSchemaError` for consistent error handling.
- Aligning the runtime error names with the spec improves test determinism and public API compatibility.

### Description
- Renamed the `.name` fields on dependency-graph error classes to the spec-aligned names by setting `InvalidNode` to report `InvalidNodeError` and `InvalidSchema` to report `InvalidSchemaError` in `backend/src/generators/dependency_graph/errors.js`.
- Updated conformance tests in `backend/tests/dependency_graph_spec.test.js` to assert the new error names where applicable.
- Kept type guards and constructor shapes unchanged so behavior and type checks remain intact.

### Testing
- Ran the focused test: `npx jest backend/tests/dependency_graph_spec.test.js`, which passed (all tests in that file succeeded).
- Ran the full test suite with `npm test`, which completed with most suites passing but one unrelated test (`backend/tests/scheduler_orphaned_task_restart.test.js`) timed out.
- Ran static analysis with `npm run static-analysis`, which succeeded without errors.
- Built the frontend with `npm run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ef2e04340832ea4b5a03f3cbc10cc)