### PR TITLE
Fix dependency graph materialized node listing

### DIFF
--- a/backend/src/generators/dependency_graph/graph_storage.js
+++ b/backend/src/generators/dependency_graph/graph_storage.js
@@ -199,9 +199,9 @@ function makeGraphStorage(rootDatabase, schemaHash) {
      */
     async function listMaterializedNodes() {
         const keys = [];
-        for await (const key of schemaStorage.values.keys()) {
+        for await (const key of schemaStorage.inputs.keys()) {
             if (typeof key !== "string") {
-                throw new Error("Invalid key type in values database");
+                throw new Error("Invalid key type in inputs database");
             }
             keys.push(stringToNodeKeyString(key));
         }


### PR DESCRIPTION
### Motivation

- `listMaterializedNodes` should enumerate nodes that were explicitly materialized; those are recorded in the `inputs` index, not the `values` DB.
- The previous implementation iterated the `values` sublevel which can miss persisted materialization markers and break restart-resilience tests.

### Description

- Change `listMaterializedNodes` to iterate `schemaStorage.inputs.keys()` instead of `schemaStorage.values.keys()`.
- Update the thrown error message to reference the `inputs` database when encountering an unexpected key type.
- The change is localized to `backend/src/generators/dependency_graph/graph_storage.js` and preserves the existing return format of `NodeKeyString[]`.

### Testing

- No automated tests were run for this change.
- Static project tests were not executed as part of this rollout.
- A single-file change was committed (`graph_storage.js`) and the repository state was updated successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f103d4014832eba9e38c36beef95c)