### PR TITLE
Standardize error .name suffixes in dependency_graph errors

### DIFF
--- a/backend/src/generators/dependency_graph/errors.js
+++ b/backend/src/generators/dependency_graph/errors.js
@@ -81,7 +81,7 @@ class SchemaPatternNotAllowed extends Error {
                 `Schema patterns with variables can only be used as templates. ` +
                 `Provide concrete instantiations instead.`
         );
-        this.name = "SchemaPatternNotAllowed";
+        this.name = "SchemaPatternNotAllowedError";
         this.pattern = pattern;
     }
 }
@@ -328,7 +328,7 @@ class InvalidComputorReturnValue extends Error {
             `Computor for node '${nodeName}' returned an invalid value: ${value}. ` +
                 `Computors must return a valid DatabaseValue or Unchanged, not null or undefined.`
         );
-        this.name = "InvalidComputorReturnValue";
+        this.name = "InvalidComputorReturnValueError";
         this.nodeName = nodeName;
         this.value = value;
     }


### PR DESCRIPTION
### Motivation
- Align error `.name` values with the dependency graph specification and project conventions that use the `*Error` suffix for error types.
- Improve consistency across the codebase so tests and consumers can rely on stable error names.
- Fix two error classes whose `.name` values omitted the `Error` suffix, preventing mismatches with expected taxonomy.

### Description
- Updated `SchemaPatternNotAllowed` to set `this.name = "SchemaPatternNotAllowedError"` in `backend/src/generators/dependency_graph/errors.js`.
- Updated `InvalidComputorReturnValue` to set `this.name = "InvalidComputorReturnValueError"` in the same file.
- No other behavior or public API was changed; only the `.name` strings on the error instances were adjusted.

### Testing
- No automated tests were executed as part of this change.
- A local commit was created containing the modifications and the repository state was updated accordingly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f3c8c772c832e9de2bac6124afa68)