### PR TITLE
Make MissingValueError carry serialized node keys

### DIFF
--- a/backend/src/generators/dependency_graph/class.js
+++ b/backend/src/generators/dependency_graph/class.js
@@ -518,7 +518,7 @@ class DependencyGraphClass {
             // Return old value (must exist if Unchanged returned)
             const result = await batch.values.get(nodeKey);
             if (result === undefined) {
-                throw makeMissingValueError(deserializeNodeKey(nodeKey).head);
+                throw makeMissingValueError(nodeKey);
             }
             return { value: result, status: "unchanged" };
         } else {
@@ -629,9 +629,7 @@ class DependencyGraphClass {
                     nodeDefinition.output
                 );
                 if (result === undefined) {
-                    throw makeMissingValueError(
-                        deserializeNodeKey(nodeDefinition.output).head
-                    );
+                    throw makeMissingValueError(nodeDefinition.output);
                 }
                 return { value: result, status: "cached" };
             }
@@ -702,9 +700,7 @@ class DependencyGraphClass {
 
                 const result = await batch.values.get(nodeKeyStr);
                 if (result === undefined) {
-                    throw makeMissingValueError(
-                        deserializeNodeKey(nodeKeyStr).head
-                    );
+                    throw makeMissingValueError(nodeKeyStr);
                 }
                 return { value: result, status: "cached" };
             }

--- a/backend/src/generators/dependency_graph/errors.js
+++ b/backend/src/generators/dependency_graph/errors.js
@@ -1,6 +1,7 @@
 
 /** @typedef {import('./database/types').NodeName} NodeName */
 /** @typedef {import('./database/types').SchemaPattern} SchemaPattern */
+/** @typedef {import('./database/types').NodeKeyString} NodeKeyString */
 
 /**
  * Base error class for database operations.
@@ -250,25 +251,25 @@ function isSchemaCycle(object) {
  */
 class MissingValue extends Error {
     /**
-     * @param {NodeName} nodeName
+     * @param {NodeKeyString} nodeKey
      */
-    constructor(nodeName) {
+    constructor(nodeKey) {
         super(
-            `Expected value for up-to-date node '${nodeName}', but found none. ` +
+            `Expected value for up-to-date node '${nodeKey}', but found none. ` +
                 `This indicates database corruption or an implementation bug.`
         );
         this.name = "MissingValueError";
-        this.nodeName = nodeName;
+        this.nodeKey = nodeKey;
     }
 }
 
 /**
  * Constructs a MissingValue error.
- * @param {NodeName} nodeName
+ * @param {NodeKeyString} nodeKey
  * @returns {MissingValue}
  */
-function makeMissingValueError(nodeName) {
-    return new MissingValue(nodeName);
+function makeMissingValueError(nodeKey) {
+    return new MissingValue(nodeKey);
 }
 
 /**


### PR DESCRIPTION
### Motivation

- The `MissingValueError` previously referenced a `nodeName` which loses the exact concrete node identity used in storage operations.
- Error messages and fields should reflect the serialized node key (`NodeKeyString`) because the implementation works with concrete node key strings in the database.

### Description

- Change `MissingValue`/`makeMissingValueError` to accept and store a `NodeKeyString` instead of a `NodeName` in `backend/src/generators/dependency_graph/errors.js`.
- Update call sites in `backend/src/generators/dependency_graph/class.js` to pass the serialized node key strings into `makeMissingValueError` (replacing previous use of `.head` extraction).
- Adjust the error message and the stored property name from `nodeName` to `nodeKey` to reflect the concrete key carried by the error.
- No behavior changes to logic other than passing the correct identifier into the error constructor.

### Testing

- No automated tests were executed for this change.
- No test failures were observed because only error construction and call sites were updated and code compiles in-place (manual run not performed).
- Recommend running the full test suite with `npm test` and performing targeted tests for dependency graph error paths after merge.
- Recommend running static analysis with `npm run static-analysis` to ensure JSDoc/type expectations remain satisfied.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f3c8c772c832e9de2bac6124afa68)