### PR TITLE
Fix dependency graph error names

### DIFF
--- a/backend/src/generators/dependency_graph/errors.js
+++ b/backend/src/generators/dependency_graph/errors.js
@@ -81,7 +81,7 @@ class SchemaPatternNotAllowed extends Error {
                 `Schema patterns with variables can only be used as templates. ` +
                 `Provide concrete instantiations instead.`
         );
-        this.name = "SchemaPatternNotAllowed";
+        this.name = "SchemaPatternNotAllowedError";
         this.pattern = pattern;
     }
 }
@@ -328,7 +328,7 @@ class InvalidComputorReturnValue extends Error {
             `Computor for node '${nodeName}' returned an invalid value: ${value}. ` +
                 `Computors must return a valid DatabaseValue or Unchanged, not null or undefined.`
         );
-        this.name = "InvalidComputorReturnValue";
+        this.name = "InvalidComputorReturnValueError";
         this.nodeName = nodeName;
         this.value = value;
     }


### PR DESCRIPTION
### Motivation

- Ensure error class names follow the established `*Error` naming convention for consistency and clearer diagnostics.
- Avoid mismatches between `.name` values and exported factory/type-guard names used by callers and tests.

### Description

- Renamed `SchemaPatternNotAllowed` error `.name` to `SchemaPatternNotAllowedError` in `backend/src/generators/dependency_graph/errors.js`.
- Renamed `InvalidComputorReturnValue` error `.name` to `InvalidComputorReturnValueError` in `backend/src/generators/dependency_graph/errors.js`.
- Kept existing factory functions and type guards (`makeSchemaPatternNotAllowedError`, `isSchemaPatternNotAllowed`, `makeInvalidComputorReturnValueError`, `isInvalidComputorReturnValue`) unchanged so external usage remains stable.

### Testing

- Ran `npx jest backend/tests/dependency_graph_spec.test.js` and it passed (all tests in that suite succeeded).
- Ran the full test suite with `npm test` and it passed (all test suites passed); there was a worker-exit warning but suites completed successfully.
- Ran static analysis with `npm run static-analysis` and it completed without errors.
- Built the frontend with `npm run build` and it completed successfully (build emitted deprecation/chunk-size warnings but produced artifacts).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f3c8c772c832e9de2bac6124afa68)