### PR TITLE
Fix dependency graph schema error metadata

### DIFF
--- a/backend/src/generators/dependency_graph/errors.js
+++ b/backend/src/generators/dependency_graph/errors.js
@@ -41,23 +41,23 @@ function isInvalidNode(object) {
 class InvalidSchema extends Error {
     /**
      * @param {string} message
-     * @param {string} schemaOutput
+     * @param {string} schemaPattern
      */
-    constructor(message, schemaOutput) {
-        super(`Invalid schema '${schemaOutput}': ${message}`);
+    constructor(message, schemaPattern) {
+        super(`Invalid schema '${schemaPattern}': ${message}`);
         this.name = "InvalidSchemaError";
-        this.schemaOutput = schemaOutput;
+        this.schemaPattern = schemaPattern;
     }
 }
 
 /**
  * Constructs an InvalidSchema error.
  * @param {string} message
- * @param {string} schemaOutput
+ * @param {string} schemaPattern
  * @returns {InvalidSchema}
  */
-function makeInvalidSchemaError(message, schemaOutput) {
-    return new InvalidSchema(message, schemaOutput);
+function makeInvalidSchemaError(message, schemaPattern) {
+    return new InvalidSchema(message, schemaPattern);
 }
 
 /**
@@ -359,28 +359,28 @@ function isInvalidComputorReturnValue(object) {
  */
 class SchemaArityConflict extends Error {
     /**
-     * @param {NodeName} head
+     * @param {NodeName} nodeName
      * @param {number[]} arities
      */
-    constructor(head, arities) {
+    constructor(nodeName, arities) {
         super(
-            `Schema arity conflict: head '${head}' appears with multiple arities [${arities.join(", ")}]. ` +
+            `Schema arity conflict: head '${nodeName}' appears with multiple arities [${arities.join(", ")}]. ` +
                 `Each head must have a single arity across all schema outputs.`
         );
         this.name = "SchemaArityConflictError";
-        this.head = head;
+        this.nodeName = nodeName;
         this.arities = arities;
     }
 }
 
 /**
  * Constructs a SchemaArityConflict error.
- * @param {NodeName} head
+ * @param {NodeName} nodeName
  * @param {number[]} arities
  * @returns {SchemaArityConflict}
  */
-function makeSchemaArityConflictError(head, arities) {
-    return new SchemaArityConflict(head, arities);
+function makeSchemaArityConflictError(nodeName, arities) {
+    return new SchemaArityConflict(nodeName, arities);
 }
 
 /**

--- a/backend/tests/dependency_graph_spec.test.js
+++ b/backend/tests/dependency_graph_spec.test.js
@@ -344,7 +344,7 @@ describe("Schema validation (construction-time errors)", () => {
             ]);
         } catch (e) {
             expectOneOfNames(e, ["InvalidSchemaError"]);
-            expectHasOwn(e, "schemaOutput");
+            expectHasOwn(e, "schemaPattern");
         }
     });
 


### PR DESCRIPTION
### Motivation
- The dependency graph spec requires `InvalidSchemaError` to expose the pattern under `schemaPattern` rather than `schemaOutput` for error consumers.
- Schema arity conflict errors should name the offending head as `nodeName` (matching the declared error taxonomy) instead of `head`.
- Tests referred to the previous property name and needed to be updated to assert the canonical error payload.

### Description
- Rename `InvalidSchema` constructor parameter/property from `schemaOutput` to `schemaPattern` and update `makeInvalidSchemaError` accordingly in `backend/src/generators/dependency_graph/errors.js`.
- Rename `SchemaArityConflict` constructor parameter/property from `head` to `nodeName` and update `makeSchemaArityConflictError` accordingly.
- Update `backend/tests/dependency_graph_spec.test.js` to expect the `schemaPattern` property on thrown `InvalidSchemaError`.
- No validation or runtime behavior was changed beyond the shape/names of the reported error metadata.

### Testing
- Ran `npx jest backend/tests/dependency_graph_spec.test.js` and the tests passed.
- Ran the full test suite with `npm test` and all tests passed (152 suites, 1216 tests).
- Ran static analysis with `npm run static-analysis` and it completed successfully.
- Built the frontend via `npm run build` and the build finished successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f49eb9a00832eb043f1d30102a51d)