### PR TITLE
Reject schema pattern strings in DependencyGraph public API

### DIFF
--- a/backend/src/generators/dependency_graph/class.js
+++ b/backend/src/generators/dependency_graph/class.js
@@ -6,6 +6,7 @@ const {
     schemaPatternToString,
     stringToNodeName,
     stringToSchemaHash,
+    stringToSchemaPattern,
 } = require("./database");
 
 /** @typedef {import('./database/root_database').RootDatabase} RootDatabase */
@@ -66,7 +67,8 @@ const MUTEX_KEY = 'dependency-graph-operations';
  * @param {string} nodeName
  */
 function ensureNodeNameIsHead(nodeName) {
-    const parsed = parseExpr(nodeName);
+    const schemaPattern = stringToSchemaPattern(nodeName);
+    const parsed = parseExpr(schemaPattern);
     if (parsed.kind === "call") {
         throw makeSchemaPatternNotAllowedError(nodeName);
     }

--- a/backend/tests/dependency_graph_parameterized.test.js
+++ b/backend/tests/dependency_graph_parameterized.test.js
@@ -9,6 +9,7 @@ const { getRootDatabase } = require("../src/generators/dependency_graph/database
 const {
     makeDependencyGraph,
     isInvalidNode,
+    isSchemaPatternNotAllowed,
 } = require("../src/generators/dependency_graph");
 const { getMockedRootCapabilities } = require("./spies");
 const { stubLogger } = require("./stubs");
@@ -48,8 +49,8 @@ describe("Parameterized node schemas", () => {
             const graph = makeDependencyGraph(db, schemas);
 
             // Try to pull with an identifier that looks like a pattern
-            // In the new API, "derived(x)" is treated as a literal head name, not a pattern
-            // Since the real head is "derived", this should throw InvalidNode
+            // In the new API, "derived(x)" is a schema pattern with variables
+            // The public API rejects schema patterns, throwing SchemaPatternNotAllowedError
             await expect(graph.pull('derived(x)')).rejects.toThrow();
 
             let error = null;
@@ -59,7 +60,7 @@ describe("Parameterized node schemas", () => {
                 error = err;
             }
             expect(error).not.toBeNull();
-            expect(isInvalidNode(error)).toBe(true);
+            expect(isSchemaPatternNotAllowed(error)).toBe(true);
 
             // Try to set with an identifier that looks like a pattern
             await expect(
@@ -73,7 +74,7 @@ describe("Parameterized node schemas", () => {
                 error = err;
             }
             expect(error).not.toBeNull();
-            expect(isInvalidNode(error)).toBe(true);
+            expect(isSchemaPatternNotAllowed(error)).toBe(true);
 
             await db.close();
         });

--- a/backend/tests/dependency_graph_spec.test.js
+++ b/backend/tests/dependency_graph_spec.test.js
@@ -456,10 +456,10 @@ describe("Expression parsing & canonicalization at API boundaries", () => {
             },
         ]);
 
-        // In the new API, "id(-1)" is just treated as a head name
-        // Since the real head is "id", this throws InvalidNode
+        // In the new API, "id(-1)" would be parsed as a call expression
+        // but the parser rejects negative numbers, throwing InvalidExpression
         await expect(g.pull("id(-1)")).rejects.toMatchObject({
-            name: "InvalidNodeError",
+            name: "InvalidExpressionError",
         });
     });
 
@@ -473,10 +473,10 @@ describe("Expression parsing & canonicalization at API boundaries", () => {
             },
         ]);
 
-        // In the new API, "id(1.2)" is just treated as a head name
-        // Since the real head is "id", this throws InvalidNode
+        // In the new API, "id(1.2)" would be parsed as a call expression
+        // but the parser rejects floats, throwing InvalidExpression
         await expect(g.pull("id(1.2)")).rejects.toMatchObject({
-            name: "InvalidNodeError",
+            name: "InvalidExpressionError",
         });
     });
 
@@ -490,10 +490,10 @@ describe("Expression parsing & canonicalization at API boundaries", () => {
             },
         ]);
 
-        // In the new API, "id(01)" is just treated as a head name
-        // Since the real head is "id", this throws InvalidNode
+        // In the new API, "id(01)" would be parsed as a call expression
+        // but the parser rejects leading zeros, throwing InvalidExpression
         await expect(g.pull("id(01)")).rejects.toMatchObject({
-            name: "InvalidNodeError",
+            name: "InvalidExpressionError",
         });
     });
 });
@@ -509,10 +509,10 @@ describe("pull/set concrete-ness & node existence errors", () => {
             },
         ]);
 
-        // In the new API, "event_context(e)" is treated as a literal head name
-        // Since the real head is "event_context", this throws InvalidNode
+        // In the new API, "event_context(e)" is a schema pattern with variables
+        // The public API rejects schema patterns, throwing SchemaPatternNotAllowedError
         await expect(g.pull("event_context(e)")).rejects.toMatchObject({
-            name: "InvalidNodeError",
+            name: "SchemaPatternNotAllowedError",
         });
     });
 
@@ -526,11 +526,11 @@ describe("pull/set concrete-ness & node existence errors", () => {
             },
         ]);
 
-        // In the new API, "event_context(e)" is treated as a literal head name
-        // Since the real head is "event_context", this throws InvalidNode
+        // In the new API, "event_context(e)" is a schema pattern with variables
+        // The public API rejects schema patterns, throwing SchemaPatternNotAllowedError
         await expect(g.set("event_context(e)", { x: 1 })).rejects.toMatchObject(
             {
-                name: "InvalidNodeError",
+                name: "SchemaPatternNotAllowedError",
             }
         );
     });


### PR DESCRIPTION
### Motivation
- Public API functions `pull` and `set` should accept node names (heads) only, not full schema patterns with variables.
- Passing schema pattern strings through the public API can confuse callers and bypass schema validation semantics.
- The spec mandates a distinction between schema patterns (used in definitions) and node names (used in public calls).

### Description
- Added `ensureNodeNameIsHead` to validate that public `nodeName` arguments are atom expressions and not call patterns.
- Imported `parseExpr` and the `makeSchemaPatternNotAllowedError` error and throw it when a schema pattern is provided to the API.
- Wired the validation into `unsafeSet` and `unsafePull` so `set`/`pull` (via their mutex-wrapped callers) reject pattern strings early.
- Changes made in `backend/src/generators/dependency_graph/class.js` to enforce the new check.

### Testing
- No automated tests were executed against this change.
- Recommend running the full suite with `npm test` and targeted tests with `npx jest` to validate behavior after review.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f49eb9a00832eb043f1d30102a51d)