### PR TITLE
Reject schema inputs referencing undefined heads in dependency graph

### DIFF
--- a/backend/src/generators/dependency_graph/compiled_node.js
+++ b/backend/src/generators/dependency_graph/compiled_node.js
@@ -303,8 +303,16 @@ function validateInputArities(compiledNodes) {
             const inputHead = inputExpr.name;
             const inputArity = inputExpr.args.length;
             const expectedArity = headToArity.get(inputHead);
-            
-            if (expectedArity !== undefined && inputArity !== expectedArity) {
+
+            if (expectedArity === undefined) {
+                throw makeInvalidSchemaError(
+                    `Input pattern '${inputStr}' references undefined head '${inputHead}'. ` +
+                    `Every input pattern must match a schema output pattern.`,
+                    node.source.output
+                );
+            }
+
+            if (inputArity !== expectedArity) {
                 throw makeInvalidSchemaError(
                     `Input pattern '${inputStr}' has arity ${inputArity}, but head '${inputHead}' is defined with arity ${expectedArity}. ` +
                     `All references to the same head must use consistent arity (expected ${expectedArity} arguments)`,


### PR DESCRIPTION
### Motivation

- The schema compiler previously allowed input patterns that referenced heads not present in the set of output patterns, which would defer errors to later runtime stages.
- Early validation of schema correctness prevents confusing runtime failures and ensures schemas are well-formed at initialization.

### Description

- Add a validation in `validateInputArities` to throw `InvalidSchemaError` when an input pattern references an undefined head so every input must match some schema output.
- Keep the existing arity-checking logic that throws when an input's arity does not match the defined output arity for that head.
- Change implemented in `backend/src/generators/dependency_graph/compiled_node.js` inside `validateInputArities`.

### Testing

- Ran the focused unit tests with `npx jest backend/tests/compiled_node.test.js`, which passed.
- Ran the full test suite with `npm test`, which completed successfully (all tests passed).
- Ran static analysis with `npm run static-analysis`, which completed successfully.
- Verified build with `npm run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960b5376338832e87474db4f98e43f0)