### PR TITLE
Normalize empty-arg dependency graph mappings

### DIFF
--- a/backend/src/generators/dependency_graph/expr.js
+++ b/backend/src/generators/dependency_graph/expr.js
@@ -376,6 +376,9 @@ function canonicalizeMapping(inputExpressions, outputExpression) {
         if (expr.kind === "atom") {
             return nodeNameStr;
         } else {
+            if (expr.args.length === 0) {
+                return nodeNameStr;
+            }
             const canonicalArgs = expr.args
                 .map((arg) => getCanonicalVarName(arg.value))
                 .join(",");

--- a/backend/tests/dependency_graph_expr.test.js
+++ b/backend/tests/dependency_graph_expr.test.js
@@ -252,6 +252,15 @@ describe("dependency_graph/expr", () => {
             expect(result).toBe("source => derived(v0)");
         });
 
+        test("normalizes empty-argument calls to atoms", () => {
+            const inputExprs = [parseExpr("source()")];
+            const outputExpr = parseExpr("derived()");
+
+            const result = canonicalizeMapping(inputExprs, outputExpr);
+
+            expect(result).toBe("source => derived");
+        });
+
         test("variable scoping across inputs and outputs", () => {
             const inputExprs = [
                 parseExpr("first(a,b)"),


### PR DESCRIPTION
### Motivation
- The canonicalization for expression mappings treated zero-argument calls (e.g. `foo()`) differently from atoms (e.g. `foo`), making variable-less calls appear with `()` in canonical mappings and breaking stability/consistency assumptions.
- This could cause schema hashing / mapping comparisons to differ for syntactically equivalent patterns that only differ by empty parentheses.
- Tests expected empty-argument calls to canonicalize to the head only, but a regression was found where they stayed as calls with empty arg lists.

### Description
- Treat call expressions with zero arguments as atoms inside `canonicalizeMapping` so `foo()` canonicalizes to `foo`.
- Added a regression test `normalizes empty-argument calls to atoms` to `backend/tests/dependency_graph_expr.test.js` to cover the behavior.
- The change is limited to `backend/src/generators/dependency_graph/expr.js` and its tests, preserving other canonicalization semantics.

### Testing
- Ran the focused test: `npx jest backend/tests/dependency_graph_expr.test.js` and it passed.
- Ran the full test suite: `npm test` and all tests passed (`153` test suites, all green).
- Ran static analysis: `npm run static-analysis` and it completed successfully.
- Verified build: `npm run build` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960b5376338832e87474db4f98e43f0)