### PR TITLE
Normalize zero-argument rendering in dependency graph expressions

### DIFF
--- a/backend/src/generators/dependency_graph/expr.js
+++ b/backend/src/generators/dependency_graph/expr.js
@@ -323,6 +323,9 @@ function renderExpr(expr) {
     if (expr.kind === "atom") {
         return stringToSchemaPattern(nodeNameStr);
     } else {
+        if (expr.args.length === 0) {
+            return stringToSchemaPattern(nodeNameStr);
+        }
         const renderedArgs = expr.args.map(renderArg).join(",");
         return stringToSchemaPattern(`${nodeNameStr}(${renderedArgs})`);
     }

--- a/backend/tests/dependency_graph_expr.test.js
+++ b/backend/tests/dependency_graph_expr.test.js
@@ -2,7 +2,12 @@
  * Tests for dependency_graph/expr module.
  */
 
-const { parseExpr, canonicalize, canonicalizeMapping } = require("../src/generators/dependency_graph/expr");
+const {
+    parseExpr,
+    canonicalize,
+    canonicalizeMapping,
+    renderExpr,
+} = require("../src/generators/dependency_graph/expr");
 
 describe("dependency_graph/expr", () => {
     describe("parseExpr()", () => {
@@ -92,6 +97,13 @@ describe("dependency_graph/expr", () => {
 
         test("throws on invalid function name", () => {
             expect(() => parseExpr("123foo(x)")).toThrow("Unexpected character");
+        });
+    });
+
+    describe("renderExpr()", () => {
+        test("renders an empty argument call as an atom", () => {
+            const expr = parseExpr("foo()");
+            expect(renderExpr(expr)).toBe("foo");
         });
     });
 


### PR DESCRIPTION
### Motivation
- Ensure canonical rendering of expressions treats zero-argument calls as atoms so canonical forms remain consistent with parsing and canonicalization rules. 
- Avoid producing `foo()` when the canonical/atom form `foo` is expected by other modules and tests. 
- Provide an explicit test to cover the zero-argument rendering case to prevent regressions. 

### Description
- Change `renderExpr` to emit the atom string when a parsed `call` has zero arguments by returning the head name instead of `head()`. 
- Add a unit test asserting `renderExpr(parseExpr("foo()"))` returns `"foo"` in `backend/tests/dependency_graph_expr.test.js`. 
- Modified files: `backend/src/generators/dependency_graph/expr.js` and `backend/tests/dependency_graph_expr.test.js`. 

### Testing
- Ran `npx jest backend/tests/dependency_graph_expr.test.js` and the focused test suite passed. 
- Ran the full test suite with `npm test` and all test suites passed. 
- Ran static analysis with `npm run static-analysis` (typecheck/lint) and it succeeded. 
- Built the frontend with `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69612a4aee7c832ea01c073ee22a9cd1)