### PR TITLE
Preserve parentheses when rendering empty-argument dependency-graph expressions

### DIFF
--- a/backend/src/generators/dependency_graph/expr.js
+++ b/backend/src/generators/dependency_graph/expr.js
@@ -323,9 +323,6 @@ function renderExpr(expr) {
     if (expr.kind === "atom") {
         return stringToSchemaPattern(nodeNameStr);
     } else {
-        if (expr.args.length === 0) {
-            return stringToSchemaPattern(nodeNameStr);
-        }
         const renderedArgs = expr.args.map(renderArg).join(",");
         return stringToSchemaPattern(`${nodeNameStr}(${renderedArgs})`);
     }

--- a/backend/tests/dependency_graph_expr.test.js
+++ b/backend/tests/dependency_graph_expr.test.js
@@ -101,9 +101,9 @@ describe("dependency_graph/expr", () => {
     });
 
     describe("renderExpr()", () => {
-        test("renders an empty argument call as an atom", () => {
+        test("renders an empty argument call with parentheses", () => {
             const expr = parseExpr("foo()");
-            expect(renderExpr(expr)).toBe("foo");
+            expect(renderExpr(expr)).toBe("foo()");
         });
     });
 


### PR DESCRIPTION
### Motivation
- The `renderExpr` function previously collapsed empty-argument calls like `foo()` to `foo`, losing the original parentheses in the rendered output. 
- Preserving the parentheses makes the rendered form faithful to the original expression and avoids surprising diffs when round-tripping parse/render in tooling.
- Canonicalization semantics (head-only canonical form used for schema lookup) must remain unchanged while preserving rendering fidelity.

### Description
- Adjusted `renderExpr` in `backend/src/generators/dependency_graph/expr.js` to always include parentheses for call expressions, even when the argument list is empty. 
- Removed the special-case branch that turned empty-argument calls into atoms so `parseExpr("foo()")` now renders as `"foo()"`.
- Updated the test expectation in `backend/tests/dependency_graph_expr.test.js` to assert `renderExpr(parseExpr("foo()")) === "foo()"`.
- No changes to `canonicalize` behavior: `canonicalize("foo()")` still normalizes to `"foo"` for schema matching.

### Testing
- Ran `npx jest backend/tests/dependency_graph_expr.test.js` and the focused test suite passed.
- Ran the full test suite with `npm test` and all tests passed (152 test suites, 1239 tests), with a non-fatal worker teardown warning observed.
- Built the frontend with `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961a1ac9d6c832e8fb7287ffa0545c6)