### PR TITLE
Clarify arity-0 compound expression semantics in incremental graph spec

### DIFF
--- a/docs/specs/incremental-graph.md
+++ b/docs/specs/incremental-graph.md
@@ -128,7 +128,7 @@ ws            := [ \t\n\r]*
 
 **Terminology:**
 * **atom-expression** — an expression with no brackets (e.g., `all_events`). Denotes a family of exactly one node.
-* **compound-expression** — an expression with brackets (e.g., `event_context(e)`, `enhanced_event(e, p)`, `all_events()`). Each argument is a variable. Denotes an infinite family of nodes.
+* **compound-expression** — an expression with brackets (e.g., `event_context(e)`, `enhanced_event(e, p)`, `all_events()`). Each argument is a variable. If it has one or more variables, it denotes an infinite family of nodes; if it has zero variables (e.g., `all_events()`), it denotes a singleton family (arity 0).
 * **variable** — an identifier in an argument position; represents a parameter that can be bound to any `constvalue`
 * **pattern** — an expression used in a schema definition to describe a family of nodes
 * **free variables** — all variables (identifiers occurring in argument positions) in an expression


### PR DESCRIPTION
### Motivation
- Resolve ambiguity in the expression terminology by making explicit that bracketed expressions with zero variables are arity-0 singleton families, aligning the wording with `REQ-EXPR-02` and the public API semantics.

### Description
- Edit `docs/specs/incremental-graph.md` to change the `compound-expression` definition to state that if it has one or more variables it denotes an infinite family, and if it has zero variables (e.g., `all_events()`) it denotes a singleton family (arity 0).

### Testing
- Documentation-only change; no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69705f935700832eb95af562c96d5575)