### PR TITLE
Clarify deep equality for record values

### DIFF
--- a/docs/specs/incremental-graph.md
+++ b/docs/specs/incremental-graph.md
@@ -192,9 +192,9 @@ function isEqual(a, b) {
   }
   
   // Records (objects)
-  // Important: key order matters.
-  const keysA = Object.keys(a);
-  const keysB = Object.keys(b);
+  // Important: key order does NOT matter.
+  const keysA = Object.keys(a).sort();
+  const keysB = Object.keys(b).sort();
   
   if (keysA.length !== keysB.length) return false;
   


### PR DESCRIPTION
### Motivation
- The deep-equality example in the incremental graph spec implied object key order mattered, which is incorrect for record semantics, so the spec and example needed to be aligned to treat record key order as irrelevant.

### Description
- Updated the `isEqual` example in `docs/specs/incremental-graph.md` to state that record key order does NOT matter and to compare records by sorting `Object.keys(...)` before structural comparison.

### Testing
- Ran `npm test`, `npm run static-analysis`, and `npm run build`, and all automated checks completed successfully (test suite: 153 test suites, 1246 tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970635550c0832e943fbb878d7242ab)