### PR TITLE
Clarify nodeName matching rules in incremental graph spec

### DIFF
--- a/docs/specs/incremental-graph.md
+++ b/docs/specs/incremental-graph.md
@@ -299,8 +299,9 @@ await graph.pull("full_event", [{id: "123"}]);
 ### 1.9 Pattern Matching (Normative)
 
 **REQ-MATCH-01:** A schema output pattern `P` **matches** a nodeName `N` if and only if:
-1. `P` and `N` have the same functor (identifier), AND
-2. The arity of `P` matches the expected arity for `N`
+1. `P` and `N` have the same functor (identifier).
+
+Because a public `nodeName` does not encode arity, the schema is the single source of truth for arity. The binding array length is validated separately (REQ-PULL-02, REQ-INV-03), and ambiguous arities for the same functor are prohibited (REQ-MATCH-04).
 
 **REQ-MATCH-02:** Two output patterns **overlap** if they have the same functor and the same arity.
 


### PR DESCRIPTION
### Motivation
- Clarify how public `nodeName` matching relates to schema patterns by making explicit that matching is functor-based and that arity is defined by the schema rather than encoded in the `nodeName`.

### Description
- Update `docs/specs/incremental-graph.md` to replace the previous two-condition definition of `REQ-MATCH-01` with a statement that `P` and `N` match by functor and that arity is validated via the schema (referencing `REQ-PULL-02`, `REQ-INV-03`, and `REQ-MATCH-04`).

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697067301730832e992ba91451fc3c2d)