### PR TITLE
Clarify input instantiation in pull() semantics

### DIFF
--- a/docs/specs/incremental-graph.md
+++ b/docs/specs/incremental-graph.md
@@ -365,7 +365,8 @@ await graph.pull("full_event", [{id: "123"}]);
 pull(nodeName, B):
   schema = lookup_schema_by_nodeName(nodeName)
   nodeKey = createNodeKey(nodeName, B)
-  inputs_values = [pull(I_nodeName, I_bindings) for I in inputs_of(nodeKey)]
+  inputs_instances = instantiate_inputs(schema, B) // REQ-BINDING-01
+  inputs_values = [pull(I_nodeName, I_bindings) for I in inputs_instances]
   old_value = stored_value(nodeKey)
   r ∈ Outcomes(schema, inputs_values, old_value, B)  // nondeterministic choice
   store(nodeKey, r)


### PR DESCRIPTION
### Motivation
- Remove ambiguity in the `pull()` big-step pseudocode by making the input-instantiation step explicit so the semantics matches the variable-name-to-positional-binding rules (REQ-BINDING-01). 

### Description
- Update `docs/specs/incremental-graph.md` to replace the direct comprehension of `inputs_values` with an explicit `instantiate_inputs(schema, B)` step followed by `inputs_values = [pull(...) for I in inputs_instances]`, and annotate it with `// REQ-BINDING-01`.

### Testing
- Ran the focused spec `npx jest backend/tests/incremental_graph_spec.test.js`, which passed. 
- Ran the full test suite via `npm test`, which exercised many tests but produced timeouts in several suites (examples: `backend/tests/scheduler_orphaned_task_restart.test.js`, `backend/tests/entries_get.test.js`, `backend/tests/polling_scheduler_save_restore.test.js`, `backend/tests/entry.get.test.js`, `backend/tests/api_ordering_advanced.test.js`, `backend/tests/api_ordering_basic.test.js`, `backend/tests/entries_post_shortcuts.complex.test.js`, `backend/tests/config.unit.test.js`).
- Static analysis `npm run static-analysis` succeeded and the frontend build `npm run build` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697067301730832e992ba91451fc3c2d)