### PR TITLE
Clarify bindings normalization requirement for incremental graph

### DIFF
--- a/docs/specs/incremental-graph.md
+++ b/docs/specs/incremental-graph.md
@@ -108,6 +108,8 @@ The public API requires both the `nodeName` (functor) and bindings to address a 
 * Public API call: `pull("full_event", [value])` — uses nodeName only, no variable syntax
 * The arity is determined by the schema, not by the caller
 
+**REQ-ARGS-01 (Bindings Normalization):** If `bindings` is omitted or `undefined`, treat it as `[]`. If the schema arity is not 0, the runtime MUST throw an `ArityMismatchError`.
+
 ### 1.3 Expression Grammar (Normative)
 
 **REQ-EXPR-01:** All expressions MUST conform to this grammar:


### PR DESCRIPTION
### Motivation
- Make the spec explicit about how omitted `bindings` are normalized and how arity mismatches must be handled to avoid ambiguity for arity-0 vs arity>0 nodes.

### Description
- Add `REQ-ARGS-01` to `docs/specs/incremental-graph.md` requiring that omitted or `undefined` `bindings` be treated as `[]` and that the runtime must throw an `ArityMismatchError` when the schema arity is not 0.

### Testing
- None executed because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697122d1f700832eae86b46bd2aa7cf7)