### PR TITLE
Rename `canonicalize` to `functor` in incremental graph expr module

### DIFF
--- a/backend/src/generators/incremental_graph/expr.js
+++ b/backend/src/generators/incremental_graph/expr.js
@@ -1,5 +1,5 @@
 /**
- * Expression parsing and canonicalization.
+ * Expression parsing and functor extraction.
  */
 
 const {
@@ -329,17 +329,16 @@ function renderExpr(expr) {
 }
 
 /**
- * Canonicalizes an expression string.
+ * Extracts the functor (head) from an expression string.
  *
- * @param {SchemaPattern | ParsedExpr} str - The expression string to canonicalize
- * @returns {SchemaPattern} The canonical form (still a valid expression)
+ * @param {SchemaPattern | ParsedExpr} str - The expression string to inspect
+ * @returns {NodeName} The functor/head of the expression
  * @throws {Error} If the expression is malformed
  */
-function canonicalize(str) {
+function functor(str) {
     const parsed =
         typeof str === "object" && "name" in str ? str : parseExpr(str);
-    const nodeNameStr = nodeNameToString(parsed.name);
-    return stringToSchemaPattern(nodeNameStr);
+    return parsed.name;
 }
 
 /**
@@ -396,7 +395,7 @@ function canonicalizeMapping(inputExpressions, outputExpression) {
 
 module.exports = {
     parseExpr,
-    canonicalize,
+    functor,
     canonicalizeMapping,
     renderExpr,
     renderArg,

--- a/backend/tests/incremental_graph_expr.test.js
+++ b/backend/tests/incremental_graph_expr.test.js
@@ -4,7 +4,7 @@
 
 const {
     parseExpr,
-    canonicalize,
+    functor,
     canonicalizeMapping,
     renderExpr,
 } = require("../src/generators/incremental_graph/expr");
@@ -107,39 +107,39 @@ describe("incremental_graph/expr", () => {
         });
     });
 
-    describe("canonicalize()", () => {
-        test("canonicalizes an atom", () => {
-            expect(canonicalize("all_events")).toBe("all_events");
-            expect(canonicalize("  all_events  ")).toBe("all_events");
+    describe("functor()", () => {
+        test("extracts a functor from an atom", () => {
+            expect(functor("all_events")).toBe("all_events");
+            expect(functor("  all_events  ")).toBe("all_events");
         });
 
-        test("canonicalizes empty argument list to head/0", () => {
-            expect(canonicalize("foo()")).toBe("foo");
-            expect(canonicalize("foo( )")).toBe("foo");
+        test("extracts functor from empty argument list", () => {
+            expect(functor("foo()")).toBe("foo");
+            expect(functor("foo( )")).toBe("foo");
         });
 
-        test("canonicalizes to head/arity format", () => {
-            expect(canonicalize("event_context(e)")).toBe("event_context");
-            expect(canonicalize("event_context( e )")).toBe("event_context");
-            expect(canonicalize("event_context(x)")).toBe("event_context");
+        test("extracts functor independent of variable names", () => {
+            expect(functor("event_context(e)")).toBe("event_context");
+            expect(functor("event_context( e )")).toBe("event_context");
+            expect(functor("event_context(x)")).toBe("event_context");
         });
 
-        test("canonicalizes with multiple args to head/arity", () => {
-            expect(canonicalize("foo(a,b,c)")).toBe("foo");
-            expect(canonicalize("foo( a , b , c )")).toBe("foo");
-            expect(canonicalize(" foo ( a , b , c ) ")).toBe("foo");
+        test("extracts functor from multiple args", () => {
+            expect(functor("foo(a,b,c)")).toBe("foo");
+            expect(functor("foo( a , b , c )")).toBe("foo");
+            expect(functor(" foo ( a , b , c ) ")).toBe("foo");
         });
 
-        test("variable names don't affect canonicalization", () => {
-            expect(canonicalize("event_context(e)")).toBe("event_context");
-            expect(canonicalize("event_context(x)")).toBe("event_context");
-            expect(canonicalize("enhanced_event(e, p)")).toBe("enhanced_event");
-            expect(canonicalize("enhanced_event(x, y)")).toBe("enhanced_event");
+        test("variable names don't affect functor extraction", () => {
+            expect(functor("event_context(e)")).toBe("event_context");
+            expect(functor("event_context(x)")).toBe("event_context");
+            expect(functor("enhanced_event(e, p)")).toBe("enhanced_event");
+            expect(functor("enhanced_event(x, y)")).toBe("enhanced_event");
         });
 
         test("throws on malformed expression", () => {
-            expect(() => canonicalize("")).toThrow();
-            expect(() => canonicalize("foo(")).toThrow();
+            expect(() => functor("")).toThrow();
+            expect(() => functor("foo(")).toThrow();
         });
     });
 

--- a/backend/tests/test_database_helper.js
+++ b/backend/tests/test_database_helper.js
@@ -15,7 +15,7 @@
 
 const { isFreshness } = require('../src/generators/incremental_graph/database');
 const { createNodeKeyFromPattern, serializeNodeKey } = require('../src/generators/incremental_graph/node_key');
-const { canonicalize } = require('../src/generators/incremental_graph/expr');
+const { functor } = require('../src/generators/incremental_graph/expr');
 const { isJsonKey } = require('./test_json_key_helper');
 
 /**
@@ -28,8 +28,8 @@ function toJsonKey(key) {
     if (isJsonKey(key)) {
         return key;
     }
-    const canonical = canonicalize(key);
-    const nodeKey = createNodeKeyFromPattern(canonical, []);
+    const head = functor(key);
+    const nodeKey = createNodeKeyFromPattern(head, []);
     const nodeKeyString = serializeNodeKey(nodeKey);
     return nodeKeyString;
 }

--- a/backend/tests/test_json_key_helper.js
+++ b/backend/tests/test_json_key_helper.js
@@ -4,7 +4,7 @@
  */
 
 const { createNodeKeyFromPattern, serializeNodeKey } = require("../src/generators/incremental_graph/node_key");
-const { canonicalize } = require("../src/generators/incremental_graph/expr");
+const { functor } = require("../src/generators/incremental_graph/expr");
 
 /**
  * Converts a node name to its JSON key format.
@@ -14,8 +14,8 @@ const { canonicalize } = require("../src/generators/incremental_graph/expr");
  * @returns {string} JSON key
  */
 function toJsonKey(nodeName, bindings = []) {
-    const canonical = canonicalize(nodeName);
-    const nodeKey = createNodeKeyFromPattern(canonical, bindings);
+    const head = functor(nodeName);
+    const nodeKey = createNodeKeyFromPattern(head, bindings);
     const nodeKeyString = serializeNodeKey(nodeKey);
     return nodeKeyString;
 }


### PR DESCRIPTION
### Motivation
- The helper previously named `canonicalize` was actually extracting the functor/head of an expression and the name was misleading relative to the Incremental Graph spec. 
- The change clarifies intent by returning the `NodeName` (functor) rather than implying a full canonical pattern transformation. 
- Update callers and tests so the codebase consistently expresses that we extract a functor/head from expressions.

### Description
- Renamed `canonicalize` to `functor` in `backend/src/generators/incremental_graph/expr.js` and updated its JSDoc to return the `NodeName` functor. 
- Updated exports from the module to export `functor` instead of `canonicalize`. 
- Replaced usages in tests and helpers (`backend/tests/incremental_graph_expr.test.js`, `backend/tests/test_database_helper.js`, `backend/tests/test_json_key_helper.js`) to call `functor` and adjusted expectations/messages accordingly. 
- Updated header/comment text to reflect "functor extraction" and adjusted code that created `NodeKey` from patterns to use the extracted head.

### Testing
- Ran the full test suite with `npm test` and all tests passed (`153` test suites, `1246` tests). 
- Ran static analysis with `npm run static-analysis` which completed without errors. 
- Built the frontend with `npm run build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69719095c364832eba601094c72f1ccc)