### PR TITLE
Normalize zero-argument expression rendering

### DIFF
--- a/backend/src/generators/incremental_graph/expr.js
+++ b/backend/src/generators/incremental_graph/expr.js
@@ -320,7 +320,7 @@ function renderArg(arg) {
  */
 function renderExpr(expr) {
     const nodeNameStr = nodeNameToString(expr.name);
-    if (expr.kind === "atom") {
+    if (expr.kind === "atom" || expr.args.length === 0) {
         return stringToSchemaPattern(nodeNameStr);
     } else {
         const renderedArgs = expr.args.map(renderArg).join(",");

--- a/backend/tests/incremental_graph_expr.test.js
+++ b/backend/tests/incremental_graph_expr.test.js
@@ -101,9 +101,9 @@ describe("incremental_graph/expr", () => {
     });
 
     describe("renderExpr()", () => {
-        test("renders an empty argument call with parentheses", () => {
+        test("normalizes empty argument calls to atoms", () => {
             const expr = parseExpr("foo()");
-            expect(renderExpr(expr)).toBe("foo()");
+            expect(renderExpr(expr)).toBe("foo");
         });
     });
 


### PR DESCRIPTION
### Motivation

- Ensure expression rendering treats zero-argument calls as arity-0 atoms (normalize `foo()` → `foo`) to match the specification's arity-0 equivalence and existing normalization rules.

### Description

- Update `renderExpr` to serialize expressions with zero arguments as atoms by treating `expr.args.length === 0` like an atom.
- Update the corresponding test in `backend/tests/incremental_graph_expr.test.js` to expect the normalized atom form and adjust the test name accordingly.

### Testing

- Ran `npm install` and executed the focused test `npx jest backend/tests/incremental_graph_expr.test.js`, which passed.
- Ran the full test suite with `npm test`, ran static analysis with `npm run static-analysis`, and built the frontend with `npm run build`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c4492b220832eb965f33f924aeab1)