### PR TITLE
Add InvalidUnchangedError for computors returning Unchanged without prior value

### DIFF
--- a/backend/src/generators/incremental_graph/class.js
+++ b/backend/src/generators/incremental_graph/class.js
@@ -34,6 +34,7 @@ const {
     makeInvalidNodeError,
     makeMissingValueError,
     makeInvalidComputorReturnValueError,
+    makeInvalidUnchangedError,
     makeArityMismatchError,
     makeSchemaPatternNotAllowedError,
 } = require("./errors");
@@ -555,10 +556,7 @@ class IncrementalGraphClass {
         if (isUnchanged(computedValue)) {
             // Must have a previous value
             if (oldValue === undefined) {
-                throw makeInvalidComputorReturnValueError(
-                    deserializeNodeKey(nodeKey).head,
-                    "Unchanged (but no previous value exists)"
-                );
+                throw makeInvalidUnchangedError(nodeKey);
             }
         } else {
             // Must be a valid ComputedValue (not null/undefined)

--- a/backend/src/generators/incremental_graph/errors.js
+++ b/backend/src/generators/incremental_graph/errors.js
@@ -355,6 +355,41 @@ function isInvalidComputorReturnValue(object) {
 }
 
 /**
+ * Error for returning Unchanged without a previous value.
+ */
+class InvalidUnchanged extends Error {
+    /**
+     * @param {NodeKeyString} nodeKey
+     */
+    constructor(nodeKey) {
+        super(
+            `Computor returned Unchanged for node '${nodeKey}' without an existing value. ` +
+                `Unchanged is only valid when an old value is present.`
+        );
+        this.name = "InvalidUnchangedError";
+        this.nodeKey = nodeKey;
+    }
+}
+
+/**
+ * Constructs an InvalidUnchanged error.
+ * @param {NodeKeyString} nodeKey
+ * @returns {InvalidUnchanged}
+ */
+function makeInvalidUnchangedError(nodeKey) {
+    return new InvalidUnchanged(nodeKey);
+}
+
+/**
+ * Type guard for InvalidUnchanged.
+ * @param {unknown} object
+ * @returns {object is InvalidUnchanged}
+ */
+function isInvalidUnchanged(object) {
+    return object instanceof InvalidUnchanged;
+}
+
+/**
  * Error for schema arity conflict (same head with different arities).
  */
 class SchemaArityConflict extends Error {
@@ -413,6 +448,8 @@ module.exports = {
     isSchemaOverlap,
     makeInvalidComputorReturnValueError,
     isInvalidComputorReturnValue,
+    makeInvalidUnchangedError,
+    isInvalidUnchanged,
     makeSchemaArityConflictError,
     isSchemaArityConflict,
 };

--- a/backend/src/generators/incremental_graph/index.js
+++ b/backend/src/generators/incremental_graph/index.js
@@ -24,6 +24,8 @@ const {
     isMissingValue,
     makeSchemaOverlapError,
     isSchemaOverlap,
+    makeInvalidUnchangedError,
+    isInvalidUnchanged,
     makeSchemaArityConflictError,
     isSchemaArityConflict,
 } = require('./errors');
@@ -55,6 +57,8 @@ module.exports = {
     isMissingValue,
     makeSchemaOverlapError,
     isSchemaOverlap,
+    makeInvalidUnchangedError,
+    isInvalidUnchanged,
     makeSchemaArityConflictError,
     isSchemaArityConflict,
 };


### PR DESCRIPTION
### Motivation
- The spec requires a distinct error when a computor returns the `Unchanged` sentinel while there is no previous stored value (REQ-UNCH-03), so this makes that failure mode explicit and diagnosable.

### Description
- Add `InvalidUnchangedError` (helpers `makeInvalidUnchangedError` and `isInvalidUnchanged`) to `backend/src/generators/incremental_graph/errors.js` and export them from the incremental-graph module `index.js`.
- Change recomputation validation in `backend/src/generators/incremental_graph/class.js` to throw `makeInvalidUnchangedError(nodeKey)` when a computor returns `Unchanged` but `oldValue` is `undefined`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c4492b220832eb965f33f924aeab1)