### PR TITLE
Fix cached status in counter optimization

### DIFF
--- a/backend/src/generators/incremental_graph/class.js
+++ b/backend/src/generators/incremental_graph/class.js
@@ -537,7 +537,7 @@ class IncrementalGraphClass {
                         batch.freshness.put(nodeKey, "up-to-date");
 
                         // Return cached value without calling computor
-                        return { value: oldValue, status: "unchanged" };
+                        return { value: oldValue, status: "cached" };
                     }
 
                     // Counters don't match: need to recompute (fall through)


### PR DESCRIPTION
### Motivation
- Ensure the status returned when the counter-based optimization skips recomputation matches the documented semantics (should indicate a cached return rather than `unchanged`).

### Description
- Change in `backend/src/generators/incremental_graph/class.js`: when input counters match and recomputation is skipped, return `{ value: oldValue, status: "cached" }` instead of `status: "unchanged"`.

### Testing
- Ran `npm install`, `npx jest backend/tests/incremental_graph_counters.test.js`, full `npm test`, and `npm run build`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c4492b220832eb965f33f924aeab1)