### PR TITLE
Add InvalidNodeNameError and validate public nodeName inputs for incremental graph

### DIFF
--- a/backend/src/generators/incremental_graph/class.js
+++ b/backend/src/generators/incremental_graph/class.js
@@ -32,6 +32,7 @@ const crypto = require("crypto");
 const { isUnchanged } = require("./unchanged");
 const {
     makeInvalidNodeError,
+    makeInvalidNodeNameError,
     makeMissingValueError,
     makeInvalidComputorReturnValueError,
     makeInvalidUnchangedError,
@@ -70,8 +71,16 @@ const MUTEX_KEY = "incremental-graph-operations";
  * @param {string} nodeName
  */
 function ensureNodeNameIsHead(nodeName) {
-    const schemaPattern = stringToSchemaPattern(nodeName);
-    const parsed = parseExpr(schemaPattern);
+    let parsed;
+    try {
+        const schemaPattern = stringToSchemaPattern(nodeName);
+        parsed = parseExpr(schemaPattern);
+    } catch (error) {
+        if (/[(),]/.test(nodeName)) {
+            throw error;
+        }
+        throw makeInvalidNodeNameError(nodeName);
+    }
     if (parsed.kind === "call") {
         throw makeSchemaPatternNotAllowedError(nodeName);
     }

--- a/backend/src/generators/incremental_graph/errors.js
+++ b/backend/src/generators/incremental_graph/errors.js
@@ -36,6 +36,38 @@ function isInvalidNode(object) {
 }
 
 /**
+ * Error for invalid node name values.
+ */
+class InvalidNodeName extends Error {
+    /**
+     * @param {string} nodeName
+     */
+    constructor(nodeName) {
+        super(`Invalid node name '${nodeName}'. Node names must be valid identifiers.`);
+        this.name = "InvalidNodeNameError";
+        this.nodeName = nodeName;
+    }
+}
+
+/**
+ * Constructs an InvalidNodeName error.
+ * @param {string} nodeName
+ * @returns {InvalidNodeName}
+ */
+function makeInvalidNodeNameError(nodeName) {
+    return new InvalidNodeName(nodeName);
+}
+
+/**
+ * Type guard for InvalidNodeName.
+ * @param {unknown} object
+ * @returns {object is InvalidNodeName}
+ */
+function isInvalidNodeName(object) {
+    return object instanceof InvalidNodeName;
+}
+
+/**
  * Error for invalid schema definitions.
  */
 class InvalidSchema extends Error {
@@ -430,6 +462,8 @@ function isSchemaArityConflict(object) {
 module.exports = {
     makeInvalidNodeError,
     isInvalidNode,
+    makeInvalidNodeNameError,
+    isInvalidNodeName,
     makeInvalidSchemaError,
     isInvalidSchema,
     makeSchemaPatternNotAllowedError,

--- a/backend/src/generators/incremental_graph/index.js
+++ b/backend/src/generators/incremental_graph/index.js
@@ -8,6 +8,8 @@ const { makeUnchanged, isUnchanged } = require('./unchanged');
 const { 
     makeInvalidNodeError, 
     isInvalidNode,
+    makeInvalidNodeNameError,
+    isInvalidNodeName,
     makeInvalidSchemaError,
     isInvalidSchema, 
     makeSchemaPatternNotAllowedError, 
@@ -41,6 +43,8 @@ module.exports = {
     isUnchanged,
     makeInvalidNodeError,
     isInvalidNode,
+    makeInvalidNodeNameError,
+    isInvalidNodeName,
     makeInvalidSchemaError,
     isInvalidSchema,
     makeSchemaPatternNotAllowedError,

--- a/backend/tests/incremental_graph_spec.test.js
+++ b/backend/tests/incremental_graph_spec.test.js
@@ -601,6 +601,28 @@ describe("pull/set concrete-ness & node existence errors", () => {
         );
     });
 
+    test("pull rejects invalid node names with InvalidNodeNameError", async () => {
+        const db = new InMemoryDatabase();
+        const g = buildGraph(db, [
+            { output: "a", inputs: [], computor: async () => ({ a: 1 }), isDeterministic: true, hasSideEffects: false },
+        ]);
+
+        await expect(g.pull("invalid-name")).rejects.toMatchObject({
+            name: "InvalidNodeNameError",
+        });
+    });
+
+    test("invalidate rejects invalid node names with InvalidNodeNameError", async () => {
+        const db = new InMemoryDatabase();
+        const g = buildGraph(db, [
+            { output: "a", inputs: [], computor: async () => ({ a: 1 }), isDeterministic: true, hasSideEffects: false },
+        ]);
+
+        await expect(g.invalidate("invalid-name")).rejects.toMatchObject({
+            name: "InvalidNodeNameError",
+        });
+    });
+
     test("pull unknown concrete node throws InvalidNodeError", async () => {
         const db = new InMemoryDatabase();
         const g = buildGraph(db, [


### PR DESCRIPTION
### Motivation

- Provide a clear error type when callers pass invalid node-name strings to the public `pull()`/`invalidate()` API rather than schema expressions. This improves diagnostics and aligns public API validation with spec expectations.

### Description

- Added `InvalidNodeNameError` (`makeInvalidNodeNameError` / `isInvalidNodeName`) and exported the helpers from the incremental graph module (`backend/src/generators/incremental_graph/errors.js`, `index.js`).
- Updated public node-name validation in `ensureNodeNameIsHead()` to map malformed identifier inputs to `InvalidNodeNameError` while preserving existing expression parse errors for inputs that look like schema expressions (keeps expression parse semantics intact) (`backend/src/generators/incremental_graph/class.js`).
- Added spec tests covering invalid node-name cases for both `pull()` and `invalidate()` to ensure the API rejects names like `invalid-name` with `InvalidNodeNameError` (`backend/tests/incremental_graph_spec.test.js`).

### Testing

- Ran dependency install with `npm install` successfully. 
- Ran focused tests with `npx jest backend/tests/incremental_graph_spec.test.js` which passed after the change. 
- Ran the full test suite with `npm test` and all tests passed (`153` suites, `1248` tests). 
- Ran static analysis with `npm run static-analysis` and `npm run build`; both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c5b9e5d94832eac1f3cdc672cf349)