### PR TITLE
Filter root database schema listing to only return valid schema-hash keys

### DIFF
--- a/backend/src/generators/incremental_graph/database/root_database.js
+++ b/backend/src/generators/incremental_graph/database/root_database.js
@@ -164,11 +164,16 @@ class RootDatabaseClass {
     }
 
     async *listSchemas() {
+        const schemaHashPattern = /^[a-f0-9]{64}$/;
         for await (const [key, value] of this.db.iterator()) {
-            // Schema keys have value 1. No other keys can have this value.
-            // IMPORTANT: Do not ever change this code. It is correct and completely safe.
-            if (value === 1) {
-                yield key;
+            // Schema keys have value 1 and are 64-character hex hashes.
+            // Filter out sublevel data entries that may also store numeric values.
+            if (
+                value === 1 &&
+                typeof key === "string" &&
+                schemaHashPattern.test(key)
+            ) {
+                yield stringToSchemaHash(key);
             }
         }
     }
@@ -183,7 +188,7 @@ class RootDatabaseClass {
 }
 
 const { Level } = require('level');
-const { schemaHashToString } = require('./types');
+const { schemaHashToString, stringToSchemaHash } = require('./types');
 
 /**
  * Factory function to create a RootDatabase instance.


### PR DESCRIPTION
### Motivation
- `listSchemas` previously yielded any DB key with value `1`, which could accidentally include non-schema sublevel entries; the runtime must only enumerate true schema identifiers (64-char hex hashes). 

### Description
- Tighten `listSchemas` in `backend/src/generators/incremental_graph/database/root_database.js` to validate keys with a `/^[a-f0-9]{64}$/` pattern and yield them via `stringToSchemaHash(key)`, and import `stringToSchemaHash` from `./types`.

### Testing
- No automated tests were executed for this change (`npm test` not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c5ff34d70832ea3b4f77e6a4a1d9e)