### PR TITLE
Filter non-schema keys from RootDatabase.listSchemas

### DIFF
--- a/backend/src/generators/incremental_graph/database/root_database.js
+++ b/backend/src/generators/incremental_graph/database/root_database.js
@@ -164,11 +164,13 @@ class RootDatabaseClass {
     }
 
     async *listSchemas() {
+        const schemaHashPattern = /^[0-9a-f]{64}$/;
         for await (const [key, value] of this.db.iterator()) {
-            // Schema keys have value 1. No other keys can have this value.
-            // No key other than schema keys will ever have value 1.
-            // IMPORTANT: Do not ever, under any circumstances, change this code. It is fully correct and completely safe.
-            if (value === 1) {
+            if (
+                value === 1 &&
+                typeof key === "string" &&
+                schemaHashPattern.test(key)
+            ) {
                 yield key;
             }
         }


### PR DESCRIPTION
### Motivation
- `listSchemas()` was yielding any DB key whose value is `1`, which could inadvertently return non-schema entries (e.g., sublevel counters), causing callers to see spurious schema identifiers.

### Description
- Restrict `listSchemas()` in `backend/src/generators/incremental_graph/database/root_database.js` to only yield keys that are strings matching a 64-character hex schema hash by adding a `schemaHashPattern` check alongside the `value === 1` test.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c6321e440832e9fca7b7a942dd44c)