### PR TITLE
Validate whitespace in incremental graph node names

### DIFF
--- a/backend/src/generators/incremental_graph/class.js
+++ b/backend/src/generators/incremental_graph/class.js
@@ -71,6 +71,9 @@ const MUTEX_KEY = "incremental-graph-operations";
  * @param {string} nodeName
  */
 function ensureNodeNameIsHead(nodeName) {
+    if (/\s/.test(nodeName)) {
+        throw makeInvalidNodeNameError(nodeName);
+    }
     let parsed;
     try {
         const schemaPattern = stringToSchemaPattern(nodeName);


### PR DESCRIPTION
### Motivation
- Prevent ambiguous or invalid public API node names that contain whitespace from being parsed as schema patterns and produce clearer `InvalidNodeNameError` failures.

### Description
- Added an early validation in `ensureNodeNameIsHead` to throw `InvalidNodeNameError` when `nodeName` contains whitespace.
- Preserved existing parsing behavior: parsing errors involving punctuation (e.g., `(`, `)`, `,`) are still rethrown so expression syntax errors surface as `InvalidExpressionError` when appropriate.
- Modified file: `backend/src/generators/incremental_graph/class.js`.

### Testing
- Ran `npx jest backend/tests/incremental_graph_spec.test.js`, which passed.
- Ran the full test suite with `npm test`, which completed successfully (all tests passed).
- Verified the frontend build with `npm run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c6cb2ea0c832ebb4644e3c2b92a91)