### PR TITLE
Handle missing LevelDB keys in typed database reads

### DIFF
--- a/backend/src/generators/incremental_graph/database/typed_database.js
+++ b/backend/src/generators/incremental_graph/database/typed_database.js
@@ -61,14 +61,20 @@ class TypedDatabaseClass {
     /**
      * Retrieve a value from the database.
      *
-     * Note: Level v10+ returns `undefined` for missing keys rather than throwing an error.
-     * This is the expected behavior and we pass it through directly.
-     *
      * @param {import('./types').DatabaseKey} key - The key to retrieve
      * @returns {Promise<TValue | undefined>}
      */
     async get(key) {
-        return this.sublevel.get(key);
+        try {
+            return await this.sublevel.get(key);
+        } catch (error) {
+            if (error instanceof Error && "code" in error) {
+                if (error.code === "LEVEL_NOT_FOUND") {
+                    return undefined;
+                }
+            }
+            throw error;
+        }
     }
 
     /**


### PR DESCRIPTION
### Motivation
- Ensure `TypedDatabase.get` treats LevelDB "not found" errors as missing keys and returns `undefined` instead of throwing, preserving the expected `GenericDatabase` behavior across LevelDB versions.

### Description
- Update `backend/src/generators/incremental_graph/database/typed_database.js` so `get(key)` catches LevelDB missing-key errors (checks `error.code === "LEVEL_NOT_FOUND"`) and returns `undefined`; other errors are rethrown.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d9ddd6788832eaa8623518be3eabe)