### PR TITLE
Index reverse dependencies during invalidate

### DIFF
--- a/backend/src/generators/incremental_graph/class.js
+++ b/backend/src/generators/incremental_graph/class.js
@@ -334,6 +334,14 @@ class IncrementalGraphClass {
                 batch
             );
 
+            if (nodeDefinition.inputs.length > 0) {
+                await this.storage.ensureReverseDepsIndexed(
+                    nodeDefinition.output,
+                    nodeDefinition.inputs,
+                    batch
+                );
+            }
+
             // Collect operations to mark all dependents as potentially-outdated
             await this.propagateOutdated(nodeDefinition.output, batch);
         });


### PR DESCRIPTION
### Motivation
- Ensure that when a node is invalidated its reverse-dependency index is populated so materialized but not-yet-computed dependents are discoverable during outdated propagation.

### Description
- In `backend/src/generators/incremental_graph/class.js` added a call to `ensureReverseDepsIndexed(nodeDefinition.output, nodeDefinition.inputs, batch)` after `ensureMaterialized(...)` inside `unsafeInvalidate`, gated by `nodeDefinition.inputs.length > 0`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697da38f876c832ebf37694a1e83e4b8)