### PR TITLE
Propagate invalidations through already-stale nodes

### DIFF
--- a/backend/src/generators/incremental_graph/class.js
+++ b/backend/src/generators/incremental_graph/class.js
@@ -268,8 +268,13 @@ class IncrementalGraphClass {
                 // Node not yet materialized, skip
                 continue;
             } else if (currentFreshness === "potentially-outdated") {
-                // Already potentially-outdated, skip
-                continue;
+                // Already potentially-outdated: still propagate to dependents.
+                nodesBecomingOutdated.add(output);
+                await this.propagateOutdated(
+                    output,
+                    batch,
+                    nodesBecomingOutdated
+                );
             } else {
                 /** @type {never} */
                 const x = currentFreshness;


### PR DESCRIPTION
### Motivation

- The invalidation traversal previously stopped when it encountered a node already marked `potentially-outdated`, which can leave that node's transitive materialized dependents erroneously `up-to-date` and violates the invariant that all transitive materialized dependents of a potentially-outdated node must also be potentially-outdated.
- This can cause incorrect behavior when downstream computors are nondeterministic or have side effects, because they may be skipped from recomputation even though an upstream change should have invalidated them.

### Description

- Update `propagateOutdated` in `backend/src/generators/incremental_graph/class.js` to continue recursion for nodes whose `currentFreshness === "potentially-outdated"` by adding them to `nodesBecomingOutdated` and calling `propagateOutdated` on them instead of skipping them.
- The change preserves the loop-avoidance optimization via `nodesBecomingOutdated` while ensuring traversal continues through already-stale nodes so all downstream materialized dependents are reached and marked.

### Testing

- No automated tests were executed for this change (`npm test` was not run); change is small and localized but should be covered by integration tests that exercise `invalidate()` and transitive dependent freshness propagation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697db1b990f4832e919a241e30880402)