### PR TITLE
Index reverse-deps when invalidating materialized nodes

### DIFF
--- a/backend/src/generators/incremental_graph/class.js
+++ b/backend/src/generators/incremental_graph/class.js
@@ -334,6 +334,15 @@ class IncrementalGraphClass {
                 batch
             );
 
+            // Ensure reverse dependencies are indexed for this materialized node.
+            if (nodeDefinition.inputs.length > 0) {
+                await this.storage.ensureReverseDepsIndexed(
+                    nodeDefinition.output,
+                    nodeDefinition.inputs,
+                    batch
+                );
+            }
+
             // Collect operations to mark all dependents as potentially-outdated
             await this.propagateOutdated(nodeDefinition.output, batch);
         });

--- a/backend/tests/incremental_graph_invalidate_revdeps.test.js
+++ b/backend/tests/incremental_graph_invalidate_revdeps.test.js
@@ -1,0 +1,72 @@
+/**
+ * Tests for reverse dependency indexing during invalidate.
+ */
+
+const path = require("path");
+const fs = require("fs");
+const os = require("os");
+const { getRootDatabase } = require("../src/generators/incremental_graph/database");
+const { makeIncrementalGraph } = require("../src/generators/incremental_graph");
+const { getMockedRootCapabilities } = require("./spies");
+const { stubLogger } = require("./stubs");
+const { toJsonKey } = require("./test_json_key_helper");
+
+/**
+ * @typedef {import('../src/generators/incremental_graph/database/types').DatabaseCapabilities} DatabaseCapabilities
+ */
+
+/**
+ * Creates test capabilities with a temporary data directory.
+ * @returns {DatabaseCapabilities & { tmpDir: string }}
+ */
+function getTestCapabilities() {
+    const capabilities = getMockedRootCapabilities();
+    const tmpDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), "incremental-graph-invalidate-revdeps-")
+    );
+
+    stubLogger(capabilities);
+
+    capabilities.environment = {
+        pathToVolodyslavDataDirectory: jest.fn().mockReturnValue(tmpDir),
+    };
+
+    return { ...capabilities, tmpDir };
+}
+
+describe("incremental_graph invalidate reverse deps", () => {
+    test("invalidate indexes reverse dependencies for materialized nodes", async () => {
+        const capabilities = getTestCapabilities();
+        const db = await getRootDatabase(capabilities);
+
+        const graphDef = [
+            {
+                output: "source",
+                inputs: [],
+                computor: async () => ({ type: "all_events", events: [] }),
+                isDeterministic: true,
+                hasSideEffects: false,
+            },
+            {
+                output: "derived",
+                inputs: ["source"],
+                computor: async () => ({ type: "meta_events", meta_events: [] }),
+                isDeterministic: true,
+                hasSideEffects: false,
+            },
+        ];
+
+        const graph = makeIncrementalGraph(db, graphDef);
+
+        await graph.invalidate("derived");
+
+        const storage = graph.getStorage();
+        const sourceKey = toJsonKey("source");
+        const derivedKey = toJsonKey("derived");
+
+        const dependents = await storage.revdeps.get(sourceKey);
+        expect(dependents).toEqual([derivedKey]);
+
+        await db.close();
+    });
+});


### PR DESCRIPTION
### Motivation
- `invalidate()` materialized nodes without recording reverse-dependency entries, so a node that was materialized only via `invalidate()` would not appear in its inputs’ `revdeps` list and could be omitted from later invalidation propagation, violating the spec’s requirement that previously-materialized dependents be reachable for propagation. 

### Description
- Ensure reverse-dependencies are indexed during `unsafeInvalidate()` by calling `storage.ensureReverseDepsIndexed(node, inputs, batch)` when the node has inputs so that invalidation persists the dynamic edge index even if the node is never pulled. 
- Add a regression test `backend/tests/incremental_graph_invalidate_revdeps.test.js` that creates a simple schema, calls `graph.invalidate("derived")`, and asserts the `source` node’s `revdeps` contains the `derived` key.

### Testing
- Ran focused test: `npx jest backend/tests/incremental_graph_invalidate_revdeps.test.js` — passed. 
- Ran full test suite: `npm test` — all tests passed (154 suites, 1248 tests). 
- Static analysis: `npm run static-analysis` — passed. 
- Build: `npm run build` — completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697db1b990f4832e919a241e30880402)