### PR TITLE
Preserve counters for invalidated nodes during incremental-graph migrations

### DIFF
--- a/backend/src/generators/incremental_graph/migration_runner.js
+++ b/backend/src/generators/incremental_graph/migration_runner.js
@@ -118,6 +118,10 @@ async function applyDecisions(prevStorage, newStorage, decisions) {
             ops.push(
                 newStorage.freshness.putOp(nodeKey, "potentially-outdated")
             );
+            const counter = await prevStorage.counters.get(nodeKey);
+            if (counter !== undefined) {
+                ops.push(newStorage.counters.putOp(nodeKey, counter));
+            }
         }
     }
 

--- a/backend/tests/migration_runner.test.js
+++ b/backend/tests/migration_runner.test.js
@@ -1,0 +1,77 @@
+const { runMigration } = require("../src/generators/incremental_graph/migration_runner");
+const { toJsonKey } = require("./test_json_key_helper");
+
+function makeInMemoryDb(table) {
+    const store = new Map();
+    return {
+        async get(key) { return store.get(key); },
+        async put(key, value) { store.set(key, value); },
+        putOp(key, value) { return { type: "put", table, key, value }; },
+        async *keys() { for (const key of store.keys()) yield key; },
+        apply(operation) {
+            if (operation.type === "put" && operation.table === table) {
+                store.set(operation.key, operation.value);
+            }
+        },
+    };
+}
+
+function makeSchemaStorage() {
+    const values = makeInMemoryDb("values");
+    const freshness = makeInMemoryDb("freshness");
+    const inputs = makeInMemoryDb("inputs");
+    const revdeps = makeInMemoryDb("revdeps");
+    const counters = makeInMemoryDb("counters");
+
+    return {
+        values,
+        freshness,
+        inputs,
+        revdeps,
+        counters,
+        async batch(operations) {
+            for (const operation of operations) {
+                values.apply(operation);
+                freshness.apply(operation);
+                inputs.apply(operation);
+                revdeps.apply(operation);
+                counters.apply(operation);
+            }
+        },
+    };
+}
+
+describe("runMigration", () => {
+    test("invalidate preserves counters from previous storage", async () => {
+        const previousStorage = makeSchemaStorage();
+        const currentStorage = makeSchemaStorage();
+        const nodeKey = toJsonKey("A");
+
+        await previousStorage.inputs.put(nodeKey, { inputs: [], inputCounters: [] });
+        await previousStorage.values.put(nodeKey, { type: "all_events", events: [] });
+        await previousStorage.freshness.put(nodeKey, "up-to-date");
+        await previousStorage.counters.put(nodeKey, 5);
+
+        const rootDatabase = {
+            async lastSchema() { return "previous"; },
+            getSchemaStorageForVersion() { return previousStorage; },
+            getSchemaStorage() { return currentStorage; },
+        };
+
+        const nodeDefs = [{
+            output: "A",
+            inputs: [],
+            computor: async () => ({ type: "all_events", events: [] }),
+            isDeterministic: true,
+            hasSideEffects: false,
+            migrations: {},
+        }];
+
+        await runMigration(rootDatabase, nodeDefs, async (storage) => {
+            await storage.invalidate(nodeKey);
+        });
+
+        await expect(currentStorage.counters.get(nodeKey)).resolves.toBe(5);
+        await expect(currentStorage.freshness.get(nodeKey)).resolves.toBe("potentially-outdated");
+    });
+});


### PR DESCRIPTION
### Motivation

- Migration `invalidate` decisions were not preserving prior `counters` when applied to the new schema, which can break counter-based freshness optimizations after migration.

### Description

- Update `applyDecisions` in `backend/src/generators/incremental_graph/migration_runner.js` to write the previous `counters` value for nodes with an `invalidate` decision. 
- Add a regression test `backend/tests/migration_runner.test.js` that uses in-memory schema storages and verifies `runMigration` preserves the counter while setting freshness to `potentially-outdated`.
- Keep batch application semantics unchanged so decisions are still applied atomically via `newStorage.batch`.

### Testing

- Ran `npx jest backend/tests/migration_runner.test.js` and the new test passed.
- Ran the full test suite with `npm test` and all test suites passed (156 passed, 156 total at time of run).
- Ran `npm run static-analysis` and `npm run build` and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5eb12a728832e928f7331d68f73e2)