### PR TITLE
Fix WiFi status detection when BSSID is empty

### DIFF
--- a/backend/src/wifi/connection_checker.js
+++ b/backend/src/wifi/connection_checker.js
@@ -106,11 +106,17 @@ function parseWifiConnectionInfo(jsonOutput) {
     try {
         const data = JSON.parse(jsonOutput);
 
-        // Check if we have the expected structure and bssid is not null
-        if (data && typeof data === 'object' && 'bssid' in data && data.bssid !== null) {
-            const ssid = data.ssid || null;
+        if (!data || typeof data !== "object" || Array.isArray(data)) {
+            return makeDisconnectedStatus();
+        }
+
+        const hasValidBssid = "bssid" in data && typeof data.bssid === "string" && data.bssid.length > 0;
+
+        // Check if we have the expected structure and bssid is a non-empty string
+        if (hasValidBssid) {
+            const ssid = typeof data.ssid === "string" ? data.ssid : null;
             const bssid = data.bssid;
-            const rssi = typeof data.rssi === 'number' ? data.rssi : null;
+            const rssi = typeof data.rssi === "number" ? data.rssi : null;
 
             return makeConnectedStatus(ssid, bssid, rssi);
         }

--- a/backend/tests/wifi.connection_checker.test.js
+++ b/backend/tests/wifi.connection_checker.test.js
@@ -1,0 +1,53 @@
+/**
+ * Tests for WiFi connection parsing behavior in checker.
+ */
+
+describe("WiFi connection checker parsing", () => {
+    test("treats empty-string bssid as disconnected", async () => {
+        jest.resetModules();
+        jest.doMock("../src/executables", () => ({
+            termuxWifiCommand: {
+                call: async () => ({
+                    stdout: JSON.stringify({
+                        ssid: "TestNet",
+                        bssid: "",
+                        rssi: -50,
+                    }),
+                }),
+                ensureAvailable: async () => {},
+            },
+        }));
+
+        const { makeWifiConnectionChecker } = require("../src/wifi/connection_checker");
+        const checker = makeWifiConnectionChecker();
+
+        const result = await checker.checkConnection();
+
+        expect(result.connected).toBe(false);
+        expect(result.bssid).toBeNull();
+    });
+
+    test("keeps connected when bssid is non-empty string", async () => {
+        jest.resetModules();
+        jest.doMock("../src/executables", () => ({
+            termuxWifiCommand: {
+                call: async () => ({
+                    stdout: JSON.stringify({
+                        ssid: "TestNet",
+                        bssid: "aa:bb:cc:dd:ee:ff",
+                        rssi: -50,
+                    }),
+                }),
+                ensureAvailable: async () => {},
+            },
+        }));
+
+        const { makeWifiConnectionChecker } = require("../src/wifi/connection_checker");
+        const checker = makeWifiConnectionChecker();
+
+        const result = await checker.checkConnection();
+
+        expect(result.connected).toBe(true);
+        expect(result.bssid).toBe("aa:bb:cc:dd:ee:ff");
+    });
+});


### PR DESCRIPTION
### Motivation
- The WiFi parser treated any non-null `bssid` (including empty string) as connected, causing false-positive connection status.
- The JSON payload from `termux-wifi-connectioninfo` can be malformed or not an object, which should be treated as disconnected.
- Normalize `ssid`/`rssi` extraction so types are predictable for callers of `parseWifiConnectionInfo`.

### Description
- Tighten `parseWifiConnectionInfo` to return connected only when `bssid` is a non-empty string and to reject non-object/malformed JSON payloads. (`backend/src/wifi/connection_checker.js`) 
- Normalize `ssid` to `null` unless it is a string and keep `rssi` only when it is a number. (`parseWifiConnectionInfo`) 
- Add focused tests verifying empty-string `bssid` is treated as disconnected and a non-empty `bssid` remains connected. (`backend/tests/wifi.connection_checker.test.js`)

### Testing
- Ran `npx jest backend/tests/wifi.connection_checker.test.js` and the two new tests passed.
- Ran the full test suite with `npm test` and all test suites passed (176 passed, 176 total).
- Ran `npm run static-analysis` (TypeScript + ESLint) and it completed successfully.
- Ran `npm run build` and frontend build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aff2bfd97c832ea0f276544a809970)