### PR TITLE
Fix hasMore detection for search pagination responses

### DIFF
--- a/frontend/src/Search/api.js
+++ b/frontend/src/Search/api.js
@@ -46,7 +46,7 @@ export async function searchEntries(pattern, page = 1, limit = 50) {
 
         if (response.ok) {
             const data = await response.json();
-            return { results: parseEntries(data.results), hasMore: data.next !== null };
+            return { results: parseEntries(data.results), hasMore: data.next != null };
         }
 
         logger.warn("Failed to search entries:", response.status);


### PR DESCRIPTION
### Motivation
- The frontend treated an absent `next` field as a truthy value, causing the UI to show a stale "Load more" state when the backend omits `next` instead of returning `null`.

### Description
- Change comparison in `frontend/src/Search/api.js` so `hasMore` is computed with `data.next != null` instead of `data.next !== null`, treating both `null` and `undefined` as "no next page".

### Testing
- Ran focused tests: `npx jest frontend/tests/Search.test.jsx` — passed.
- Ran full test suite: `npm test` — reported unrelated backend timeouts in 3 tests (`incremental_graph_counters`, `scheduler_orphaned_task_restart`, `incremental_graph_batch_consistency`).
- Ran static analysis: `npm run static-analysis` — passed.
- Ran build: `npm run build` — passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aff2bfd97c832ea0f276544a809970)