### PR TITLE
Fix race condition in sleeper mutex implementation

### DIFF
--- a/backend/src/sleeper.js
+++ b/backend/src/sleeper.js
@@ -2,8 +2,6 @@
  * SleepCapability capability for pausing execution.
  */
 
-const memconst = require('./memconst');
-
 /** @typedef {import('./datetime').Duration} Duration */
 /** @typedef {import('./unique_functor').UniqueTerm} UniqueTerm */
 
@@ -22,7 +20,7 @@ const memconst = require('./memconst');
 
 function make() {
 
-    /** @type {Map<string, () => Promise<unknown>>} */
+    /** @type {Map<string, Promise<void>>} */
     const mutexes = new Map();
 
     /**
@@ -36,21 +34,24 @@ function make() {
         for (;;) {
             const existing = mutexes.get(stringKey);
             if (existing === undefined) {
-                break;    
-            } else {
-                await existing();
+                break;
             }
+            await existing;
         }
 
-        const wrapped = memconst(async () => {
-            mutexes.set(stringKey, wrapped);
-            try {
-                return await procedure();
-            } finally {
-                mutexes.delete(stringKey);
-            }
+        /** @type {(value: void) => void} */
+        let release = () => undefined;
+        const lock = new Promise((resolve) => {
+            release = resolve;
         });
-        return await wrapped();
+        mutexes.set(stringKey, lock);
+
+        try {
+            return await procedure();
+        } finally {
+            mutexes.delete(stringKey);
+            release();
+        }
     }
 
     /**

--- a/backend/tests/sleeper_mutex.test.js
+++ b/backend/tests/sleeper_mutex.test.js
@@ -1,0 +1,40 @@
+const { make } = require('../src/sleeper');
+const { makeUniqueFunctor } = require('../src/unique_functor');
+
+let uniqueCounter = 0;
+
+function makeKey() {
+    uniqueCounter += 1;
+    const functor = makeUniqueFunctor(`sleeper-mutex-test-${uniqueCounter}-${Math.random()}`);
+    return functor.instantiate(['resource']);
+}
+
+describe('sleeper.withMutex', () => {
+    it('runs concurrent calls with the same key sequentially', async () => {
+        const sleeper = make();
+        const key = makeKey();
+
+        /** @type {Array<string>} */
+        const trace = [];
+
+        const first = sleeper.withMutex(key, async () => {
+            trace.push('first-start');
+            await new Promise((resolve) => setTimeout(resolve, 30));
+            trace.push('first-end');
+        });
+
+        const second = sleeper.withMutex(key, async () => {
+            trace.push('second-start');
+            trace.push('second-end');
+        });
+
+        await Promise.all([first, second]);
+
+        expect(trace).toEqual([
+            'first-start',
+            'first-end',
+            'second-start',
+            'second-end',
+        ]);
+    });
+});


### PR DESCRIPTION
### Motivation

- The `withMutex` implementation could allow two concurrent callers with the same mutex key to both enter the critical section because the lock was not inserted into the mutex map before running the protected procedure.

### Description

- Insert an explicit lock `Promise` into the mutex map before invoking the protected `procedure` and release it in `finally` to ensure strict mutual exclusion.
- Replace the previous memoized-wrapper approach and remove the unused `memconst` dependency in this module.
- Tighten the mutex map typing to `Map<string, Promise<void>>` to reflect the stored lock promises.
- Add a regression test `backend/tests/sleeper_mutex.test.js` that verifies two concurrent `withMutex` calls using the same key execute sequentially.

### Testing

- Ran the new regression test with `npx jest backend/tests/sleeper_mutex.test.js --runInBand` which passed.
- Ran the full test suite with `npm test` and all tests passed (176 passed, 176 total).
- Ran static analysis with `npm run static-analysis` which passed with no ESLint/TS errors.
- Verified frontend build with `npm run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aff2bfd97c832ea0f276544a809970)