### PR TITLE
Throw FilenameDoesNotEncodeDate for invalid timestamps in filenames

### DIFF
--- a/backend/src/format_time_stamp.js
+++ b/backend/src/format_time_stamp.js
@@ -46,10 +46,9 @@ function formatFileTimestamp(filename) {
     const dateObject = formatTimeStamp(basic);
 
     if (dateObject === undefined) {
-        // This should ideally not be hit if 'basic' is from the regex match above
-        // and format_time_stamp's regex is correct.
-        throw new Error(
-            `Failed to parse valid Date from timestamp string: ${basic}`
+        throw new FilenameDoesNotEncodeDate(
+            `Filename ${JSON.stringify(filename)} contains an invalid timestamp: ${basic}`,
+            filename,
         );
     }
 

--- a/backend/tests/format_time_stamp.test.js
+++ b/backend/tests/format_time_stamp.test.js
@@ -28,6 +28,6 @@ describe('formatFileTimestamp', () => {
     const dt = require('../src/datetime').make();
     await expect(async () =>
       formatFileTimestamp('20250230T000000Z.txt', dt)
-    ).rejects.toThrow('Failed to parse valid Date from timestamp string: 20250230T000000Z');
+    ).rejects.toThrow('Filename "20250230T000000Z.txt" contains an invalid timestamp: 20250230T000000Z');
   });
 });


### PR DESCRIPTION
### Motivation
- Previously `formatFileTimestamp` threw a generic `Error` when a filename contained the expected timestamp prefix but encoded an invalid calendar timestamp, which reduced error inspectability and consistency with the module's specific error types.

### Description
- Replace the generic `Error` with `FilenameDoesNotEncodeDate` in `backend/src/format_time_stamp.js` when `formatTimeStamp` returns `undefined` for a matched prefix and include the filename and extracted timestamp in the message.
- Update `backend/tests/format_time_stamp.test.js` to expect the new, more specific error message for invalid calendar dates.

### Testing
- Ran the focused test with `npx jest backend/tests/format_time_stamp.test.js` and it passed.
- Ran the full test suite with `npm test`, static analysis with `npm run static-analysis`, and build with `npm run build`, and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b009686a9c832e94e145e9d516d75d)