### PR TITLE
Require non-empty extension in timestamp filename parsing

### DIFF
--- a/backend/src/format_time_stamp.js
+++ b/backend/src/format_time_stamp.js
@@ -31,7 +31,7 @@ function isFilenameDoesNotEncodeDate(object) {
 */
 function formatFileTimestamp(filename) {
     // 1) extract the basic‐ISO timestamp (YYYYMMDDThhmmssZ)
-    const m = filename.match(/^(\d{8}T\d{6}Z)[.].*/);
+    const m = filename.match(/^(\d{8}T\d{6}Z)[.].+/);
     if (!m)
         throw new FilenameDoesNotEncodeDate(
             `Filename ${JSON.stringify(

--- a/backend/tests/format_time_stamp.test.js
+++ b/backend/tests/format_time_stamp.test.js
@@ -24,6 +24,13 @@ describe('formatFileTimestamp', () => {
     );
   });
 
+
+  it('throws an error when extension is missing after dot', async () => {
+    await expect(async () =>
+      formatFileTimestamp('20250228T120000Z.')
+    ).rejects.toThrow('does not start with YYYYMMDDThhmmssZ');
+  });
+
   it('throws an error for invalid calendar date', async () => {
     const dt = require('../src/datetime').make();
     await expect(async () =>


### PR DESCRIPTION
### Motivation
- Ensure `formatFileTimestamp` enforces the documented filename format `YYYYMMDDThhmmssZ.<extension>` and reject filenames that end with a dot and no extension, which were previously accepted.

### Description
- Tightened the filename regex in `backend/src/format_time_stamp.js` to require at least one character after the dot (`/^(
\d{8}T\d{6}Z)[.].+/`) and added a regression test in `backend/tests/format_time_stamp.test.js` that asserts `'20250228T120000Z.'` is rejected.

### Testing
- Ran `npx jest backend/tests/format_time_stamp.test.js` which passed, ran `npm run static-analysis` which passed, and ran `npm run build` which passed; running the full `npm test` in this environment produced unrelated existing Jest timeout failures outside the scope of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b009686a9c832e94e145e9d516d75d)