### PR TITLE
Await route registration during server startup

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -63,7 +63,7 @@ async function addRoutes(capabilities, app) {
  * @description Ensures that the necessary startup dependencies are available.
  */
 async function ensureStartupDependencies(capabilities, app) {
-    addRoutes(capabilities, app);
+    await addRoutes(capabilities, app);
     await capabilities.environment.ensureEnvironmentIsInitialized(
         capabilities.environment
     );


### PR DESCRIPTION
### Motivation
- Fix a startup sequencing bug where the async `addRoutes` call in `ensureStartupDependencies` was not awaited, which could allow initialization to continue before routes were fully registered.

### Description
- Awaited `addRoutes(capabilities, app)` in `backend/src/server.js` so route registration completes before subsequent startup checks and scheduler initialization.

### Testing
- `npx jest backend/tests/index.test.js --runInBand` passed; `npm run static-analysis` passed; `npm run build` passed; running the full `npm test -- --runInBand` exposed pre-existing frontend failures (React "Invalid hook call") that appear unrelated to this backend change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b009686a9c832e94e145e9d516d75d)