### PR TITLE
Fix RNG nextInt boundary handling

### DIFF
--- a/backend/src/random/interface.js
+++ b/backend/src/random/interface.js
@@ -24,8 +24,17 @@ function fromFloatGenerator(nextFloat) {
             throw new RangeError("max must be greater or equal than min");
         }
 
+        const randomFloat = nextFloat();
+        if (!Number.isFinite(randomFloat) || randomFloat < 0 || randomFloat > 1) {
+            throw new RangeError("nextFloat must return a finite number in [0, 1]");
+        }
+
+        const boundedFloat = randomFloat === 1
+            ? 1 - Number.EPSILON
+            : randomFloat;
+
         const range = max + 1 - min;
-        return min + Math.floor(nextFloat() * range);
+        return min + Math.floor(boundedFloat * range);
     }
 
     return nextInt;

--- a/backend/tests/random.test.js
+++ b/backend/tests/random.test.js
@@ -1,5 +1,7 @@
 const { defaultGenerator } = require("../src/random");
 
+const { make } = require("../src/random/interface");
+
 const capabilities = {
     seed: {
         generate: () => 42,
@@ -30,5 +32,15 @@ describe("RandomNumberGeneratorClass", () => {
         expect(() => rng.nextInt(1.2, 5)).toThrow(TypeError);
         expect(() => rng.nextInt(5, 4)).toThrow(RangeError);
         expect(() => rng.nextInt(10, 5)).toThrow(RangeError);
+    });
+
+    test("nextInt handles boundary value when nextFloat returns 1", () => {
+        const rng = make({ nextFloat: () => 1 });
+        expect(rng.nextInt(5, 10)).toBe(10);
+    });
+
+    test("nextInt throws when nextFloat returns invalid value", () => {
+        const rng = make({ nextFloat: () => Number.NaN });
+        expect(() => rng.nextInt(1, 3)).toThrow(RangeError);
     });
 });


### PR DESCRIPTION
### Motivation

- The integer RNG conversion could produce `max + 1` when the underlying `nextFloat()` returned exactly `1`, and invalid `nextFloat()` outputs (e.g. `NaN`) could silently propagate.

### Description

- Validate that `nextFloat()` returns a finite number in `[0, 1]` and throw a `RangeError` for invalid outputs in `fromFloatGenerator`.
- Treat the `nextFloat() === 1` edge by bounding it to `1 - Number.EPSILON` before scaling so `nextInt(min, max)` always yields a value in `[min, max]`.
- Update the RNG factory to use the bounded float for integer generation and add regression tests covering the `1` boundary and invalid `nextFloat` values.
- Files changed: `backend/src/random/interface.js` and `backend/tests/random.test.js`.

### Testing

- Ran the focused test: `npx jest backend/tests/random.test.js --runInBand`, which passed (5 tests).
- Ran static analysis: `npm run static-analysis` (TypeScript + ESLint) and it completed successfully.
- Built the frontend: `npm run build` and the build succeeded.
- Ran the full test suite: `npm test`, which completed successfully (`177` test suites, `1662` tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b009686a9c832e94e145e9d516d75d)