### PR TITLE
Handle invalid cron hour/minute sets in previous execution calculator

### DIFF
--- a/backend/src/scheduler/calculator/previous.js
+++ b/backend/src/scheduler/calculator/previous.js
@@ -16,6 +16,13 @@ const { CronCalculationError } = require("./errors");
  * @returns {import('../../datetime').DateTime} Previous execution datetime, or null if none found
  */
 function getMostRecentExecution(cronExpr, origin) {
+    if (cronExpr.validHours.length === 0 || cronExpr.validMinutes.length === 0) {
+        throw new CronCalculationError("Cron expression has no valid hour/minute values", {
+            cronExpression: cronExpr,
+            origin,
+        });
+    }
+
     for (const { year, month, day } of iterateValidDaysBackwards(cronExpr, origin)) {
         const getTime = () => {
             const validHours = cronExpr.validHours;
@@ -48,6 +55,14 @@ function getMostRecentExecution(cronExpr, origin) {
             } else {
                 const hour = validHours[validHours.length - 1];
                 const minute = validMinutes[validMinutes.length - 1];
+
+                if (hour === undefined || minute === undefined) {
+                    throw new CronCalculationError("Cron expression has no valid hour/minute values", {
+                        cronExpression: cronExpr,
+                        origin,
+                    });
+                }
+
                 return { hour, minute };
             }
         };

--- a/backend/tests/scheduler_calculator.test.js
+++ b/backend/tests/scheduler_calculator.test.js
@@ -1,6 +1,7 @@
 
 const { getNextExecution, getMostRecentExecution } = require("../src/scheduler/calculator");
 const { parseCronExpression } = require("../src/scheduler/expression");
+const { isCronCalculationError } = require("../src/scheduler/calculator/errors");
 const { fromISOString } = require("../src/datetime");
 
 function next(cronExprStr, fromISOStringStr) {
@@ -172,6 +173,23 @@ describe("getMostRecentExecution", () => {
 
     test("previous minute explicit values alignment: prev('0,15,30,45 * * * *') from :01 → :00", () => {
         expect(prev("0,15,30,45 * * * *", "2025-01-14T10:01:00.000Z")).toBe("2025-01-14T10:00:00.000Z");
+    });
+
+    test("throws CronCalculationError when cron expression has no valid minutes", () => {
+        const expr = parseCronExpression("* * * * *");
+        expr.validMinutes.length = 0;
+
+        expect(() => getMostRecentExecution(expr, fromISOString("2025-01-01T00:00:00.000Z"))).toThrow(
+            /Cron expression has no valid hour\/minute values/
+        );
+
+        let thrown;
+        try {
+            getMostRecentExecution(expr, fromISOString("2025-01-01T00:00:00.000Z"));
+        } catch (error) {
+            thrown = error;
+        }
+        expect(isCronCalculationError(thrown)).toBe(true);
     });
 });
 


### PR DESCRIPTION
### Motivation
- Prevent inconsistent or internal-error behavior when a parsed cron expression has an empty `validHours` or `validMinutes` (e.g. mutated or malformed expression) by surfacing a typed error early.

### Description
- Added defensive validation in `getMostRecentExecution` (`backend/src/scheduler/calculator/previous.js`) to throw `CronCalculationError` when `validHours` or `validMinutes` are empty.
- Replaced a potential generic internal error path with the same `CronCalculationError` for consistent error typing and inspectability.
- Added a regression unit test to `backend/tests/scheduler_calculator.test.js` that corrupts a parsed expression (`expr.validMinutes.length = 0`) and asserts the thrown error message and the `isCronCalculationError` type guard.

### Testing
- Ran the focused unit test with `npx jest backend/tests/scheduler_calculator.test.js --runInBand`, which passed (all scheduler calculator assertions including the new case).
- Ran static analysis via `npm run static-analysis`, which passed (`tsc` + `eslint`).
- Verified frontend build with `npm run build`, which completed successfully.
- Ran the full test suite with `npm test`; the run exposed a pre-existing unrelated test timeout in `backend/tests/api_ordering_advanced.test.js` (unrelated to these changes). All scheduler-related tests and the newly added test passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0340e20c0832ea4304ee3cef67307)