### PR TITLE
Fix relative date formatting for invalid and future timestamps

### DIFF
--- a/frontend/src/DescriptionEntry/utils.js
+++ b/frontend/src/DescriptionEntry/utils.js
@@ -11,9 +11,18 @@ import { DateTime } from 'luxon';
  */
 export const formatRelativeDate = (dateString) => {
     const date = DateTime.fromISO(dateString);
+    if (!date.isValid) {
+        return "just now";
+    }
+
     const now = DateTime.now();
     const diff = now.diff(date);
     const diffMs = diff.as('milliseconds');
+
+    if (diffMs <= 0) {
+        return "just now";
+    }
+
     const diffMins = Math.floor(diffMs / (1000 * 60));
     const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
     const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));

--- a/frontend/tests/DescriptionEntry.utils.test.js
+++ b/frontend/tests/DescriptionEntry.utils.test.js
@@ -1,0 +1,13 @@
+import { DateTime } from "luxon";
+import { formatRelativeDate } from "../src/DescriptionEntry/utils.js";
+
+describe("formatRelativeDate", () => {
+    it("returns just now for invalid ISO inputs", () => {
+        expect(formatRelativeDate("not-an-iso-date")).toBe("just now");
+    });
+
+    it("returns just now for future dates", () => {
+        const future = DateTime.now().plus({ minutes: 5 }).toISO();
+        expect(formatRelativeDate(future)).toBe("just now");
+    });
+});


### PR DESCRIPTION
### Motivation
- Prevent `formatRelativeDate` from returning misleading values when given invalid ISO strings or future timestamps by normalizing those cases to a safe "just now" output.

### Description
- Add a validity guard to `formatRelativeDate` to return `"just now"` when `DateTime.fromISO` produces an invalid value.
- Return `"just now"` when the computed time difference is non-positive (future or equal timestamps).
- Add focused tests in `frontend/tests/DescriptionEntry.utils.test.js` covering invalid ISO input and future timestamps.

### Testing
- Ran `npm install` and `npx jest frontend/tests/DescriptionEntry.utils.test.js` and the new tests passed.
- Ran the full suite with `npm test` and all test suites passed (178 passed).
- Ran static analysis with `npm run static-analysis` and the checks passed.
- Built the frontend with `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0340e20c0832ea4304ee3cef67307)