### PR TITLE
Make DescriptionEntry error classification case-insensitive and map photo-storage permission errors

### DIFF
--- a/frontend/src/DescriptionEntry/error_helpers.js
+++ b/frontend/src/DescriptionEntry/error_helpers.js
@@ -105,31 +105,36 @@ export const ErrorMessages = {
  * @returns {string} - User-friendly error message
  */
 export function getUserFriendlyErrorMessage(error) {
+    const normalizedMessage = error instanceof Error ? error.message.toLowerCase() : "";
+
     if (isPhotoRetrievalError(error)) {
-        if (error.message.includes('JSON')) {
+        if (normalizedMessage.includes('json')) {
             return ErrorMessages.photoRetrieval.corrupted;
         }
-        if (error.message.includes('fetch') || error.message.includes('File')) {
+        if (normalizedMessage.includes('fetch') || normalizedMessage.includes('file')) {
             return ErrorMessages.photoRetrieval.conversionFailed;
         }
-        if (error.message.includes('storage')) {
+        if (normalizedMessage.includes('storage')) {
             return ErrorMessages.photoRetrieval.sessionStorage;
         }
         return ErrorMessages.photoRetrieval.notFound;
     }
 
     if (isPhotoStorageError(error)) {
-        if (error.message.includes('quota') || error.message.includes('QuotaExceededError')) {
+        if (normalizedMessage.includes('quota') || normalizedMessage.includes('quotaexceedederror')) {
             return ErrorMessages.photoStorage.quotaExceeded;
+        }
+        if (normalizedMessage.includes('denied') || normalizedMessage.includes('permission')) {
+            return ErrorMessages.photoStorage.accessDenied;
         }
         return ErrorMessages.photoStorage.genericFailure;
     }
 
     if (isCameraAccessError(error)) {
-        if (error.message.includes('Permission') || error.message.includes('permission')) {
+        if (normalizedMessage.includes('permission')) {
             return ErrorMessages.cameraAccess.permissionDenied;
         }
-        if (error.message.includes('device') || error.message.includes('Device')) {
+        if (normalizedMessage.includes('device')) {
             return ErrorMessages.cameraAccess.deviceNotFound;
         }
         return ErrorMessages.cameraAccess.genericFailure;
@@ -142,7 +147,7 @@ export function getUserFriendlyErrorMessage(error) {
         if (error.statusCode && error.statusCode >= 500) {
             return ErrorMessages.submission.serverError;
         }
-        if (error.message.includes('network') || error.message.includes('fetch')) {
+        if (normalizedMessage.includes('network') || normalizedMessage.includes('fetch')) {
             return ErrorMessages.submission.networkError;
         }
         return ErrorMessages.submission.genericFailure;
@@ -212,4 +217,3 @@ export function makePhotoStorageError(message, cause = null) {
 export function makePhotoConversionError(message, conversionType, cause = null) {
     return new PhotoConversionError(message, conversionType, cause);
 }
-

--- a/frontend/tests/DescriptionEntry.errorHandling.test.jsx
+++ b/frontend/tests/DescriptionEntry.errorHandling.test.jsx
@@ -5,6 +5,7 @@
 import {
     makePhotoRetrievalError,
     makeEntrySubmissionError,
+    makePhotoStorageError,
     getUserFriendlyErrorMessage,
     isPhotoRetrievalError,
     isEntrySubmissionError
@@ -50,6 +51,18 @@ describe('Error Handling System', () => {
             const error = makeEntrySubmissionError('fetch failed');
             const message = getUserFriendlyErrorMessage(error);
             expect(message).toContain('Network');
+        });
+
+        it('handles uppercase fetch/file hints for photo retrieval errors', () => {
+            const error = makePhotoRetrievalError('File conversion failed after FETCH');
+            const message = getUserFriendlyErrorMessage(error);
+            expect(message).toContain('Failed to process');
+        });
+
+        it('returns access denied message for photo storage permission errors', () => {
+            const error = makePhotoStorageError('Permission denied while writing image');
+            const message = getUserFriendlyErrorMessage(error);
+            expect(message).toContain('browser settings');
         });
 
         it('generates appropriate message for validation errors', () => {


### PR DESCRIPTION
### Motivation

- Error classification in `getUserFriendlyErrorMessage` relied on case-sensitive string checks (e.g. `"JSON"`, `"File"`, `"Permission"`) which caused misclassification for messages with different capitalization.
- Photo storage permission/denied messages were not explicitly mapped to the `accessDenied` user message and could fall through to a generic failure message.

### Description

- Normalize the inspected error text by adding `const normalizedMessage = error instanceof Error ? error.message.toLowerCase() : "";` and use `normalizedMessage` for all substring checks in `getUserFriendlyErrorMessage` in `frontend/src/DescriptionEntry/error_helpers.js`.
- Add explicit detection of permission/denied wording for `PhotoStorageError` to return `ErrorMessages.photoStorage.accessDenied` instead of the generic failure message.
- Add regression tests to `frontend/tests/DescriptionEntry.errorHandling.test.jsx` that exercise uppercase/mixed-case hints (`File`/`FETCH`) and a photo-storage permission error using `makePhotoStorageError` so these scenarios are covered.

### Testing

- Ran targeted tests with `npx jest frontend/tests/DescriptionEntry.errorHandling.test.jsx frontend/tests/DescriptionEntry.hooks.errorHandling.test.jsx`, and both suites passed.
- Ran full static analysis with `npm run static-analysis` and a production frontend build with `npm run build`, both of which completed successfully.
- Ran the full test suite with `npm test`; note that unrelated existing frontend test failures (invalid React hook calls in suites such as `Search`, `ConfigPage`, `Camera`, and several DescriptionEntry integration tests) cause the overall `npm test` to report failures, but the updated DescriptionEntry tests pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0340e20c0832ea4304ee3cef67307)