### PR TITLE
Fix audio diary submission: attach request identifier and use .weba extension

### DIFF
--- a/frontend/src/AudioDiary/AudioDiary.jsx
+++ b/frontend/src/AudioDiary/AudioDiary.jsx
@@ -19,7 +19,11 @@ import {
 import { keyframes } from "@emotion/react";
 import { submitEntry } from "../DescriptionEntry/api.js";
 import { useAudioRecorder } from "./useAudioRecorder.js";
-import { formatTime, extensionForMime } from "./audio_helpers.js";
+import {
+    formatTime,
+    extensionForMime,
+    makeDiaryRequestIdentifier,
+} from "./audio_helpers.js";
 import AudioVisualization from "./AudioVisualization.jsx";
 import { MicrophoneIcon, PauseIcon, StopIcon } from "./icons.jsx";
 import RestoredSessionBanner from "./RestoredSessionBanner.jsx";
@@ -76,6 +80,7 @@ export default function AudioDiary() {
         try {
             const ext = extensionForMime(mimeTypeRef.current);
             const filename = `diary-recording.${ext}`;
+            const requestIdentifier = makeDiaryRequestIdentifier();
             const file = new File([audioBlob], filename, {
                 type: mimeTypeRef.current || "audio/webm",
             });
@@ -84,7 +89,7 @@ export default function AudioDiary() {
                 ? `diary [audiorecording] ${note.trim()}`
                 : "diary [audiorecording]";
 
-            const result = await submitEntry(rawInput, undefined, [file]);
+            const result = await submitEntry(rawInput, requestIdentifier, [file]);
 
             if (!isMountedRef.current) {
                 return;

--- a/frontend/src/AudioDiary/audio_helpers.js
+++ b/frontend/src/AudioDiary/audio_helpers.js
@@ -23,9 +23,23 @@ export function formatTime(totalSeconds) {
  * @returns {string}
  */
 export function extensionForMime(mimeType) {
+    if (mimeType.includes("webm")) return "weba";
     if (mimeType.includes("ogg")) return "ogg";
     if (mimeType.includes("mp4")) return "mp4";
-    return "webm";
+    return "weba";
+}
+
+/**
+ * Builds a request identifier for an audio diary submission.
+ * This mirrors the describe flow, where asset-bearing submissions carry a
+ * client-generated identifier alongside the entry payload.
+ *
+ * @returns {string}
+ */
+export function makeDiaryRequestIdentifier() {
+    const randomComponent = Math.random().toString(36).slice(2, 11);
+    const suffix = `${randomComponent}${Math.random().toString(36).slice(2, 7)}`;
+    return `diary_${suffix}`;
 }
 
 /** @returns {RecorderState} */

--- a/frontend/tests/AudioDiary.test.jsx
+++ b/frontend/tests/AudioDiary.test.jsx
@@ -462,12 +462,13 @@ describe("AudioDiary page", () => {
             expect(submitEntry).toHaveBeenCalledTimes(1);
         });
 
-        const [rawInput, _reqId, files] = submitEntry.mock.calls[0];
+        const [rawInput, requestIdentifier, files] = submitEntry.mock.calls[0];
         expect(rawInput).toBe("diary [audiorecording]");
-        expect(_reqId).toBeUndefined();
+        expect(requestIdentifier).toMatch(/^diary_/);
         expect(Array.isArray(files)).toBe(true);
         expect(files).toHaveLength(1);
         expect(files[0]).toBeInstanceOf(File);
+        expect(files[0].name).toBe("diary-recording.weba");
     });
 
     it("submit with a note includes the note in rawInput", async () => {

--- a/frontend/tests/audio_helpers.test.js
+++ b/frontend/tests/audio_helpers.test.js
@@ -1,0 +1,25 @@
+import {
+    extensionForMime,
+    makeDiaryRequestIdentifier,
+} from "../src/AudioDiary/audio_helpers.js";
+
+describe("audio_helpers", () => {
+    it("uses the backend-compatible weba extension for webm audio", () => {
+        expect(extensionForMime("audio/webm;codecs=opus")).toBe("weba");
+        expect(extensionForMime("audio/webm")).toBe("weba");
+    });
+
+    it("keeps known non-webm audio extensions unchanged", () => {
+        expect(extensionForMime("audio/ogg")).toBe("ogg");
+        expect(extensionForMime("audio/mp4")).toBe("mp4");
+    });
+
+    it("builds diary submission request identifiers with a stable prefix", () => {
+        const firstIdentifier = makeDiaryRequestIdentifier();
+        const secondIdentifier = makeDiaryRequestIdentifier();
+
+        expect(firstIdentifier).toMatch(/^diary_/);
+        expect(secondIdentifier).toMatch(/^diary_/);
+        expect(secondIdentifier).not.toBe(firstIdentifier);
+    });
+});


### PR DESCRIPTION
### Motivation
- The audio diary submit flow created a file upload without the request identifier used elsewhere for asset uploads, and used a `.webm` filename that the backend does not expect for diary audio assets.
- Align the audio-diary behavior with the `/describe`/camera flow so uploaded audio assets are processed and associated with photos/requests correctly.

### Description
- Generate and include a client-side request identifier for audio diary submissions by adding `makeDiaryRequestIdentifier()` and passing it to `submitEntry` from the diary page (`frontend/src/AudioDiary/AudioDiary.jsx`).
- Use the backend-compatible `.weba` extension for WebM diary recordings by updating `extensionForMime` in `frontend/src/AudioDiary/audio_helpers.js` and adding `makeDiaryRequestIdentifier()` there.
- Update tests to assert the new behavior and add focused unit tests: modified `frontend/tests/AudioDiary.test.jsx` to expect a `diary_` request id and `.weba` filename, and added `frontend/tests/audio_helpers.test.js` to cover extension and identifier generation.

### Testing
- Ran targeted frontend tests: `npx jest frontend/tests/AudioDiary.test.jsx frontend/tests/audio_helpers.test.js --runInBand` and they passed.
- Ran static analysis: `npm run static-analysis` (TypeScript + ESLint) and it passed.
- Ran full test suite: `npm test` and all tests passed (197 test suites, 2058 tests in this run).
- Built the frontend: `npm run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0e7e75fb4832eb51fb20d0f6c45f7)