### PR TITLE
Fix main page element widths to match action buttons

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -135,10 +135,10 @@ function App() {
 
         <SyncSection />
 
-        <Box pt={4}>
+        <VStack pt={4}>
           <Separator mb={4} />
           <Box
-            alignSelf="center"
+            w="200px"
             bg="gray.50"
             border="1px solid"
             borderColor="gray.200"
@@ -154,7 +154,7 @@ function App() {
                   : 'Loading Volodyslav version…'}
             </Text>
           </Box>
-        </Box>
+        </VStack>
       </VStack>
     </Box>
   );

--- a/frontend/src/Sync/SyncSection.jsx
+++ b/frontend/src/Sync/SyncSection.jsx
@@ -159,7 +159,7 @@ export function SyncSection() {
 
   return (
     <VStack gap={2}>
-      <NativeSelect.Root>
+      <NativeSelect.Root w="200px">
         <NativeSelect.Field
           aria-label="Sync mode"
           value={syncMode}
@@ -208,7 +208,7 @@ export function SyncSection() {
         <SyncStepList steps={syncSteps} isRunning={syncState === 'loading'} />
       )}
       {syncSuccessMessage && (
-        <Alert.Root status="success" borderRadius="md" alignItems="flex-start">
+        <Alert.Root status="success" borderRadius="md" alignItems="flex-start" w="200px">
           <Alert.Indicator mt={1} />
           <Box>
             <Alert.Title>Sync complete</Alert.Title>
@@ -217,7 +217,7 @@ export function SyncSection() {
         </Alert.Root>
       )}
       {syncState === 'error' && syncError.message !== '' && (
-        <Alert.Root status="error" borderRadius="md" alignItems="flex-start">
+        <Alert.Root status="error" borderRadius="md" alignItems="flex-start" w="200px">
           <Alert.Indicator mt={1} />
           <Box>
             <Alert.Title>Sync failed</Alert.Title>


### PR DESCRIPTION
### Motivation

- The sync mode selector, sync result alerts, and footer version pill were stretching full-width and did not align with the main action buttons column.
- These controls should share the same horizontal width as the primary buttons on the main page to improve visual alignment.
- Constrain those elements to the same fixed width used by the main buttons for a consistent layout.

### Description

- Constrained the sync mode control by adding `w="200px"` to `NativeSelect.Root` in `frontend/src/Sync/SyncSection.jsx` so it no longer stretches full-width.
- Constrained sync notifications by adding `w="200px"` to both success and error `Alert.Root` instances in `frontend/src/Sync/SyncSection.jsx` so alerts align with buttons.
- Constrained the footer version pill by wrapping it in a `VStack` and setting `w="200px"` on the version `Box` in `frontend/src/App.jsx` to prevent full-width stretching and keep it centered.

### Testing

- Ran `npm install` successfully.
- Ran `npx jest frontend/tests/App.test.jsx` and it passed (15 tests).
- Ran `npm test` which reported failures due to existing backend Jest timeouts in unrelated tests (`backend/tests/scheduler_orphaned_task_restart.test.js`, `backend/tests/database_synchronize.test.js`, `backend/tests/polling_scheduler_save_restore.test.js`).
- Ran `npm run static-analysis` and `npm run build` and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1d7366254832ebb09452f625fb7b8)