### PR TITLE
Prevent search page scroll jump by disabling autofocus on POP-restored navigation

### DIFF
--- a/frontend/src/Search/Search.jsx
+++ b/frontend/src/Search/Search.jsx
@@ -85,11 +85,14 @@ export default function Search() {
     const isStateRestoredRef = useRef(restoredState !== null);
 
     useEffect(() => {
+        if (restoredState !== null) {
+            return;
+        }
         if (inputRef.current) {
             // @ts-expect-error: inputRef is not typed, but focus() is valid for Chakra Input
             inputRef.current.focus();
         }
-    }, []);
+    }, [restoredState]);
 
     useEffect(() => {
         setError(null);

--- a/frontend/tests/Search.test.jsx
+++ b/frontend/tests/Search.test.jsx
@@ -1,8 +1,16 @@
 import React from "react";
 import { screen, fireEvent, waitFor, act } from "@testing-library/react";
 import "@testing-library/jest-dom";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, useNavigationType } from "react-router-dom";
 import { renderWithProviders } from "./renderWithProviders.jsx";
+
+jest.mock("react-router-dom", () => {
+    const actual = jest.requireActual("react-router-dom");
+    return {
+        ...actual,
+        useNavigationType: jest.fn(() => "POP"),
+    };
+});
 
 // Mock the Search API module
 jest.mock("../src/Search/api", () => ({
@@ -38,6 +46,7 @@ describe("Search page", () => {
         searchEntries.mockResolvedValue({ results: [] });
         jest.useFakeTimers();
         sessionStorage.clear();
+        useNavigationType.mockReturnValue("POP");
     });
 
     afterEach(() => {
@@ -777,5 +786,43 @@ describe("Search page", () => {
             expect(screen.getByText("- Restored entry")).toBeInTheDocument();
         });
         expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    });
+
+    it("does not focus the search input on restored POP navigation", async () => {
+        const restoredEntry = mockEntry({ id: "restored-1", input: "food - Restored entry" });
+        sessionStorage.setItem("volodyslav_search_state", JSON.stringify({
+            pattern: "food",
+            results: [restoredEntry],
+            page: 1,
+            hasMore: false,
+            error: null,
+        }));
+        const focusSpy = jest.spyOn(HTMLElement.prototype, "focus");
+
+        renderWithProviders(
+            <MemoryRouter>
+                <Search />
+            </MemoryRouter>
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText("- Restored entry")).toBeInTheDocument();
+        });
+        expect(focusSpy).not.toHaveBeenCalled();
+        focusSpy.mockRestore();
+    });
+
+    it("focuses the search input when opening search with a PUSH navigation", async () => {
+        useNavigationType.mockReturnValue("PUSH");
+        const focusSpy = jest.spyOn(HTMLElement.prototype, "focus");
+
+        renderWithProviders(
+            <MemoryRouter>
+                <Search />
+            </MemoryRouter>
+        );
+
+        expect(focusSpy).toHaveBeenCalled();
+        focusSpy.mockRestore();
     });
 });


### PR DESCRIPTION
### Motivation
- Returning to `/search` via browser back/forward (POP navigation) restores search state from `sessionStorage` but the input auto-focus caused the page to scroll to the top, which is undesirable. 
- The page should still autofocus when opened fresh so users can start typing immediately.

### Description
- Stop auto-focusing the search input when a restored search state is present by early-returning from the focus effect when `restoredState !== null` in `frontend/src/Search/Search.jsx`.
- Make navigation type deterministic in tests by mocking `useNavigationType` and defaulting it to `POP`, and add tests that verify both behaviors. Changes are in `frontend/tests/Search.test.jsx` where new tests check that restored POP navigation does not call `focus` and that PUSH navigation still focuses the input.
- Preserve existing search state restoration and debounced fetch behavior; only the autofocus effect was gated.

### Testing
- Ran the focused test suite with `npx jest frontend/tests/Search.test.jsx`, which passed (32/32 tests).
- Ran the full test suite with `npm test`, which completed successfully (all test suites passed).
- Ran static analysis with `npm run static-analysis`, which succeeded with no errors.
- Built the frontend with `npm run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c40c3e4750832e8711ae38da467c9b)