### PR TITLE
Avoid scrolling to top when returning to Search by using focus({ preventScroll: true })

### DIFF
--- a/frontend/src/Search/Search.jsx
+++ b/frontend/src/Search/Search.jsx
@@ -87,7 +87,7 @@ export default function Search() {
     useEffect(() => {
         if (inputRef.current) {
             // @ts-expect-error: inputRef is not typed, but focus() is valid for Chakra Input
-            inputRef.current.focus();
+            inputRef.current.focus({ preventScroll: true });
         }
     }, []);
 

--- a/frontend/tests/Search.test.jsx
+++ b/frontend/tests/Search.test.jsx
@@ -57,6 +57,19 @@ describe("Search page", () => {
         ).toBeInTheDocument();
     });
 
+    it("focuses the search input without scrolling the page", () => {
+        const focusSpy = jest.spyOn(HTMLElement.prototype, "focus").mockImplementation(() => {});
+
+        renderWithProviders(
+            <MemoryRouter>
+                <Search />
+            </MemoryRouter>
+        );
+
+        expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
+        focusSpy.mockRestore();
+    });
+
     it("shows recent entries on initial load", async () => {
         searchEntries.mockResolvedValue({ results: [mockEntry({ input: "food - Recent entry" })] });
 


### PR DESCRIPTION
### Motivation
- Prevent the search page from forcing the viewport to the top when the user returns via the browser back button while preserving the ability to type immediately into the search field.

### Description
- Change the search input autofocus call to `inputRef.current.focus({ preventScroll: true })` and add a unit test that asserts focus is invoked with `{ preventScroll: true }` to guard against regressions.

### Testing
- Ran `npx jest frontend/tests/Search.test.jsx` which passed, ran `npm test` (full suite) which surfaced unrelated backend Jest timeouts/failures outside this change, and ran `npm run static-analysis` and `npm run build` which both succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c40c3e4750832e8711ae38da467c9b)