### PR TITLE
Hide Take Photos button during description submission

### DIFF
--- a/frontend/src/DescriptionEntry/FormInputSection.jsx
+++ b/frontend/src/DescriptionEntry/FormInputSection.jsx
@@ -51,15 +51,16 @@ export const FormInputSection = ({
                     )}
 
                     <HStack justify="flex-end" gap={2}>
-                        <Button
-                            variant="ghost"
-                            color="gray.600"
-                            onClick={onTakePhotos}
-                            size="sm"
-                            disabled={isSubmitting}
-                        >
-                            📸 Take Photos
-                        </Button>
+                        {!isSubmitting && (
+                            <Button
+                                variant="ghost"
+                                color="gray.600"
+                                onClick={onTakePhotos}
+                                size="sm"
+                            >
+                                📸 Take Photos
+                            </Button>
+                        )}
                         <Button
                             colorPalette="blue"
                             px={8}

--- a/frontend/tests/DescriptionEntry.basic.test.jsx
+++ b/frontend/tests/DescriptionEntry.basic.test.jsx
@@ -159,7 +159,7 @@ describe("DescriptionEntry", () => {
         expect(input.value).toBe("test input");
     });
 
-    it("renders Take Photos button correctly", async () => {
+    it("renders Take Photos button correctly when idle", async () => {
         renderWithChakra(<DescriptionEntry />);
 
         // Wait for component to be fully loaded
@@ -180,6 +180,38 @@ describe("DescriptionEntry", () => {
 
         // Take Photos button should still be enabled
         expect(takePhotosButton).toBeEnabled();
+    });
+
+    it("hides Take Photos button while submitting", async () => {
+        let resolveSubmission;
+        submitEntry.mockImplementation(() => new Promise((resolve) => {
+            resolveSubmission = resolve;
+        }));
+
+        renderWithChakra(<DescriptionEntry />);
+
+        await waitFor(() => {
+            expect(fetchConfig).toHaveBeenCalled();
+        });
+
+        const input = screen.getByPlaceholderText(
+            "Type your event description here..."
+        );
+        fireEvent.change(input, { target: { value: "test event" } });
+        fireEvent.click(screen.getByRole("button", { name: "Submit" }));
+
+        await waitFor(() => {
+            expect(screen.queryByRole("button", { name: /take photos/i })).not.toBeInTheDocument();
+        });
+
+        resolveSubmission({
+            success: true,
+            entry: { input: "test event" },
+        });
+
+        await waitFor(() => {
+            expect(screen.getByRole("button", { name: /take photos/i })).toBeInTheDocument();
+        });
     });
 
     it("does not render config section when no config is available", async () => {


### PR DESCRIPTION
### Motivation

- Prevent the neighbouring “Take Photos” button from shifting/overflowing the layout when the form is submitting by hiding it while submission is in flight.
- Preserve the existing visual submit feedback (Submit stays in its `loading` state) so users still see progress.

### Description

- Render the Take Photos button only when the form is idle by wrapping it with `!isSubmitting` in `frontend/src/DescriptionEntry/FormInputSection.jsx`, and remove the `disabled` prop that previously left it visible but inactive.
- Keep the Submit button behavior unchanged (`loading={isSubmitting}` and `loadingText`).
- Update tests in `frontend/tests/DescriptionEntry.basic.test.jsx` by renaming the idle-state test and adding `hides Take Photos button while submitting`, which mocks an in-flight `submitEntry` to assert the Take Photos button is not present while submitting and returns after the promise resolves.

### Testing

- Ran `npx jest frontend/tests/DescriptionEntry.basic.test.jsx`; the frontend test suite passed (1 suite, 7 tests passed).
- Ran the full `npm test` (automated); the frontend changes are not responsible but the full test run failed due to unrelated backend Jest timeouts in scheduler/database tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c40caf2e84832ea35dd6c461020a87)