### PR TITLE
Increase Jest timeout for git-backed backend tests

### DIFF
--- a/backend/tests/database_gitstore.test.js
+++ b/backend/tests/database_gitstore.test.js
@@ -21,6 +21,8 @@ const {
 const defaultBranch = require("../src/gitstore/default_branch");
 const { getMockedRootCapabilities } = require("./spies");
 const { stubEnvironment, stubDatetime, stubLogger } = require("./stubs");
+jest.setTimeout(30000);
+
 
 // ── Test capability factory ───────────────────────────────────────────────────
 

--- a/backend/tests/database_synchronize.test.js
+++ b/backend/tests/database_synchronize.test.js
@@ -10,6 +10,8 @@ const {
 const defaultBranch = require("../src/gitstore/default_branch");
 const { getMockedRootCapabilities } = require("./spies");
 const { stubEnvironment, stubDatetime, stubLogger } = require("./stubs");
+jest.setTimeout(30000);
+
 
 function getTestCapabilities() {
     const capabilities = getMockedRootCapabilities();

--- a/backend/tests/generators_repository_merge.test.js
+++ b/backend/tests/generators_repository_merge.test.js
@@ -4,6 +4,8 @@ const gitstore = require("../src/gitstore");
 const isMergeHostBranchesError = gitstore.mergeHostBranches.isMergeHostBranchesError;
 const { getMockedRootCapabilities } = require("./spies");
 const { stubDatetime, stubEnvironment, stubLogger } = require("./stubs");
+jest.setTimeout(30000);
+
 
 function getTestCapabilities() {
     const capabilities = getMockedRootCapabilities();

--- a/backend/tests/generators_repository_setup.test.js
+++ b/backend/tests/generators_repository_setup.test.js
@@ -2,6 +2,8 @@ const path = require("path");
 const workingRepository = require("../src/gitstore/working_repository");
 const { getMockedRootCapabilities } = require("./spies");
 const { stubDatetime, stubEnvironment, stubGit, stubLogger } = require("./stubs");
+jest.setTimeout(30000);
+
 
 function getTestCapabilities() {
     const capabilities = getMockedRootCapabilities();

--- a/backend/tests/generators_repository_setup_concurrent.test.js
+++ b/backend/tests/generators_repository_setup_concurrent.test.js
@@ -3,6 +3,8 @@ const mover = require("../src/filesystem/mover");
 const workingRepository = require("../src/gitstore/working_repository");
 const { getMockedRootCapabilities } = require("./spies");
 const { stubDatetime, stubEnvironment, stubGit, stubLogger } = require("./stubs");
+jest.setTimeout(30000);
+
 
 function getTestCapabilities() {
     const capabilities = getMockedRootCapabilities();

--- a/backend/tests/gitstore.test.js
+++ b/backend/tests/gitstore.test.js
@@ -6,6 +6,8 @@ const defaultBranch = require("../src/gitstore/default_branch");
 const workingRepository = require("../src/gitstore/working_repository");
 const { getMockedRootCapabilities } = require("./spies");
 const { stubEnvironment, stubEventLogRepository, stubDatetime, stubLogger } = require("./stubs");
+jest.setTimeout(30000);
+
 
 function getTestCapabilities() {
     const capabilities = getMockedRootCapabilities();

--- a/backend/tests/gitstore_checkpoint.test.js
+++ b/backend/tests/gitstore_checkpoint.test.js
@@ -7,6 +7,8 @@ const defaultBranch = require("../src/gitstore/default_branch");
 const workingRepository = require("../src/gitstore/working_repository");
 const { getMockedRootCapabilities } = require("./spies");
 const { stubEnvironment, stubEventLogRepository, stubDatetime, stubLogger } = require("./stubs");
+jest.setTimeout(30000);
+
 
 function getTestCapabilities() {
     const capabilities = getMockedRootCapabilities();

--- a/backend/tests/gitstore_retry.test.js
+++ b/backend/tests/gitstore_retry.test.js
@@ -4,6 +4,8 @@ const { transaction } = require("../src/gitstore");
 const { PushError, isPushError } = require("../src/gitstore/wrappers");
 const { getMockedRootCapabilities } = require("./spies");
 const { stubEnvironment, stubEventLogRepository, stubDatetime, stubLogger, stubGit } = require("./stubs");
+jest.setTimeout(30000);
+
 
 function getTestCapabilities() {
     const capabilities = getMockedRootCapabilities();

--- a/backend/tests/working_repository.atomic.test.js
+++ b/backend/tests/working_repository.atomic.test.js
@@ -5,6 +5,8 @@ const workingRepository = require("../src/gitstore/working_repository");
 const defaultBranch = require("../src/gitstore/default_branch");
 const { getMockedRootCapabilities } = require("./spies");
 const { stubEnvironment, stubLogger, stubDatetime, stubEventLogRepository } = require("./stubs");
+jest.setTimeout(30000);
+
 
 function getTestCapabilities() {
     const capabilities = getMockedRootCapabilities();

--- a/backend/tests/working_repository.basic.test.js
+++ b/backend/tests/working_repository.basic.test.js
@@ -8,6 +8,8 @@ const {
     stubDatetime,
     stubEventLogRepository,
 } = require("./stubs");
+jest.setTimeout(30000);
+
 
 function getTestCapabilities() {
     const capabilities = getMockedRootCapabilities();

--- a/backend/tests/working_repository.remote.test.js
+++ b/backend/tests/working_repository.remote.test.js
@@ -8,6 +8,8 @@ const {
     stubEventLogRepository,
 } = require("./stubs");
 const defaultBranch = require("../src/gitstore/default_branch");
+jest.setTimeout(30000);
+
 
 function getTestCapabilities() {
     const capabilities = getMockedRootCapabilities();

--- a/backend/tests/working_repository.reset_mode.test.js
+++ b/backend/tests/working_repository.reset_mode.test.js
@@ -7,6 +7,8 @@ const {
     stubDatetime,
 } = require("./stubs");
 const defaultBranch = require("../src/gitstore/default_branch");
+jest.setTimeout(30000);
+
 
 function getTestCapabilities() {
     const capabilities = getMockedRootCapabilities();


### PR DESCRIPTION
### Motivation
- Several backend integration tests perform real `git` operations and can be slow in CI or constrained environments, causing intermittent Jest timeouts. 
- Increasing the per-suite timeout to 30 seconds prevents spurious failures without changing test logic.

### Description
- Added `jest.setTimeout(30000);` to the top of git-heavy backend test suites that exercise the real `git` binary. 
- Files updated include `backend/tests/database_gitstore.test.js`, `backend/tests/database_synchronize.test.js`, `backend/tests/generators_repository_merge.test.js`, `backend/tests/generators_repository_setup.test.js`, `backend/tests/generators_repository_setup_concurrent.test.js`, `backend/tests/gitstore.test.js`, `backend/tests/gitstore_checkpoint.test.js`, `backend/tests/gitstore_retry.test.js`, `backend/tests/working_repository.atomic.test.js`, `backend/tests/working_repository.basic.test.js`, `backend/tests/working_repository.remote.test.js`, and `backend/tests/working_repository.reset_mode.test.js`. 
- This change only adjusts Jest timeout configuration and makes no production code or test behavior changes.

### Testing
- Ran the focused Jest command `npx jest backend/tests/database_synchronize.test.js backend/tests/generators_repository_merge.test.js backend/tests/gitstore.test.js backend/tests/working_repository.remote.test.js backend/tests/gitstore_retry.test.js`, and the suites passed. 
- Test run summary: `Test Suites: 5 passed, Tests: 25 passed, Time: 17.555 s`, indicating the adjusted timeouts resolved time-related failures for the selected suites.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c459372064832ea2a8ba8ba14c652d)