### PR TITLE
Show spinner per computed property in Entry Detail

### DIFF
--- a/frontend/src/EntryDetail/EntryDetail.jsx
+++ b/frontend/src/EntryDetail/EntryDetail.jsx
@@ -234,16 +234,21 @@ export default function EntryDetail() {
                         )}
                         {loadingComputedProperties.length > 0 ? (
                             <Box py={SPACING.md}>
-                                <HStack align="flex-start" gap={SPACING.sm}>
-                                    <Spinner size="sm" color="blue.400" mt="2px" />
-                                    <VStack align="flex-start" gap={1}>
-                                        {loadingComputedProperties.map((propertyName) => (
-                                            <Text key={propertyName} {...TEXT_STYLES.helper}>
+                                <VStack align="stretch" gap={SPACING.xs}>
+                                    {loadingComputedProperties.map((propertyName) => (
+                                        <HStack key={propertyName} align="flex-start" gap={SPACING.sm}>
+                                            <Spinner
+                                                size="sm"
+                                                color="blue.400"
+                                                mt="2px"
+                                                data-testid={`computed-property-spinner-${propertyName}`}
+                                            />
+                                            <Text {...TEXT_STYLES.helper}>
                                                 Loading {propertyName}...
                                             </Text>
-                                        ))}
-                                    </VStack>
-                                </HStack>
+                                        </HStack>
+                                    ))}
+                                </VStack>
                             </Box>
                         ) : additionalFields.length === 0 && Object.keys(additionalPropertyErrors).length === 0 ? (
                             <Text {...TEXT_STYLES.helper}>None</Text>

--- a/frontend/tests/EntryDetail.test.jsx
+++ b/frontend/tests/EntryDetail.test.jsx
@@ -429,6 +429,8 @@ describe("EntryDetail page", () => {
 
         expect(screen.getByText("Loading calories...")).toBeInTheDocument();
         expect(screen.getByText("Loading transcription...")).toBeInTheDocument();
+        expect(screen.getByTestId("computed-property-spinner-calories")).toBeInTheDocument();
+        expect(screen.getByTestId("computed-property-spinner-transcription")).toBeInTheDocument();
         expect(screen.queryByText("None")).not.toBeInTheDocument();
     });
 


### PR DESCRIPTION
### Motivation
- The Computed Properties UI rendered a single spinner for the whole loading block, so only the first property label visually showed loading while multiple properties were still being fetched.

### Description
- Render each loading computed property on its own row so each label displays an individual spinner by mapping `loadingComputedProperties` to an `HStack` with a `Spinner` and label in `frontend/src/EntryDetail/EntryDetail.jsx`.
- Add stable test IDs `computed-property-spinner-<propertyName>` to each spinner to make per-property loading verifiable.
- Update the optimistic-loading test in `frontend/tests/EntryDetail.test.jsx` to assert the presence of the per-property spinners for `calories` and `transcription`.

### Testing
- Ran `npx jest frontend/tests/EntryDetail.test.jsx --runInBand`, which passed (test suite for the file succeeded).
- Ran `npm run static-analysis` (`tsc` + `eslint`), which completed successfully.
- Ran `npm run build` (frontend), which completed successfully.
- Attempted full `npm test -- --runInBand` in this environment, which timed out due to time limits and did not complete here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c57a83b6a8832eb8e2851ddb2df3d4)