### PR TITLE
Refactor generators DB initialization to avoid lazy post-teardown imports

### DIFF
--- a/backend/src/generators/incremental_graph/database/get_root_database.js
+++ b/backend/src/generators/incremental_graph/database/get_root_database.js
@@ -1,0 +1,83 @@
+/**
+ * Root database initialization utilities.
+ */
+
+const { pathToLiveDatabase } = require('./gitstore');
+const { makeRootDatabase } = require('./root_database');
+
+/** @typedef {import('./types').DatabaseCapabilities} DatabaseCapabilities */
+
+/**
+ * Thrown when the database cannot be opened or created.
+ */
+class DatabaseInitializationError extends Error {
+    /**
+     * @param {string} message
+     * @param {string} databasePath
+     * @param {Error} [cause]
+     */
+    constructor(message, databasePath, cause) {
+        super(message);
+        this.name = 'DatabaseInitializationError';
+        this.databasePath = databasePath;
+        this.cause = cause;
+    }
+}
+
+/**
+ * @param {unknown} object
+ * @returns {object is DatabaseInitializationError}
+ */
+function isDatabaseInitializationError(object) {
+    return object instanceof DatabaseInitializationError;
+}
+
+/**
+ * Gets or creates a RootDatabase instance for the generators module.
+ * The database is stored in the Volodyslav data directory.
+ *
+ * @param {DatabaseCapabilities} capabilities - The capabilities object
+ * @returns {Promise<import('./root_database').RootDatabase>} The root database instance
+ * @throws {DatabaseInitializationError} If database initialization fails
+ */
+async function getRootDatabase(capabilities) {
+    const databasePath = pathToLiveDatabase(capabilities);
+
+    if (await capabilities.checker.directoryExists(databasePath)) {
+        capabilities.logger.logInfo({ databasePath }, 'Database directory exists');
+    } else {
+        capabilities.logger.logInfo({ databasePath }, 'Database directory does not exist, will be created');
+    }
+
+    // Ensure the LevelDB directory exists before LevelDB opens.
+    try {
+        await capabilities.creator.createDirectory(databasePath);
+    } catch (error) {
+        const err = error instanceof Error ? error : new Error(String(error));
+        throw new DatabaseInitializationError(
+            `Failed to create data directory: ${err.message}`,
+            databasePath,
+            err
+        );
+    }
+
+    // Open or create the database
+    try {
+        const db = await makeRootDatabase(capabilities, databasePath);
+        capabilities.logger.logDebug({ databasePath }, 'Root database opened');
+        return db;
+    } catch (error) {
+        const err = error instanceof Error ? error : new Error(String(error));
+        throw new DatabaseInitializationError(
+            `Failed to open root database: ${err.message}`,
+            databasePath,
+            err
+        );
+    }
+}
+
+module.exports = {
+    DatabaseInitializationError,
+    isDatabaseInitializationError,
+    getRootDatabase,
+};

--- a/backend/src/generators/incremental_graph/database/index.js
+++ b/backend/src/generators/incremental_graph/database/index.js
@@ -12,81 +12,16 @@ const {
     CHECKPOINT_WORKING_PATH,
     DATABASE_SUBPATH,
     LIVE_DATABASE_WORKING_PATH,
-    pathToLiveDatabase,
 } = require('./gitstore');
 const { synchronizeNoLock } = require('./synchronize');
 const { renderToFilesystem, scanFromFilesystem, keyToRelativePath, relativePathToKey } = require('./render');
 
 /** @typedef {import('./types').DatabaseCapabilities} DatabaseCapabilities */
 
-/**
- * Thrown when the database cannot be opened or created.
- */
-class DatabaseInitializationError extends Error {
-    /**
-     * @param {string} message
-     * @param {string} databasePath
-     * @param {Error} [cause]
-     */
-    constructor(message, databasePath, cause) {
-        super(message);
-        this.name = 'DatabaseInitializationError';
-        this.databasePath = databasePath;
-        this.cause = cause;
-    }
-}
-
-/**
- * @param {unknown} object
- * @returns {object is DatabaseInitializationError}
- */
-function isDatabaseInitializationError(object) {
-    return object instanceof DatabaseInitializationError;
-}
-
-/**
- * Gets or creates a RootDatabase instance for the generators module.
- * The database is stored in the Volodyslav data directory.
- *
- * @param {DatabaseCapabilities} capabilities - The capabilities object
- * @returns {Promise<import('./root_database').RootDatabase>} The root database instance
- * @throws {DatabaseInitializationError} If database initialization fails
- */
-async function getRootDatabase(capabilities) {
-    const databasePath = pathToLiveDatabase(capabilities);
-
-    if (await capabilities.checker.directoryExists(databasePath)) {
-        capabilities.logger.logInfo({ databasePath }, 'Database directory exists');
-    } else {
-        capabilities.logger.logInfo({ databasePath }, 'Database directory does not exist, will be created');
-    }
-
-    // Ensure the LevelDB directory exists before LevelDB opens.
-    try {
-        await capabilities.creator.createDirectory(databasePath);
-    } catch (error) {
-        const err = error instanceof Error ? error : new Error(String(error));
-        throw new DatabaseInitializationError(
-            `Failed to create data directory: ${err.message}`,
-            databasePath,
-            err
-        );
-    }
-
-    // Open or create the database
-    try {
-        const db = await makeRootDatabase(capabilities, databasePath);
-        capabilities.logger.logDebug({ databasePath }, 'Root database opened');
-        return db;
-    } catch (error) {
-        const err = error instanceof Error ? error : new Error(String(error));
-        throw new DatabaseInitializationError(
-            `Failed to open root database: ${err.message}`,
-            databasePath,
-            err
-        );
-    }
-}
+const {
+    isDatabaseInitializationError,
+    getRootDatabase,
+} = require('./get_root_database');
 
 module.exports = {
     getRootDatabase,

--- a/backend/src/generators/incremental_graph/database/synchronize.js
+++ b/backend/src/generators/incremental_graph/database/synchronize.js
@@ -20,6 +20,7 @@ const {
     DATABASE_SUBPATH,
 } = require('./gitstore');
 const { scanFromFilesystem } = require('./render');
+const { getRootDatabase } = require('./get_root_database');
 
 /** @typedef {import('../../../filesystem/checker').FileChecker} FileChecker */
 /** @typedef {import('../../../filesystem/mover').FileMover} FileMover */
@@ -74,7 +75,6 @@ const { scanFromFilesystem } = require('./render');
 async function synchronizeNoLock(capabilities, options) {
     const remotePath = capabilities.environment.generatorsRepository();
     const remoteLocation = { url: remotePath };
-    const { getRootDatabase } = require('./index');
     const rootDatabase = await getRootDatabase(capabilities);
     /** @type {Error | null} */
     let mergeHostBranchesError = null;


### PR DESCRIPTION
### Motivation
- Tests intermittently threw `ReferenceError: You are trying to import a file after the Jest environment has been torn down` originating from a deferred `require('./index')` inside `synchronizeNoLock`, caused by a circular dependency and scheduler work continuing after teardown.
- The goal is to remove the late runtime import path so the module graph is resolved at load time and the deferred import cannot run after Jest has torn down the environment.

### Description
- Extracted root database initialization and typed error helpers into `backend/src/generators/incremental_graph/database/get_root_database.js` and exported `getRootDatabase` and `isDatabaseInitializationError` from it.
- Updated `backend/src/generators/incremental_graph/database/index.js` to re-export `getRootDatabase`/`isDatabaseInitializationError` from the new module to preserve the public API.
- Replaced the runtime `require('./index')` in `backend/src/generators/incremental_graph/database/synchronize.js` with a top-level `require('./get_root_database')` to eliminate the deferred import and break the cycle.
- Removed the now-unused import in `index.js` (fixing a TypeScript unused-variable error) and kept behaviour and error types unchanged.

### Testing
- Ran `npm install` which completed successfully.
- Ran `npx jest backend/tests/server.test.js` which passed (server startup tests exercised the affected code path) and confirmed the post-teardown import no longer occurs.
- Ran `npm run static-analysis` and `npm run build` which completed successfully after fixing the unused-import issue.
- Attempted a full `npm test`; the project test suite has existing long-running async-handle behavior in scheduler-related tests that made a full run unreliable in this environment, but this change addresses the specific post-teardown import path.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6c846d524832ebaade1a5c8e410a8)