### PR TITLE
Await scheduler shutdown in server test suites

### DIFF
--- a/backend/tests/server.test.js
+++ b/backend/tests/server.test.js
@@ -37,7 +37,7 @@ describe("Startup Dependencies", () => {
         expect(res.status).toBe(200);
         expect(res.text).toBe("pong");
 
-        capabilities.scheduler.stop();
+        await capabilities.scheduler.stop();
     });
 
     it("throws if notifications are not available", async () => {

--- a/backend/tests/server_integration.test.js
+++ b/backend/tests/server_integration.test.js
@@ -47,7 +47,7 @@ describe("Server Integration with Declarative Scheduler", () => {
 
         // App should have been configured with middleware
         expect(app.use).toHaveBeenCalled();
-        capabilities.scheduler.stop();
+        await capabilities.scheduler.stop();
     });
 
     test("server initialization rejects second call - not idempotent", async () => {
@@ -62,7 +62,7 @@ describe("Server Integration with Declarative Scheduler", () => {
         await expect(initialize(capabilities, app)).rejects.toThrow("Cannot initialize scheduler: scheduler is already running");
         // Should have configured app at least once
         expect(app.use).toHaveBeenCalled();
-        capabilities.scheduler.stop();
+        await capabilities.scheduler.stop();
     });
 
     test("server handles scheduler initialization errors gracefully", async () => {
@@ -76,7 +76,7 @@ describe("Server Integration with Declarative Scheduler", () => {
 
         // Server initialization should fail gracefully
         await expect(initialize(capabilities, app)).rejects.toThrow("Environment setup failed");
-        capabilities.scheduler.stop();
+        await capabilities.scheduler.stop();
     });
 
     test("server properly sets up all middleware even with scheduler", async () => {
@@ -92,7 +92,7 @@ describe("Server Integration with Declarative Scheduler", () => {
 
         // App configuration should have been set up
         expect(app.use).toHaveBeenCalled();
-        capabilities.scheduler.stop();
+        await capabilities.scheduler.stop();
     });
 
     test("server logs appropriate messages during initialization", async () => {
@@ -108,7 +108,7 @@ describe("Server Integration with Declarative Scheduler", () => {
         // Check that logger was properly configured  
         const logInfoCalls = capabilities.logger.logInfo.mock.calls;
         expect(logInfoCalls.length).toBeGreaterThan(0);
-        capabilities.scheduler.stop();
+        await capabilities.scheduler.stop();
     });
 
     test("server handles concurrent initialization attempts", async () => {
@@ -129,7 +129,7 @@ describe("Server Integration with Declarative Scheduler", () => {
         // Both apps should be configured
         expect(app1.use).toHaveBeenCalled();
         expect(app2.use).toHaveBeenCalled();
-        capabilities1.scheduler.stop();
-        capabilities2.scheduler.stop();
+        await capabilities1.scheduler.stop();
+        await capabilities2.scheduler.stop();
     });
 });


### PR DESCRIPTION
### Motivation
- Tests started the declarative scheduler during `initialize(...)` and called `capabilities.scheduler.stop()` without awaiting it, allowing background scheduler work to continue after the test finished and causing late module loads during Jest teardown. 
- The uncovered race produced `ReferenceError: You are trying to import a file after the Jest environment has been torn down.` in CI when background tasks executed after the test process began tearing down.

### Description
- Replaced non-awaited calls to `capabilities.scheduler.stop()` with `await capabilities.scheduler.stop()` in `backend/tests/server.test.js`. 
- Replaced multiple non-awaited `capabilities.scheduler.stop()` calls with `await capabilities.scheduler.stop()` in `backend/tests/server_integration.test.js`, including awaiting both schedulers in the concurrent-initialization test. 
- The changes ensure tests wait for the scheduler to fully stop and drain in-flight tasks before the Jest environment is torn down.

### Testing
- Ran `npm test -- backend/tests/server.test.js backend/tests/server_integration.test.js` and both suites passed. 
- Ran the full test suite with `npm test` and all tests passed (`208` suites, `2272` tests). 
- Ran static analysis with `npm run static-analysis` and it completed successfully. 
- Ran `npm run build` and the frontend built successfully (Vite emitted a non-fatal chunk-size warning).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6c846d524832ebaade1a5c8e410a8)