### PR TITLE
Improve live transcript recombination by trimming unstable tail word

### DIFF
--- a/backend/src/live_diary/service.js
+++ b/backend/src/live_diary/service.js
@@ -83,6 +83,54 @@ function normalizeMimeType(mimeType) {
     return (mimeType.split(";")[0] || "").trim().toLowerCase();
 }
 
+/**
+ * Prepare a window transcript for recombination.
+ *
+ * When the transcript contains at least 4 words, remove the last word before
+ * sending it to the recombination model (to avoid anchoring on a likely
+ * unstable boundary token), then append that removed word back after
+ * recombination.
+ *
+ * @param {string} transcript
+ * @returns {{ textForRecombination: string, removedTailWord: string }}
+ */
+function prepareTranscriptForRecombination(transcript) {
+    const trimmed = transcript.trim();
+    if (!trimmed) {
+        return { textForRecombination: transcript, removedTailWord: "" };
+    }
+
+    const words = trimmed.split(/\s+/u);
+    if (words.length < 4) {
+        return { textForRecombination: transcript, removedTailWord: "" };
+    }
+
+    const removedTailWord = words.pop() || "";
+    return {
+        textForRecombination: words.join(" "),
+        removedTailWord,
+    };
+}
+
+/**
+ * Append a removed tail word to recombination output.
+ * @param {string} recombinedText
+ * @param {string} removedTailWord
+ * @returns {string}
+ */
+function appendRemovedTailWord(recombinedText, removedTailWord) {
+    if (!removedTailWord) {
+        return recombinedText;
+    }
+
+    const trimmed = recombinedText.trim();
+    if (!trimmed) {
+        return removedTailWord;
+    }
+
+    return `${trimmed} ${removedTailWord}`;
+}
+
 const LIVE_DIARY_SUBLEVEL = "live_diary";
 const LAST_FRAGMENT_KEY = stringToTempKey("last_fragment");
 const LAST_FRAGMENT_MIME_KEY = stringToTempKey("last_fragment_mime");
@@ -434,10 +482,12 @@ async function pushAudio(capabilities, sessionId, fragmentBuffer, mimeType, frag
     let merged;
     if (lastWindowTranscript) {
         try {
+            const prepared = prepareTranscriptForRecombination(newWindowTranscript);
             merged = await capabilities.aiTranscriptRecombination.recombineOverlap(
                 lastWindowTranscript,
-                newWindowTranscript
+                prepared.textForRecombination
             );
+            merged = appendRemovedTailWord(merged, prepared.removedTailWord);
         } catch (error) {
             capabilities.logger.logError(
                 { sessionId, error: error instanceof Error ? error.message : String(error) },

--- a/backend/tests/live_diary.test.js
+++ b/backend/tests/live_diary.test.js
@@ -91,6 +91,217 @@ describe("pushAudio", () => {
         expect(caps.aiTranscriptRecombination.recombineOverlap).toHaveBeenCalledTimes(1);
     });
 
+    it("removes the last word from the newer transcript before recombination when it has at least four words", async () => {
+        const caps = makeCapabilities();
+        caps.aiTranscription.transcribeStreamDetailed = jest
+            .fn()
+            .mockResolvedValueOnce({
+                text: "one two three four five",
+                provider: "Google",
+                model: "mocked",
+                finishReason: "STOP",
+                finishMessage: null,
+                candidateTokenCount: 0,
+                usageMetadata: null,
+                modelVersion: null,
+                responseId: null,
+                structured: { transcript: "one two three four five", coverage: "full", warnings: [], unclearAudio: false },
+                rawResponse: null,
+            })
+            .mockResolvedValueOnce({
+                text: "alpha beta gamma delta epsilon",
+                provider: "Google",
+                model: "mocked",
+                finishReason: "STOP",
+                finishMessage: null,
+                candidateTokenCount: 0,
+                usageMetadata: null,
+                modelVersion: null,
+                responseId: null,
+                structured: { transcript: "alpha beta gamma delta epsilon", coverage: "full", warnings: [], unclearAudio: false },
+                rawResponse: null,
+            });
+
+        await pushAudio(caps, "sess-trim", Buffer.from("a1"), "audio/webm", 1);
+        await pushAudio(caps, "sess-trim", Buffer.from("a2"), "audio/webm", 2);
+        await pushAudio(caps, "sess-trim", Buffer.from("a3"), "audio/webm", 3);
+
+        expect(caps.aiTranscriptRecombination.recombineOverlap).toHaveBeenCalledWith(
+            "one two three four five",
+            "alpha beta gamma delta"
+        );
+    });
+
+    it("keeps the newer transcript unchanged for recombination when it has fewer than four words", async () => {
+        const caps = makeCapabilities();
+        caps.aiTranscription.transcribeStreamDetailed = jest
+            .fn()
+            .mockResolvedValueOnce({
+                text: "existing overlap transcript",
+                provider: "Google",
+                model: "mocked",
+                finishReason: "STOP",
+                finishMessage: null,
+                candidateTokenCount: 0,
+                usageMetadata: null,
+                modelVersion: null,
+                responseId: null,
+                structured: { transcript: "existing overlap transcript", coverage: "full", warnings: [], unclearAudio: false },
+                rawResponse: null,
+            })
+            .mockResolvedValueOnce({
+                text: "only three words",
+                provider: "Google",
+                model: "mocked",
+                finishReason: "STOP",
+                finishMessage: null,
+                candidateTokenCount: 0,
+                usageMetadata: null,
+                modelVersion: null,
+                responseId: null,
+                structured: { transcript: "only three words", coverage: "full", warnings: [], unclearAudio: false },
+                rawResponse: null,
+            });
+
+        await pushAudio(caps, "sess-short", Buffer.from("a1"), "audio/webm", 1);
+        await pushAudio(caps, "sess-short", Buffer.from("a2"), "audio/webm", 2);
+        await pushAudio(caps, "sess-short", Buffer.from("a3"), "audio/webm", 3);
+
+        expect(caps.aiTranscriptRecombination.recombineOverlap).toHaveBeenCalledWith(
+            "existing overlap transcript",
+            "only three words"
+        );
+    });
+
+    it("removes the last word when the newer transcript has exactly four words", async () => {
+        const caps = makeCapabilities();
+        caps.aiTranscription.transcribeStreamDetailed = jest
+            .fn()
+            .mockResolvedValueOnce({
+                text: "first overlap window text",
+                provider: "Google",
+                model: "mocked",
+                finishReason: "STOP",
+                finishMessage: null,
+                candidateTokenCount: 0,
+                usageMetadata: null,
+                modelVersion: null,
+                responseId: null,
+                structured: { transcript: "first overlap window text", coverage: "full", warnings: [], unclearAudio: false },
+                rawResponse: null,
+            })
+            .mockResolvedValueOnce({
+                text: "red blue green yellow",
+                provider: "Google",
+                model: "mocked",
+                finishReason: "STOP",
+                finishMessage: null,
+                candidateTokenCount: 0,
+                usageMetadata: null,
+                modelVersion: null,
+                responseId: null,
+                structured: { transcript: "red blue green yellow", coverage: "full", warnings: [], unclearAudio: false },
+                rawResponse: null,
+            });
+
+        await pushAudio(caps, "sess-four", Buffer.from("a1"), "audio/webm", 1);
+        await pushAudio(caps, "sess-four", Buffer.from("a2"), "audio/webm", 2);
+        await pushAudio(caps, "sess-four", Buffer.from("a3"), "audio/webm", 3);
+
+        expect(caps.aiTranscriptRecombination.recombineOverlap).toHaveBeenCalledWith(
+            "first overlap window text",
+            "red blue green"
+        );
+    });
+
+    it("appends the removed last word to recombination output", async () => {
+        const caps = makeCapabilities();
+        caps.aiTranscription.transcribeStreamDetailed = jest
+            .fn()
+            .mockResolvedValueOnce({
+                text: "walking to the park now",
+                provider: "Google",
+                model: "mocked",
+                finishReason: "STOP",
+                finishMessage: null,
+                candidateTokenCount: 0,
+                usageMetadata: null,
+                modelVersion: null,
+                responseId: null,
+                structured: { transcript: "walking to the park now", coverage: "full", warnings: [], unclearAudio: false },
+                rawResponse: null,
+            })
+            .mockResolvedValueOnce({
+                text: "to the park for fresh air",
+                provider: "Google",
+                model: "mocked",
+                finishReason: "STOP",
+                finishMessage: null,
+                candidateTokenCount: 0,
+                usageMetadata: null,
+                modelVersion: null,
+                responseId: null,
+                structured: { transcript: "to the park for fresh air", coverage: "full", warnings: [], unclearAudio: false },
+                rawResponse: null,
+            });
+        caps.aiTranscriptRecombination.recombineOverlap = jest
+            .fn()
+            .mockResolvedValue("walking to the park for fresh");
+
+        await pushAudio(caps, "sess-append", Buffer.from("a1"), "audio/webm", 1);
+        await pushAudio(caps, "sess-append", Buffer.from("a2"), "audio/webm", 2);
+        const result = await pushAudio(caps, "sess-append", Buffer.from("a3"), "audio/webm", 3);
+
+        // Running transcript generated at fragment 3 should include the appended boundary word.
+        expect(caps.aiDiaryQuestions.generateQuestions).toHaveBeenLastCalledWith(
+            expect.stringContaining("walking to the park for fresh air"),
+            expect.any(Array)
+        );
+        expect(result.status).toBe("ok");
+    });
+
+    it("uses the removed last word as merged text when recombination output is empty", async () => {
+        const caps = makeCapabilities();
+        caps.aiTranscription.transcribeStreamDetailed = jest
+            .fn()
+            .mockResolvedValueOnce({
+                text: "first second third fourth fifth",
+                provider: "Google",
+                model: "mocked",
+                finishReason: "STOP",
+                finishMessage: null,
+                candidateTokenCount: 0,
+                usageMetadata: null,
+                modelVersion: null,
+                responseId: null,
+                structured: { transcript: "first second third fourth fifth", coverage: "full", warnings: [], unclearAudio: false },
+                rawResponse: null,
+            })
+            .mockResolvedValueOnce({
+                text: "new overlap sentence ending word",
+                provider: "Google",
+                model: "mocked",
+                finishReason: "STOP",
+                finishMessage: null,
+                candidateTokenCount: 0,
+                usageMetadata: null,
+                modelVersion: null,
+                responseId: null,
+                structured: { transcript: "new overlap sentence ending word", coverage: "full", warnings: [], unclearAudio: false },
+                rawResponse: null,
+            });
+        caps.aiTranscriptRecombination.recombineOverlap = jest.fn().mockResolvedValue("   ");
+
+        await pushAudio(caps, "sess-empty-merge", Buffer.from("a1"), "audio/webm", 1);
+        await pushAudio(caps, "sess-empty-merge", Buffer.from("a2"), "audio/webm", 2);
+        await pushAudio(caps, "sess-empty-merge", Buffer.from("a3"), "audio/webm", 3);
+
+        expect(caps.aiDiaryQuestions.generateQuestions).toHaveBeenLastCalledWith(
+            expect.stringContaining("word"),
+            expect.any(Array)
+        );
+    });
+
     it("returns empty questions when transcription fails (non-fatal)", async () => {
         const caps = makeCapabilities();
         caps.aiTranscription.transcribeStreamDetailed = jest


### PR DESCRIPTION
### Motivation
- Recombination LLMs can be confused by a likely-incorrect trailing word from the later 20s window; trimming that unstable boundary token improves recombination quality.
- The goal is to drop the last word of the newer window when it has enough context (>= 4 words) before calling the LLM, then restore it afterward so running transcript continuity is preserved.

### Description
- Add `prepareTranscriptForRecombination` and `appendRemovedTailWord` helpers to `backend/src/live_diary/service.js` to implement the trim-and-restore behavior.
- Integrate trimming into the `pushAudio` recombination flow so `aiTranscriptRecombination.recombineOverlap` receives the prepared text and the removed tail word is appended to the recombination result before accumulation.
- Preserve existing fail-soft behavior: transcription or recombination failures fall back to using the new window transcript unchanged.
- Add extensive tests in `backend/tests/live_diary.test.js` covering trimming for `>= 4` words, no trimming for `< 4` words, the exact 4-word boundary, appending the removed tail word to recombination output, and fallback when recombination returns empty text.

### Testing
- Ran `npm install` successfully to prepare the environment.
- Ran focused tests with `npx jest backend/tests/live_diary.test.js` and the file-level suite passed.
- Ran the full test suite with `npm test` and all tests passed (`2274` tests across the repo).
- Ran static analysis with `npm run static-analysis` (`tsc` + `eslint`) and it completed without errors.
- Built the frontend with `npm run build` and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c71b16e310832ea88c271d3d6ed255)