### PR TITLE
Use OpenAI `whisper-1` for short live-diary fragment transcription

### DIFF
--- a/backend/src/ai/transcription.js
+++ b/backend/src/ai/transcription.js
@@ -18,6 +18,7 @@
  */
 
 const { GoogleGenAI, createUserContent, createPartFromUri, ThinkingLevel } = require("@google/genai");
+const { OpenAI } = require("openai");
 const path = require("path");
 const memconst = require("../memconst");
 const memoize = require("@emotion/memoize").default;
@@ -56,7 +57,7 @@ const {
 /**
  * @typedef {object} TranscriptionResult
  * @property {string} text - The final transcript text.
- * @property {string} provider - The AI provider name ("Google").
+ * @property {string} provider - The AI provider name.
  * @property {string} model - The model name used.
  * @property {string | null} finishReason - The candidate finish reason.
  * @property {string | null} finishMessage - The candidate finish message.
@@ -71,6 +72,7 @@ const {
 /** @typedef {import('./transcription_gemini').UploadedGeminiFile} UploadedGeminiFile */
 
 const TRANSCRIBER_MODEL = "gemini-3-flash-preview";
+const PRECISE_TRANSCRIBER_MODEL = "whisper-1";
 const MAX_OUTPUT_TOKENS = 65536;
 const TEMPERATURE = 0.0;
 const THINKING_LEVEL = ThinkingLevel.LOW;
@@ -128,8 +130,81 @@ function mimeTypeForPath(filePath) {
  * @typedef {object} AITranscription
  * @property {(fileStream: import('fs').ReadStream) => Promise<string>} transcribeStream
  * @property {(fileStream: import('fs').ReadStream) => Promise<TranscriptionResult>} transcribeStreamDetailed
+ * @property {(fileStream: import('fs').ReadStream) => Promise<string>} transcribeStreamPrecise
+ * @property {(fileStream: import('fs').ReadStream) => Promise<TranscriptionResult>} transcribeStreamPreciseDetailed
  * @property {() => Transcriber} getTranscriberInfo
  */
+
+/**
+ * Transcribes short audio fragments with Whisper for precise speech-to-text output.
+ * @param {function(string): OpenAI} makeClient - A memoized function to create an OpenAI client.
+ * @param {Capabilities} capabilities - The capabilities object.
+ * @param {import('fs').ReadStream} fileStream - The audio file stream to transcribe.
+ * @returns {Promise<TranscriptionResult>}
+ */
+async function transcribeStreamPreciseDetailed(makeClient, capabilities, fileStream) {
+    const apiKey = capabilities.environment.openaiAPIKey();
+    const client = makeClient(apiKey);
+
+    let rawResponse;
+    try {
+        rawResponse = await client.audio.transcriptions.create({
+            file: fileStream,
+            model: PRECISE_TRANSCRIBER_MODEL,
+            response_format: "verbose_json",
+        });
+    } catch (error) {
+        throw new AITranscriptionError(
+            `Failed to generate precise transcription: ${error instanceof Error ? error.message : String(error)}`,
+            error
+        );
+    }
+
+    if (!rawResponse || typeof rawResponse !== "object") {
+        throw new AITranscriptionError("Precise transcription response is not an object", rawResponse);
+    }
+
+    if (typeof rawResponse.text !== "string") {
+        throw new AITranscriptionError("Precise transcription response is missing 'text'", rawResponse);
+    }
+
+    return {
+        text: rawResponse.text,
+        provider: "OpenAI",
+        model: PRECISE_TRANSCRIBER_MODEL,
+        finishReason: null,
+        finishMessage: null,
+        candidateTokenCount: null,
+        usageMetadata: null,
+        modelVersion: null,
+        responseId: null,
+        structured: {
+            transcript: rawResponse.text,
+            coverage: "full",
+            warnings: [],
+            unclearAudio: false,
+        },
+        rawResponse,
+    };
+}
+
+/**
+ * Transcribes short audio fragments with Whisper and returns only transcript text.
+ * @param {function(string): OpenAI} makeClient - A memoized function to create an OpenAI client.
+ * @param {Capabilities} capabilities - The capabilities object.
+ * @param {import('fs').ReadStream} fileStream - The audio file stream to transcribe.
+ * @returns {Promise<string>}
+ */
+async function transcribeStreamPrecise(makeClient, capabilities, fileStream) {
+    const result = await transcribeStreamPreciseDetailed(makeClient, capabilities, fileStream);
+    capabilities.logger.logInfo(
+        {
+            file: fileStream.path,
+        },
+        "Precise transcription completed"
+    );
+    return result.text;
+}
 
 /**
  * Transcribes audio with full metadata using the Gemini API.
@@ -339,10 +414,15 @@ function getTranscriberInfo() {
 function make(getCapabilities) {
     const getCapabilitiesMemo = memconst(getCapabilities);
     const makeClient = memoize((apiKey) => new GoogleGenAI({ apiKey }));
+    const makeOpenAIClient = memoize((apiKey) => new OpenAI({ apiKey }));
     return {
         transcribeStream: (fileStream) => transcribeStream(makeClient, getCapabilitiesMemo(), fileStream),
         transcribeStreamDetailed: (fileStream) =>
             transcribeStreamDetailed(makeClient, getCapabilitiesMemo(), fileStream),
+        transcribeStreamPrecise: (fileStream) =>
+            transcribeStreamPrecise(makeOpenAIClient, getCapabilitiesMemo(), fileStream),
+        transcribeStreamPreciseDetailed: (fileStream) =>
+            transcribeStreamPreciseDetailed(makeOpenAIClient, getCapabilitiesMemo(), fileStream),
         getTranscriberInfo,
     };
 }
@@ -351,6 +431,7 @@ module.exports = {
     make,
     isAITranscriptionError,
     TRANSCRIBER_MODEL,
+    PRECISE_TRANSCRIBER_MODEL,
     MAX_OUTPUT_TOKENS,
     TEMPERATURE,
     THINKING_LEVEL,

--- a/backend/src/live_diary/service.js
+++ b/backend/src/live_diary/service.js
@@ -163,7 +163,7 @@ async function transcribeBuffer(audioBuffer, mimeType, capabilities) {
 
         let result;
         try {
-            result = await capabilities.aiTranscription.transcribeStreamDetailed(fileStream);
+            result = await capabilities.aiTranscription.transcribeStreamPreciseDetailed(fileStream);
         } finally {
             fileStream.destroy();
         }

--- a/backend/tests/ai_transcription.test.js
+++ b/backend/tests/ai_transcription.test.js
@@ -18,12 +18,17 @@ jest.mock("@google/genai", () => {
         GoogleGenAI: jest.fn(),
     };
 });
+jest.mock("openai", () => ({
+    OpenAI: jest.fn(),
+}));
 
 const { GoogleGenAI } = require("@google/genai");
+const { OpenAI } = require("openai");
 const {
     make,
     isAITranscriptionError,
     TRANSCRIBER_MODEL,
+    PRECISE_TRANSCRIBER_MODEL,
     MAX_OUTPUT_TOKENS,
     TEMPERATURE,
     THINKING_LEVEL,
@@ -39,6 +44,7 @@ function makeMockCapabilities() {
     return {
         environment: {
             geminiApiKey: jest.fn().mockReturnValue("test-api-key"),
+            openaiAPIKey: jest.fn().mockReturnValue("test-openai-api-key"),
         },
         sleeper: {
             sleep: jest.fn().mockResolvedValue(undefined),
@@ -50,6 +56,23 @@ function makeMockCapabilities() {
             logDebug: jest.fn(),
         },
     };
+}
+
+function setupMockOpenAIClient(resultOrError) {
+    const createTranscription = jest.fn();
+    if (resultOrError instanceof Error) {
+        createTranscription.mockRejectedValue(resultOrError);
+    } else {
+        createTranscription.mockResolvedValue(resultOrError);
+    }
+    OpenAI.mockImplementation(() => ({
+        audio: {
+            transcriptions: {
+                create: createTranscription,
+            },
+        },
+    }));
+    return { createTranscription };
 }
 
 function makeFileStream(filePath = "/tmp/test.mp3") {
@@ -962,5 +985,50 @@ describe("transcribeStream: compatibility", () => {
 
         expect(info.name).toBe(TRANSCRIBER_MODEL);
         expect(info.creator).toBe("Google");
+    });
+});
+
+describe("transcribeStreamPreciseDetailed/transcribeStreamPrecise", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test("uses whisper-1 for precise detailed transcription", async () => {
+        const { createTranscription } = setupMockOpenAIClient({
+            text: "precise transcript",
+            language: "en",
+        });
+        const caps = makeMockCapabilities();
+        const ai = make(() => caps);
+
+        const fileStream = makeFileStream("/tmp/fragment.webm");
+        const result = await ai.transcribeStreamPreciseDetailed(fileStream);
+
+        expect(createTranscription).toHaveBeenCalledWith({
+            file: fileStream,
+            model: PRECISE_TRANSCRIBER_MODEL,
+            response_format: "verbose_json",
+        });
+        expect(result.provider).toBe("OpenAI");
+        expect(result.model).toBe(PRECISE_TRANSCRIBER_MODEL);
+        expect(result.structured.transcript).toBe("precise transcript");
+    });
+
+    test("returns text in transcribeStreamPrecise", async () => {
+        setupMockOpenAIClient({ text: "precise transcript" });
+        const caps = makeMockCapabilities();
+        const ai = make(() => caps);
+
+        await expect(ai.transcribeStreamPrecise(makeFileStream("/tmp/fragment.mp3"))).resolves.toBe(
+            "precise transcript"
+        );
+    });
+
+    test("throws AITranscriptionError when precise transcription request fails", async () => {
+        setupMockOpenAIClient(new Error("network down"));
+        const caps = makeMockCapabilities();
+        const ai = make(() => caps);
+
+        await expectAITranscriptionError(ai.transcribeStreamPreciseDetailed(makeFileStream("/tmp/fragment.mp3")));
     });
 });

--- a/backend/tests/diary_live.test.js
+++ b/backend/tests/diary_live.test.js
@@ -145,7 +145,7 @@ describe("POST /api/audio-recording-session/:sessionId/push-audio", () => {
 
         // Wait for background processing then verify transcription was not called.
         await flushProcessing();
-        expect(capabilities.aiTranscription.transcribeStreamDetailed).not.toHaveBeenCalled();
+        expect(capabilities.aiTranscription.transcribeStreamPreciseDetailed).not.toHaveBeenCalled();
     });
 
     it("transcribes the overlap window and makes questions available via live-questions endpoint", async () => {
@@ -184,7 +184,7 @@ describe("POST /api/audio-recording-session/:sessionId/push-audio", () => {
         await flushProcessing();
 
         // Transcription was called once (for the overlap window formed by fragments 1+2).
-        expect(capabilities.aiTranscription.transcribeStreamDetailed).toHaveBeenCalledTimes(1);
+        expect(capabilities.aiTranscription.transcribeStreamPreciseDetailed).toHaveBeenCalledTimes(1);
         // Question generation was called once.
         expect(capabilities.aiDiaryQuestions.generateQuestions).toHaveBeenCalledTimes(1);
 
@@ -220,14 +220,14 @@ describe("POST /api/audio-recording-session/:sessionId/push-audio", () => {
 
         // Fragments 2: transcription(1+2) → first window. No recombination (no previous window).
         // Fragments 3: transcription(2+3) → second window. Recombination(window1, window2) called.
-        expect(capabilities.aiTranscription.transcribeStreamDetailed).toHaveBeenCalledTimes(2);
+        expect(capabilities.aiTranscription.transcribeStreamPreciseDetailed).toHaveBeenCalledTimes(2);
         expect(capabilities.aiTranscriptRecombination.recombineOverlap).toHaveBeenCalledTimes(1);
     });
 
     it("returns empty live-questions when the transcript is silent (empty transcription)", async () => {
         const capabilities = getTestCapabilities();
         // Override transcription to return empty.
-        capabilities.aiTranscription.transcribeStreamDetailed = jest.fn().mockResolvedValue({
+        capabilities.aiTranscription.transcribeStreamPreciseDetailed = jest.fn().mockResolvedValue({
             text: "",
             provider: "Google",
             model: "mocked",
@@ -279,7 +279,7 @@ describe("POST /api/audio-recording-session/:sessionId/push-audio", () => {
 
     it("returns 200 immediately even when transcription fails (background non-fatal)", async () => {
         const capabilities = getTestCapabilities();
-        capabilities.aiTranscription.transcribeStreamDetailed = jest
+        capabilities.aiTranscription.transcribeStreamPreciseDetailed = jest
             .fn()
             .mockRejectedValue(new Error("Transcription API error"));
         const app = await makeApp(capabilities);
@@ -321,7 +321,7 @@ describe("POST /api/audio-recording-session/:sessionId/push-audio", () => {
     it("continues processing newer fragments when one fragment transcription hangs", async () => {
         const capabilities = getTestCapabilities();
         let transcribeCallCount = 0;
-        capabilities.aiTranscription.transcribeStreamDetailed = jest
+        capabilities.aiTranscription.transcribeStreamPreciseDetailed = jest
             .fn()
             .mockImplementation(async () => {
                 transcribeCallCount += 1;
@@ -529,6 +529,6 @@ describe("POST /api/audio-recording-session/:sessionId/push-audio", () => {
         await flushProcessing();
 
         // Each new session starts fresh with no previous fragment to combine.
-        expect(capabilities.aiTranscription.transcribeStreamDetailed).not.toHaveBeenCalled();
+        expect(capabilities.aiTranscription.transcribeStreamPreciseDetailed).not.toHaveBeenCalled();
     });
 });

--- a/backend/tests/live_diary.test.js
+++ b/backend/tests/live_diary.test.js
@@ -64,14 +64,14 @@ describe("pushAudio", () => {
         const result = await pushAudio(caps, "sess-1", Buffer.from("audio1"), "audio/webm", 1);
         expect(result.questions).toEqual([]);
         expect(result.status).toBe("empty_result");
-        expect(caps.aiTranscription.transcribeStreamDetailed).not.toHaveBeenCalled();
+        expect(caps.aiTranscription.transcribeStreamPreciseDetailed).not.toHaveBeenCalled();
     });
 
     it("transcribes the 20s window on the second fragment", async () => {
         const caps = makeCapabilities();
         await pushAudio(caps, "sess-2", Buffer.from("audio1"), "audio/webm", 1);
         await pushAudio(caps, "sess-2", Buffer.from("audio2"), "audio/webm", 2);
-        expect(caps.aiTranscription.transcribeStreamDetailed).toHaveBeenCalledTimes(1);
+        expect(caps.aiTranscription.transcribeStreamPreciseDetailed).toHaveBeenCalledTimes(1);
     });
 
     it("returns questions on the second fragment when transcription succeeds", async () => {
@@ -89,13 +89,13 @@ describe("pushAudio", () => {
         await pushAudio(caps, "sess-3", Buffer.from("a1"), "audio/webm", 1);
         await pushAudio(caps, "sess-3", Buffer.from("a2"), "audio/webm", 2);
         await pushAudio(caps, "sess-3", Buffer.from("a3"), "audio/webm", 3);
-        expect(caps.aiTranscription.transcribeStreamDetailed).toHaveBeenCalledTimes(2);
+        expect(caps.aiTranscription.transcribeStreamPreciseDetailed).toHaveBeenCalledTimes(2);
         expect(caps.aiTranscriptRecombination.recombineOverlap).toHaveBeenCalledTimes(1);
     });
 
     it("removes the last word from the newer transcript before recombination when it has at least four words", async () => {
         const caps = makeCapabilities();
-        caps.aiTranscription.transcribeStreamDetailed = jest
+        caps.aiTranscription.transcribeStreamPreciseDetailed = jest
             .fn()
             .mockResolvedValueOnce({
                 text: "one two three four five",
@@ -136,7 +136,7 @@ describe("pushAudio", () => {
 
     it("keeps the newer transcript unchanged for recombination when it has fewer than two words", async () => {
         const caps = makeCapabilities();
-        caps.aiTranscription.transcribeStreamDetailed = jest
+        caps.aiTranscription.transcribeStreamPreciseDetailed = jest
             .fn()
             .mockResolvedValueOnce({
                 text: "existing overlap transcript",
@@ -177,7 +177,7 @@ describe("pushAudio", () => {
 
     it("removes the last word when the newer transcript has exactly four words", async () => {
         const caps = makeCapabilities();
-        caps.aiTranscription.transcribeStreamDetailed = jest
+        caps.aiTranscription.transcribeStreamPreciseDetailed = jest
             .fn()
             .mockResolvedValueOnce({
                 text: "first overlap window text",
@@ -218,7 +218,7 @@ describe("pushAudio", () => {
 
     it("appends the removed last word to recombination output", async () => {
         const caps = makeCapabilities();
-        caps.aiTranscription.transcribeStreamDetailed = jest
+        caps.aiTranscription.transcribeStreamPreciseDetailed = jest
             .fn()
             .mockResolvedValueOnce({
                 text: "walking to the park now",
@@ -264,7 +264,7 @@ describe("pushAudio", () => {
 
     it("uses the removed last word as merged text when recombination output is empty", async () => {
         const caps = makeCapabilities();
-        caps.aiTranscription.transcribeStreamDetailed = jest
+        caps.aiTranscription.transcribeStreamPreciseDetailed = jest
             .fn()
             .mockResolvedValueOnce({
                 text: "first second third fourth fifth",
@@ -306,7 +306,7 @@ describe("pushAudio", () => {
 
     it("returns empty questions when transcription fails (non-fatal)", async () => {
         const caps = makeCapabilities();
-        caps.aiTranscription.transcribeStreamDetailed = jest
+        caps.aiTranscription.transcribeStreamPreciseDetailed = jest
             .fn()
             .mockRejectedValue(new Error("API error"));
 
@@ -318,7 +318,7 @@ describe("pushAudio", () => {
 
     it("returns degraded_transcription if transcription takes too long", async () => {
         const caps = makeCapabilities();
-        caps.aiTranscription.transcribeStreamDetailed = jest
+        caps.aiTranscription.transcribeStreamPreciseDetailed = jest
             .fn()
             .mockImplementation(() => new Promise((resolve) => {
                 setTimeout(() => {
@@ -353,7 +353,7 @@ describe("pushAudio", () => {
 
     it("returns empty questions when transcription returns empty string (silence)", async () => {
         const caps = makeCapabilities();
-        caps.aiTranscription.transcribeStreamDetailed = jest.fn().mockResolvedValue({
+        caps.aiTranscription.transcribeStreamPreciseDetailed = jest.fn().mockResolvedValue({
             text: "",
             provider: "Google",
             model: "mocked",
@@ -395,7 +395,7 @@ describe("pushAudio", () => {
 
     it("returns degraded_question_generation if question generation takes too long", async () => {
         const caps = makeCapabilities();
-        caps.aiTranscription.transcribeStreamDetailed = jest.fn().mockResolvedValue({
+        caps.aiTranscription.transcribeStreamPreciseDetailed = jest.fn().mockResolvedValue({
             text: "steady transcript",
             provider: "Google",
             model: "mocked",
@@ -456,7 +456,7 @@ describe("pushAudio", () => {
         const result = await pushAudio(caps, "sess-mime", Buffer.from("a2"), "audio/ogg", 2);
         expect(result.questions).toEqual([]);
         expect(result.status).toBe("unsupported_mime");
-        expect(caps.aiTranscription.transcribeStreamDetailed).not.toHaveBeenCalled();
+        expect(caps.aiTranscription.transcribeStreamPreciseDetailed).not.toHaveBeenCalled();
     });
 });
 
@@ -480,7 +480,7 @@ describe("session cleanup on new session", () => {
         await pushAudio(caps, "new-session", Buffer.from("b2"), "audio/webm", 2);
 
         // Total transcription calls: 1 (for old-session window) + 1 (for new-session window) = 2.
-        expect(caps.aiTranscription.transcribeStreamDetailed).toHaveBeenCalledTimes(2);
+        expect(caps.aiTranscription.transcribeStreamPreciseDetailed).toHaveBeenCalledTimes(2);
     });
 });
 
@@ -506,9 +506,9 @@ describe("backend reboot continuity", () => {
         // Fragment 2 arrives at the new instance. It should find fragment 1 in DB and transcribe.
         await pushAudio(caps2, "reboot-session", Buffer.from("fragment-2"), "audio/webm", 2);
 
-        expect(caps2.aiTranscription.transcribeStreamDetailed).toHaveBeenCalledTimes(1);
+        expect(caps2.aiTranscription.transcribeStreamPreciseDetailed).toHaveBeenCalledTimes(1);
         // caps1 should NOT have been asked to transcribe (it only stored fragment 1).
-        expect(caps1.aiTranscription.transcribeStreamDetailed).not.toHaveBeenCalled();
+        expect(caps1.aiTranscription.transcribeStreamPreciseDetailed).not.toHaveBeenCalled();
     });
 
     it("persists running transcript across backend restarts", async () => {
@@ -532,7 +532,7 @@ describe("backend reboot continuity", () => {
 
         // caps2 should have called transcription (for window f2+f3) and recombination
         // (because the last window transcript was persisted).
-        expect(caps2.aiTranscription.transcribeStreamDetailed).toHaveBeenCalledTimes(1);
+        expect(caps2.aiTranscription.transcribeStreamPreciseDetailed).toHaveBeenCalledTimes(1);
         expect(caps2.aiTranscriptRecombination.recombineOverlap).toHaveBeenCalledTimes(1);
     });
 

--- a/backend/tests/stubs.js
+++ b/backend/tests/stubs.js
@@ -110,6 +110,29 @@ function stubAiTranscriber(capabilities) {
             },
             rawResponse: null,
         });
+    capabilities.aiTranscription.transcribeStreamPrecise = jest
+        .fn()
+        .mockResolvedValue("mocked transcription result");
+    capabilities.aiTranscription.transcribeStreamPreciseDetailed = jest
+        .fn()
+        .mockResolvedValue({
+            text: "mocked transcription result",
+            provider: "OpenAI",
+            model: "whisper-1",
+            finishReason: null,
+            finishMessage: null,
+            candidateTokenCount: null,
+            usageMetadata: null,
+            modelVersion: null,
+            responseId: null,
+            structured: {
+                transcript: "mocked transcription result",
+                coverage: "full",
+                warnings: [],
+                unclearAudio: false,
+            },
+            rawResponse: null,
+        });
     capabilities.aiTranscription.getTranscriberInfo = jest.fn().mockReturnValue({
         name: "mocked-transcriber",
         creator: "Mocked Creator",


### PR DESCRIPTION
### Motivation
- Short 20s live-diary fragments are better served by OpenAI Whisper than the existing Gemini-based path, so we need a precise transcriber for those overlap windows.
- Introduce capability-level methods so the live-diary pipeline can call a Whisper-based path without disrupting existing Gemini flows.

### Description
- Added two new AITranscription capability methods in `backend/src/ai/transcription.js`: `transcribeStreamPrecise` and `transcribeStreamPreciseDetailed`, implemented using OpenAI via `client.audio.transcriptions.create` with `model: "whisper-1"` and `response_format: "verbose_json"`.
- Wired the new precise methods into the capability factory (`make(...)`) with a memoized OpenAI client and preserved the existing Gemini-based `transcribeStream`/`transcribeStreamDetailed` methods.
- Switched the live-diary overlap-window transcription call in `backend/src/live_diary/service.js` to use `capabilities.aiTranscription.transcribeStreamPreciseDetailed(...)` instead of the Gemini detailed method.
- Updated test scaffolding and unit tests: added OpenAI mocks in `backend/tests/ai_transcription.test.js`, provided precise-method stubs in `backend/tests/stubs.js`, and updated live-diary tests (`backend/tests/live_diary.test.js` and `backend/tests/diary_live.test.js`) to assert/expect calls to the precise methods.

### Testing
- Ran targeted unit tests with `npx jest backend/tests/ai_transcription.test.js backend/tests/diary_live.test.js`, which passed.
- Ran `npm install` successfully to refresh deps.
- Ran the full test suite with `npm test`, which produced one unrelated/flaky failure (timeout in `backend/tests/interface.test.js`), while the rest of the suite passed.
- Ran static analysis with `npm run static-analysis`, which succeeded, and verified the frontend build with `npm run build`, which also succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c748538974832e9816ac6eeedc00de)