### PR TITLE
Fix live question text overflow in prompt cards

### DIFF
--- a/frontend/src/AudioDiary/LiveQuestionsPanel.jsx
+++ b/frontend/src/AudioDiary/LiveQuestionsPanel.jsx
@@ -50,6 +50,7 @@ function QuestionItem({ question, isPinned, isNew, onTogglePin }) {
             aria-label={isPinned ? `Unpin question: ${question.text}` : `Pin question: ${question.text}`}
             textAlign="left"
             width="100%"
+            whiteSpace="normal"
             style={
                 isNew
                     ? { animation: `${fadeIn} 300ms ease-out` }
@@ -62,6 +63,9 @@ function QuestionItem({ question, isPinned, isNew, onTogglePin }) {
                 fontSize="sm"
                 lineHeight="1.5"
                 color="gray.700"
+                whiteSpace="normal"
+                wordBreak="break-word"
+                overflowWrap="anywhere"
                 style={{ maxWidth: "70ch" }}
             >
                 {question.text}


### PR DESCRIPTION
### Motivation
- Fix live questions UI on `/baseurl/record-diary` where long question text could overflow and escape its enclosing card, breaking layout.

### Description
- Update `LiveQuestionsPanel` `QuestionItem` so the button allows wrapping (`whiteSpace="normal"`) and the question `Text` forces robust wrapping (`whiteSpace="normal"`, `wordBreak="break-word"`, `overflowWrap="anywhere"`) so long prompts wrap inside their card instead of overflowing.

### Testing
- Ran `npx jest frontend/tests/LiveQuestionsPanel.test.jsx` which passed, ran the full test suite with `npm test` which failed due to an existing backend timeout in `backend/tests/interface.test.js` (test "events survive a simulated restart (synchronizeDatabase reopen)"), and ran `npm run static-analysis` and `npm run build` which both succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9e6615b30832ebbc1afc154b1e6b0)