### PR TITLE
Fix sync error panel overflow with horizontal scrolling

### DIFF
--- a/frontend/src/Sync/SyncSection.jsx
+++ b/frontend/src/Sync/SyncSection.jsx
@@ -217,13 +217,22 @@ export function SyncSection() {
         </Alert.Root>
       )}
       {syncState === 'error' && syncError.message !== '' && (
-        <Alert.Root status="error" borderRadius="md" alignItems="flex-start" w="200px">
+        <Alert.Root
+          status="error"
+          borderRadius="md"
+          alignItems="flex-start"
+          w="full"
+          maxW="min(1000px, calc(100vw - 2rem))">
           <Alert.Indicator mt={1} />
-          <Box>
+          <Box w="full" minW={0}>
             <Alert.Title>Sync failed</Alert.Title>
             <Alert.Description>
               <VStack gap={3} align="stretch" mt={2}>
-                <Text whiteSpace="pre-wrap">{syncError.message}</Text>
+                <Box overflowX="auto" w="full">
+                  <Text as="pre" whiteSpace="pre" m={0}>
+                    {syncError.message}
+                  </Text>
+                </Box>
                 {syncError.details.length > 0 && (
                   <Box>
                     <Text fontWeight="semibold" mb={2}>Details</Text>
@@ -231,11 +240,17 @@ export function SyncSection() {
                       {syncError.details.map((detail, index) => (
                         <List.Item key={`${detail.name}-${index}`}>
                           <Text fontWeight="medium">{detail.name}</Text>
-                          <Text>{detail.message}</Text>
+                          <Box overflowX="auto" w="full">
+                            <Text as="pre" whiteSpace="pre" m={0}>
+                              {detail.message}
+                            </Text>
+                          </Box>
                           {detail.causes.length > 0 && (
-                            <Code display="block" mt={2} whiteSpace="pre-wrap">
-                              {detail.causes.join('\n')}
-                            </Code>
+                            <Box overflowX="auto" w="full">
+                              <Code display="block" mt={2} whiteSpace="pre">
+                                {detail.causes.join('\n')}
+                              </Code>
+                            </Box>
                           )}
                         </List.Item>
                       ))}


### PR DESCRIPTION
### Motivation
- The sync error alert on the main page showed full stack traces that overflowed the fixed 200px container and caused the page to scroll horizontally. 
- The goal is to let the error panel expand across most of the viewport and contain long lines with an internal horizontal scroller so stack traces remain readable and preserve formatting.

### Description
- Enlarged the error alert container by replacing the fixed `w="200px"` with `w="full"` and `maxW="min(1000px, calc(100vw - 2rem))"` in `frontend/src/Sync/SyncSection.jsx`.
- Ensured the inner wrapper can shrink by adding `w="full"` and `minW={0}` to the alert content container to avoid flex overflow issues.
- Wrapped the top-level error message, per-detail message, and cause stack-trace block in `Box overflowX="auto"` and render them as preformatted blocks (`<Text as="pre" whiteSpace="pre">` and `<Code whiteSpace="pre">`) so long lines preserve formatting and scroll horizontally inside the box.
- Modified file: `frontend/src/Sync/SyncSection.jsx`.

### Testing
- Ran `npm install` which completed successfully.
- Ran focused unit tests with `npx jest frontend/tests/App.test.jsx` and they passed (`15` tests passed).
- Ran static analysis with `npm run static-analysis` which completed successfully.
- Built the frontend with `npm run build` which completed successfully.
- Attempted to run the full test suite (`npm test -- --runInBand --ci`), but the run timed out in this environment and did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9e6da8d94832e8a74de68e1aaf860)