### PR TITLE
Decouple entry submit prefetch from backend last_entries endpoint

### DIFF
--- a/frontend/src/DescriptionEntry/api.js
+++ b/frontend/src/DescriptionEntry/api.js
@@ -7,12 +7,6 @@ import {
 } from "./errors.js";
 
 /**
- * Number of events pre-cached in the `last_entries(n)` graph node.
- * Must match `SORTED_EVENTS_CACHE_SIZE` in the backend constants.
- */
-const SORTED_EVENTS_CACHE_SIZE = 100;
-
-/**
  * Get the client's local IANA timezone name.
  * @returns {string}
  */
@@ -191,20 +185,17 @@ export const updateConfig = async (config) => {
 };
 
 /**
- * Triggers a background pull of the `last_entries(SORTED_EVENTS_CACHE_SIZE)`
- * graph node to warm the cache after a new entry is created.
+ * Triggers a background history fetch to warm the same data used by
+ * the search page after a new entry is created.
  *
  * This is a fire-and-forget operation: the caller does not await the result.
  * Errors are logged but not propagated.
  *
- * The `~` prefix encodes the numeric binding per the graph URL convention
- * (mirrors the filesystem encoding in `database/render.js`).
- *
  * @returns {void}
  */
-export function triggerLastEntriesPrefetch() {
-    const url = `${API_BASE_URL}/graph/nodes/last_entries/~${SORTED_EVENTS_CACHE_SIZE}`;
-    fetch(url, { method: "POST" }).catch((error) => {
-        logger.warn("Failed to prefetch last_entries:", error);
+export function triggerHistoryPrefetch() {
+    const url = `${API_BASE_URL}/entries?page=1&limit=50&order=dateDescending`;
+    fetch(url).catch((error) => {
+        logger.warn("Failed to prefetch history:", error);
     });
 }

--- a/frontend/src/DescriptionEntry/hooks.js
+++ b/frontend/src/DescriptionEntry/hooks.js
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { useToast } from "../toast.jsx";
 import {
     submitEntry,
-    triggerLastEntriesPrefetch,
+    triggerHistoryPrefetch,
 } from "./api";
 import { isValidDescription, createToastConfig } from "./utils.js";
 import { logger } from "./logger.js";
@@ -205,7 +205,7 @@ export const useDescriptionEntry = () => {
 
             const result = await submitEntry(descriptionToSubmit, pendingRequestIdentifier || undefined, files);
             handleSubmissionSuccess(result, descriptionToSubmit, files, setPendingRequestIdentifier, setPhotoCount, toast);
-            triggerLastEntriesPrefetch();
+            triggerHistoryPrefetch();
             navigate("/search");
         } catch (error) {
             handleSubmissionError(error, toast);

--- a/frontend/tests/ConfigPage.test.jsx
+++ b/frontend/tests/ConfigPage.test.jsx
@@ -10,7 +10,7 @@ jest.mock("../src/DescriptionEntry/api", () => ({
     submitEntry: jest.fn(),
     fetchConfig: jest.fn(),
     updateConfig: jest.fn(),
-    triggerLastEntriesPrefetch: jest.fn(),
+    triggerHistoryPrefetch: jest.fn(),
 }));
 
 // Mock the logger module

--- a/frontend/tests/DescriptionEntry.api.test.js
+++ b/frontend/tests/DescriptionEntry.api.test.js
@@ -15,7 +15,7 @@ import {
     submitEntry,
     fetchConfig,
     updateConfig,
-    triggerLastEntriesPrefetch,
+    triggerHistoryPrefetch,
 } from "../src/DescriptionEntry/api.js";
 
 function makeResponse(status, data) {
@@ -299,7 +299,7 @@ describe("submitEntry", () => {
     });
 });
 
-describe("triggerLastEntriesPrefetch", () => {
+describe("triggerHistoryPrefetch", () => {
     beforeEach(() => {
         global.fetch = jest.fn().mockResolvedValue({ ok: true });
     });
@@ -308,12 +308,11 @@ describe("triggerLastEntriesPrefetch", () => {
         delete global.fetch;
     });
 
-    it("sends a POST to the last_entries graph node URL", () => {
-        triggerLastEntriesPrefetch();
+    it("fetches the same history endpoint used by the search page", () => {
+        triggerHistoryPrefetch();
 
         expect(global.fetch).toHaveBeenCalledWith(
-            expect.stringContaining("/api/graph/nodes/last_entries/"),
-            expect.objectContaining({ method: "POST" })
+            "/api/entries?page=1&limit=50&order=dateDescending"
         );
     });
 });

--- a/frontend/tests/DescriptionEntry.basic.input.test.jsx
+++ b/frontend/tests/DescriptionEntry.basic.input.test.jsx
@@ -7,7 +7,7 @@ import { renderWithChakra } from "./renderWithChakra.jsx";
 jest.mock("../src/DescriptionEntry/api", () => ({
     submitEntry: jest.fn(),
     fetchConfig: jest.fn(),
-    triggerLastEntriesPrefetch: jest.fn(),
+    triggerHistoryPrefetch: jest.fn(),
 }));
 
 // Mock the logger module to prevent console output during tests

--- a/frontend/tests/DescriptionEntry.basic.test.jsx
+++ b/frontend/tests/DescriptionEntry.basic.test.jsx
@@ -7,7 +7,7 @@ import { renderWithChakra } from "./renderWithChakra.jsx";
 jest.mock("../src/DescriptionEntry/api", () => ({
     submitEntry: jest.fn(),
     fetchConfig: jest.fn(),
-    triggerLastEntriesPrefetch: jest.fn(),
+    triggerHistoryPrefetch: jest.fn(),
 }));
 
 // Mock the logger module to prevent console output during tests

--- a/frontend/tests/DescriptionEntry.camera.fieldname.test.jsx
+++ b/frontend/tests/DescriptionEntry.camera.fieldname.test.jsx
@@ -7,7 +7,7 @@ import { renderWithChakra } from "./renderWithChakra.jsx";
 jest.mock("../src/DescriptionEntry/api", () => ({
     submitEntry: jest.fn(),
     fetchConfig: jest.fn(),
-    triggerLastEntriesPrefetch: jest.fn(),
+    triggerHistoryPrefetch: jest.fn(),
 }));
 
 // Mock the logger module to prevent console output during tests

--- a/frontend/tests/DescriptionEntry.camera.test.jsx
+++ b/frontend/tests/DescriptionEntry.camera.test.jsx
@@ -7,7 +7,7 @@ import { renderWithChakra } from "./renderWithChakra.jsx";
 jest.mock("../src/DescriptionEntry/api", () => ({
     submitEntry: jest.fn(),
     fetchConfig: jest.fn(),
-    triggerLastEntriesPrefetch: jest.fn(),
+    triggerHistoryPrefetch: jest.fn(),
 }));
 
 // Mock the logger module to prevent console output during tests

--- a/frontend/tests/DescriptionEntry.config.extra.test.jsx
+++ b/frontend/tests/DescriptionEntry.config.extra.test.jsx
@@ -7,7 +7,7 @@ import { renderWithChakra } from "./renderWithChakra.jsx";
 jest.mock("../src/DescriptionEntry/api", () => ({
     submitEntry: jest.fn(),
     fetchConfig: jest.fn(),
-    triggerLastEntriesPrefetch: jest.fn(),
+    triggerHistoryPrefetch: jest.fn(),
 }));
 
 // Mock the logger module to prevent console output during tests

--- a/frontend/tests/DescriptionEntry.config.test.jsx
+++ b/frontend/tests/DescriptionEntry.config.test.jsx
@@ -7,7 +7,7 @@ import { renderWithChakra } from "./renderWithChakra.jsx";
 jest.mock("../src/DescriptionEntry/api", () => ({
     submitEntry: jest.fn(),
     fetchConfig: jest.fn(),
-    triggerLastEntriesPrefetch: jest.fn(),
+    triggerHistoryPrefetch: jest.fn(),
 }));
 
 // Mock the logger module to prevent console output during tests

--- a/frontend/tests/DescriptionEntry.photocount.bugfix.test.jsx
+++ b/frontend/tests/DescriptionEntry.photocount.bugfix.test.jsx
@@ -14,7 +14,7 @@ jest.mock("../src/toast.jsx", () => ({
 jest.mock("../src/DescriptionEntry/api", () => ({
     submitEntry: jest.fn(),
     fetchConfig: jest.fn(),
-    triggerLastEntriesPrefetch: jest.fn(),
+    triggerHistoryPrefetch: jest.fn(),
 }));
 
 // Mock the logger module to prevent console output during tests

--- a/frontend/tests/DescriptionEntry.spam.test.jsx
+++ b/frontend/tests/DescriptionEntry.spam.test.jsx
@@ -7,7 +7,7 @@ import { renderWithChakra } from "./renderWithChakra.jsx";
 jest.mock("../src/DescriptionEntry/api", () => ({
     submitEntry: jest.fn(),
     fetchConfig: jest.fn(),
-    triggerLastEntriesPrefetch: jest.fn(),
+    triggerHistoryPrefetch: jest.fn(),
 }));
 
 // Mock the logger module to prevent console output during tests

--- a/frontend/tests/DescriptionEntry.submission.test.jsx
+++ b/frontend/tests/DescriptionEntry.submission.test.jsx
@@ -7,7 +7,7 @@ import { renderWithChakra } from "./renderWithChakra.jsx";
 jest.mock("../src/DescriptionEntry/api", () => ({
     submitEntry: jest.fn(),
     fetchConfig: jest.fn(),
-    triggerLastEntriesPrefetch: jest.fn(),
+    triggerHistoryPrefetch: jest.fn(),
 }));
 
 // Mock the logger module to prevent console output during tests
@@ -42,7 +42,7 @@ import DescriptionEntry from "../src/DescriptionEntry/DescriptionEntry.jsx";
 import {
     submitEntry,
     fetchConfig,
-    triggerLastEntriesPrefetch,
+    triggerHistoryPrefetch,
 } from "../src/DescriptionEntry/api";
 
 // Import the mocked camera functions
@@ -83,7 +83,7 @@ describe("DescriptionEntry", () => {
         submitEntry.mockClear();
         fetchConfig.mockClear();
         mockNavigate.mockClear();
-        triggerLastEntriesPrefetch.mockClear();
+        triggerHistoryPrefetch.mockClear();
 
         // Reset camera mocks - use mockReset to clear all state
         generateRequestIdentifier.mockReset();
@@ -288,7 +288,7 @@ describe("DescriptionEntry", () => {
         expect(mockNavigate).not.toHaveBeenCalled();
     });
 
-    it("triggers last entries prefetch after successful submission", async () => {
+    it("triggers history prefetch after successful submission", async () => {
         renderWithChakra(<DescriptionEntry />);
 
         // Wait for component to settle
@@ -303,11 +303,11 @@ describe("DescriptionEntry", () => {
         fireEvent.keyUp(input, { key: "Enter", code: "Enter" });
 
         await waitFor(() => {
-            expect(triggerLastEntriesPrefetch).toHaveBeenCalledTimes(1);
+            expect(triggerHistoryPrefetch).toHaveBeenCalledTimes(1);
         });
     });
 
-    it("does not trigger last entries prefetch when submission fails", async () => {
+    it("does not trigger history prefetch when submission fails", async () => {
         submitEntry.mockRejectedValue(new Error("Network error"));
 
         renderWithChakra(<DescriptionEntry />);
@@ -327,7 +327,7 @@ describe("DescriptionEntry", () => {
             expect(submitEntry).toHaveBeenCalled();
         });
 
-        expect(triggerLastEntriesPrefetch).not.toHaveBeenCalled();
+        expect(triggerHistoryPrefetch).not.toHaveBeenCalled();
     });
 
 });


### PR DESCRIPTION
### Motivation

- The frontend was coupled to a backend-internal cache graph node (`/graph/nodes/last_entries/~100`) and the hard-coded `100` constant, leaking backend implementation details into the UI. 
- After an entry submission the UI should warm the same history data used by the Search page to avoid tight coupling and make behavior backend-agnostic.

### Description

- Replaced the old graph-node prefetch helper with `triggerHistoryPrefetch` which fetches the Search-style history endpoint `'/entries?page=1&limit=50&order=dateDescending'` instead of calling `/graph/nodes/last_entries/~...` (file: `frontend/src/DescriptionEntry/api.js`).
- Updated the submission flow to call `triggerHistoryPrefetch` after successful submission (file: `frontend/src/DescriptionEntry/hooks.js`).
- Removed the obsolete `SORTED_EVENTS_CACHE_SIZE` constant and comments specific to the backend `last_entries` graph node (file: `frontend/src/DescriptionEntry/api.js`).
- Updated tests and mocks to the new helper name and endpoint expectation across the DescriptionEntry and ConfigPage tests (files under `frontend/tests/*DescriptionEntry*` and `frontend/tests/ConfigPage.test.jsx`).

### Testing

- Ran focused tests with `npx jest frontend/tests/DescriptionEntry.api.test.js frontend/tests/DescriptionEntry.submission.test.jsx` and they passed. 
- Ran the full suite with `npm test` which completed successfully (all test suites and tests passed). 
- Ran static analysis with `npm run static-analysis` and the TypeScript/lint checks passed. 
- Verified production build with `npm run build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cadfaf9958832ea0d3105b6ad7b92d)