### PR TITLE
Decouple frontend submission flow from backend last_entries prefetch

### DIFF
--- a/frontend/src/DescriptionEntry/api.js
+++ b/frontend/src/DescriptionEntry/api.js
@@ -7,12 +7,6 @@ import {
 } from "./errors.js";
 
 /**
- * Number of events pre-cached in the `last_entries(n)` graph node.
- * Must match `SORTED_EVENTS_CACHE_SIZE` in the backend constants.
- */
-const SORTED_EVENTS_CACHE_SIZE = 100;
-
-/**
  * Get the client's local IANA timezone name.
  * @returns {string}
  */
@@ -189,22 +183,3 @@ export const updateConfig = async (config) => {
         return null;
     }
 };
-
-/**
- * Triggers a background pull of the `last_entries(SORTED_EVENTS_CACHE_SIZE)`
- * graph node to warm the cache after a new entry is created.
- *
- * This is a fire-and-forget operation: the caller does not await the result.
- * Errors are logged but not propagated.
- *
- * The `~` prefix encodes the numeric binding per the graph URL convention
- * (mirrors the filesystem encoding in `database/render.js`).
- *
- * @returns {void}
- */
-export function triggerLastEntriesPrefetch() {
-    const url = `${API_BASE_URL}/graph/nodes/last_entries/~${SORTED_EVENTS_CACHE_SIZE}`;
-    fetch(url, { method: "POST" }).catch((error) => {
-        logger.warn("Failed to prefetch last_entries:", error);
-    });
-}

--- a/frontend/src/DescriptionEntry/hooks.js
+++ b/frontend/src/DescriptionEntry/hooks.js
@@ -3,7 +3,6 @@ import { useNavigate } from "react-router-dom";
 import { useToast } from "../toast.jsx";
 import {
     submitEntry,
-    triggerLastEntriesPrefetch,
 } from "./api";
 import { isValidDescription, createToastConfig } from "./utils.js";
 import { logger } from "./logger.js";
@@ -205,7 +204,6 @@ export const useDescriptionEntry = () => {
 
             const result = await submitEntry(descriptionToSubmit, pendingRequestIdentifier || undefined, files);
             handleSubmissionSuccess(result, descriptionToSubmit, files, setPendingRequestIdentifier, setPhotoCount, toast);
-            triggerLastEntriesPrefetch();
             navigate("/search");
         } catch (error) {
             handleSubmissionError(error, toast);

--- a/frontend/tests/ConfigPage.test.jsx
+++ b/frontend/tests/ConfigPage.test.jsx
@@ -10,7 +10,6 @@ jest.mock("../src/DescriptionEntry/api", () => ({
     submitEntry: jest.fn(),
     fetchConfig: jest.fn(),
     updateConfig: jest.fn(),
-    triggerLastEntriesPrefetch: jest.fn(),
 }));
 
 // Mock the logger module

--- a/frontend/tests/DescriptionEntry.api.test.js
+++ b/frontend/tests/DescriptionEntry.api.test.js
@@ -15,7 +15,6 @@ import {
     submitEntry,
     fetchConfig,
     updateConfig,
-    triggerLastEntriesPrefetch,
 } from "../src/DescriptionEntry/api.js";
 
 function makeResponse(status, data) {
@@ -296,25 +295,6 @@ describe("submitEntry", () => {
             expect(body.rawInput).toBe("work [loc home] Remote day");
             expect(isIANATimezone(body.clientTimezone)).toBe(true);
         });
-    });
-});
-
-describe("triggerLastEntriesPrefetch", () => {
-    beforeEach(() => {
-        global.fetch = jest.fn().mockResolvedValue({ ok: true });
-    });
-
-    afterEach(() => {
-        delete global.fetch;
-    });
-
-    it("sends a POST to the last_entries graph node URL", () => {
-        triggerLastEntriesPrefetch();
-
-        expect(global.fetch).toHaveBeenCalledWith(
-            expect.stringContaining("/api/graph/nodes/last_entries/"),
-            expect.objectContaining({ method: "POST" })
-        );
     });
 });
 

--- a/frontend/tests/DescriptionEntry.basic.input.test.jsx
+++ b/frontend/tests/DescriptionEntry.basic.input.test.jsx
@@ -7,7 +7,6 @@ import { renderWithChakra } from "./renderWithChakra.jsx";
 jest.mock("../src/DescriptionEntry/api", () => ({
     submitEntry: jest.fn(),
     fetchConfig: jest.fn(),
-    triggerLastEntriesPrefetch: jest.fn(),
 }));
 
 // Mock the logger module to prevent console output during tests

--- a/frontend/tests/DescriptionEntry.basic.test.jsx
+++ b/frontend/tests/DescriptionEntry.basic.test.jsx
@@ -7,7 +7,6 @@ import { renderWithChakra } from "./renderWithChakra.jsx";
 jest.mock("../src/DescriptionEntry/api", () => ({
     submitEntry: jest.fn(),
     fetchConfig: jest.fn(),
-    triggerLastEntriesPrefetch: jest.fn(),
 }));
 
 // Mock the logger module to prevent console output during tests

--- a/frontend/tests/DescriptionEntry.camera.fieldname.test.jsx
+++ b/frontend/tests/DescriptionEntry.camera.fieldname.test.jsx
@@ -7,7 +7,6 @@ import { renderWithChakra } from "./renderWithChakra.jsx";
 jest.mock("../src/DescriptionEntry/api", () => ({
     submitEntry: jest.fn(),
     fetchConfig: jest.fn(),
-    triggerLastEntriesPrefetch: jest.fn(),
 }));
 
 // Mock the logger module to prevent console output during tests

--- a/frontend/tests/DescriptionEntry.camera.test.jsx
+++ b/frontend/tests/DescriptionEntry.camera.test.jsx
@@ -7,7 +7,6 @@ import { renderWithChakra } from "./renderWithChakra.jsx";
 jest.mock("../src/DescriptionEntry/api", () => ({
     submitEntry: jest.fn(),
     fetchConfig: jest.fn(),
-    triggerLastEntriesPrefetch: jest.fn(),
 }));
 
 // Mock the logger module to prevent console output during tests

--- a/frontend/tests/DescriptionEntry.config.extra.test.jsx
+++ b/frontend/tests/DescriptionEntry.config.extra.test.jsx
@@ -7,7 +7,6 @@ import { renderWithChakra } from "./renderWithChakra.jsx";
 jest.mock("../src/DescriptionEntry/api", () => ({
     submitEntry: jest.fn(),
     fetchConfig: jest.fn(),
-    triggerLastEntriesPrefetch: jest.fn(),
 }));
 
 // Mock the logger module to prevent console output during tests

--- a/frontend/tests/DescriptionEntry.config.test.jsx
+++ b/frontend/tests/DescriptionEntry.config.test.jsx
@@ -7,7 +7,6 @@ import { renderWithChakra } from "./renderWithChakra.jsx";
 jest.mock("../src/DescriptionEntry/api", () => ({
     submitEntry: jest.fn(),
     fetchConfig: jest.fn(),
-    triggerLastEntriesPrefetch: jest.fn(),
 }));
 
 // Mock the logger module to prevent console output during tests

--- a/frontend/tests/DescriptionEntry.photocount.bugfix.test.jsx
+++ b/frontend/tests/DescriptionEntry.photocount.bugfix.test.jsx
@@ -14,7 +14,6 @@ jest.mock("../src/toast.jsx", () => ({
 jest.mock("../src/DescriptionEntry/api", () => ({
     submitEntry: jest.fn(),
     fetchConfig: jest.fn(),
-    triggerLastEntriesPrefetch: jest.fn(),
 }));
 
 // Mock the logger module to prevent console output during tests

--- a/frontend/tests/DescriptionEntry.spam.test.jsx
+++ b/frontend/tests/DescriptionEntry.spam.test.jsx
@@ -7,7 +7,6 @@ import { renderWithChakra } from "./renderWithChakra.jsx";
 jest.mock("../src/DescriptionEntry/api", () => ({
     submitEntry: jest.fn(),
     fetchConfig: jest.fn(),
-    triggerLastEntriesPrefetch: jest.fn(),
 }));
 
 // Mock the logger module to prevent console output during tests

--- a/frontend/tests/DescriptionEntry.submission.test.jsx
+++ b/frontend/tests/DescriptionEntry.submission.test.jsx
@@ -7,7 +7,6 @@ import { renderWithChakra } from "./renderWithChakra.jsx";
 jest.mock("../src/DescriptionEntry/api", () => ({
     submitEntry: jest.fn(),
     fetchConfig: jest.fn(),
-    triggerLastEntriesPrefetch: jest.fn(),
 }));
 
 // Mock the logger module to prevent console output during tests
@@ -42,7 +41,6 @@ import DescriptionEntry from "../src/DescriptionEntry/DescriptionEntry.jsx";
 import {
     submitEntry,
     fetchConfig,
-    triggerLastEntriesPrefetch,
 } from "../src/DescriptionEntry/api";
 
 // Import the mocked camera functions
@@ -83,7 +81,6 @@ describe("DescriptionEntry", () => {
         submitEntry.mockClear();
         fetchConfig.mockClear();
         mockNavigate.mockClear();
-        triggerLastEntriesPrefetch.mockClear();
 
         // Reset camera mocks - use mockReset to clear all state
         generateRequestIdentifier.mockReset();
@@ -286,48 +283,6 @@ describe("DescriptionEntry", () => {
         });
 
         expect(mockNavigate).not.toHaveBeenCalled();
-    });
-
-    it("triggers last entries prefetch after successful submission", async () => {
-        renderWithChakra(<DescriptionEntry />);
-
-        // Wait for component to settle
-        await waitFor(() => {
-            expect(screen.getByText("Help")).toBeInTheDocument();
-        });
-
-        const input = screen.getByPlaceholderText(
-            "Type your event description here..."
-        );
-        fireEvent.change(input, { target: { value: "test event" } });
-        fireEvent.keyUp(input, { key: "Enter", code: "Enter" });
-
-        await waitFor(() => {
-            expect(triggerLastEntriesPrefetch).toHaveBeenCalledTimes(1);
-        });
-    });
-
-    it("does not trigger last entries prefetch when submission fails", async () => {
-        submitEntry.mockRejectedValue(new Error("Network error"));
-
-        renderWithChakra(<DescriptionEntry />);
-
-        // Wait for component to settle
-        await waitFor(() => {
-            expect(screen.getByText("Help")).toBeInTheDocument();
-        });
-
-        const input = screen.getByPlaceholderText(
-            "Type your event description here..."
-        );
-        fireEvent.change(input, { target: { value: "test event" } });
-        fireEvent.keyUp(input, { key: "Enter", code: "Enter" });
-
-        await waitFor(() => {
-            expect(submitEntry).toHaveBeenCalled();
-        });
-
-        expect(triggerLastEntriesPrefetch).not.toHaveBeenCalled();
     });
 
 });


### PR DESCRIPTION
### Motivation
- The frontend previously called a backend-specific `last_entries` prefetch endpoint (and encoded the backend cache size `100`), coupling submission flow to server internals and making history loading dependent on a magic constant.
- The goal is to have the frontend rely on the same history-fetching path used by the `/search` page, removing the implicit dependency on the backend's cache-warming endpoint.

### Description
- Removed the `SORTED_EVENTS_CACHE_SIZE` constant and the `triggerLastEntriesPrefetch` helper from `frontend/src/DescriptionEntry/api.js` so frontend code no longer encodes backend cache details.
- Stopped calling the prefetch helper from the submission flow by removing the import and the `triggerLastEntriesPrefetch()` call in `frontend/src/DescriptionEntry/hooks.js`, keeping post-submit behavior focused on navigation to `/search`.
- Cleaned up tests and mocks that referenced the removed helper by deleting the prefetch-related test block and removing `triggerLastEntriesPrefetch` mocks/imports from affected test files.
- Preserved and left intact the `submitEntry`, `fetchConfig`, and `updateConfig` APIs and the existing search/history fetching behavior; no changes to backend API surface were made.

### Testing
- Ran targeted unit tests with `npx jest frontend/tests/DescriptionEntry.api.test.js frontend/tests/DescriptionEntry.submission.test.jsx frontend/tests/DescriptionEntry.basic.test.jsx frontend/tests/ConfigPage.test.jsx`, which passed.
- Ran the submission-specific test `npx jest frontend/tests/DescriptionEntry.submission.test.jsx`, which passed.
- Ran static analysis with `npm run static-analysis` and the build with `npm run build`, both of which succeeded.
- Attempted the full test suite with `npm test -- --runInBand` but the run timed out in this environment (partial runs and the focused test suites used above passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cadfaf9958832ea0d3105b6ad7b92d)