### PR TITLE
Fix CI flakiness and static-analysis failures (scheduler test, Sync typing, split large file)

### DIFF
--- a/backend/src/generators/incremental_graph/database/synchronize.js
+++ b/backend/src/generators/incremental_graph/database/synchronize.js
@@ -12,7 +12,7 @@
 
 const gitstore = require('../../../gitstore');
 const path = require('path');
-const { transaction, configureRemoteForAllBranches, defaultBranch } = gitstore;
+const { configureRemoteForAllBranches, defaultBranch } = gitstore;
 const { listRemoteBranches } = gitstore.mergeHostBranches;
 const workingRepository = gitstore.workingRepository;
 const { parseRemoteHostnameBranch } = require('../../../hostname');
@@ -20,9 +20,14 @@ const {
     checkpointDatabase,
     CHECKPOINT_WORKING_PATH,
     DATABASE_SUBPATH,
-    LIVE_DATABASE_WORKING_PATH,
 } = require('./gitstore');
-const { FORMAT_MARKER, makeRootDatabase } = require('./root_database');
+const {
+    synchronizeResetToHostname,
+    InvalidSnapshotFormatError,
+    isInvalidSnapshotFormatError,
+    InvalidSnapshotReplicaError,
+    isInvalidSnapshotReplicaError,
+} = require('./synchronize_reset_snapshot');
 const { scanFromFilesystem } = require('./render');
 const { getRootDatabase } = require('./get_root_database');
 const {
@@ -30,61 +35,6 @@ const {
     SyncMergeAggregateError,
     isSyncMergeAggregateError,
 } = require('./sync_merge');
-
-/**
- * Thrown when the snapshot's `_meta/current_replica` file is missing a valid
- * replica name ("x" or "y"). This indicates a corrupted or incompatible snapshot.
- */
-class InvalidSnapshotReplicaError extends Error {
-    /**
-     * @param {unknown} value - The invalid value that was read.
-     * @param {string} filePath - Path to the file that contained the bad value.
-     */
-    constructor(value, filePath) {
-        const renderedValue = value === undefined ? 'undefined' : JSON.stringify(value);
-        super(
-            `Snapshot _meta/current_replica has invalid value: ${renderedValue}. Expected "x" or "y". File: ${filePath}`
-        );
-        this.name = 'InvalidSnapshotReplicaError';
-        this.value = value;
-        this.filePath = filePath;
-    }
-}
-
-/**
- * Thrown when the snapshot's `_meta/format` marker is missing or incompatible.
- */
-class InvalidSnapshotFormatError extends Error {
-    /**
-     * @param {unknown} value - The invalid value that was read.
-     * @param {string} filePath - Path to the file that contained the bad value.
-     */
-    constructor(value, filePath) {
-        const renderedValue = value === undefined ? 'undefined' : JSON.stringify(value);
-        super(
-            `Snapshot _meta/format has invalid value: ${renderedValue}. Expected ${JSON.stringify(FORMAT_MARKER)}. File: ${filePath}`
-        );
-        this.name = 'InvalidSnapshotFormatError';
-        this.value = value;
-        this.filePath = filePath;
-    }
-}
-
-/**
- * @param {unknown} object
- * @returns {object is InvalidSnapshotReplicaError}
- */
-function isInvalidSnapshotReplicaError(object) {
-    return object instanceof InvalidSnapshotReplicaError;
-}
-
-/**
- * @param {unknown} object
- * @returns {object is InvalidSnapshotFormatError}
- */
-function isInvalidSnapshotFormatError(object) {
-    return object instanceof InvalidSnapshotFormatError;
-}
 
 /** @typedef {import('../../../filesystem/checker').FileChecker} FileChecker */
 /** @typedef {import('../../../filesystem/mover').FileMover} FileMover */
@@ -119,192 +69,6 @@ function isInvalidSnapshotFormatError(object) {
  * @property {Interface} interface
  * @property {LevelDatabase} levelDatabase
  */
-
-/**
- * @param {Capabilities} capabilities
- * @param {string} filePath
- * @returns {Promise<unknown>}
- */
-async function readJsonFromFile(capabilities, filePath) {
-    const content = await capabilities.reader.readFileAsText(filePath);
-    return JSON.parse(content);
-}
-
-/**
- * @param {Capabilities} capabilities
- * @param {string} snapshotMetaDir
- * @returns {Promise<'x' | 'y'>}
- */
-async function validateResetSnapshotMetadata(capabilities, snapshotMetaDir) {
-    const formatFile = path.join(snapshotMetaDir, 'format');
-    if (!(await capabilities.checker.fileExists(formatFile))) {
-        throw new InvalidSnapshotFormatError(undefined, formatFile);
-    }
-
-    let parsedFormat;
-    try {
-        parsedFormat = await readJsonFromFile(capabilities, formatFile);
-    } catch {
-        const formatRaw = await capabilities.reader.readFileAsText(formatFile);
-        throw new InvalidSnapshotFormatError(formatRaw, formatFile);
-    }
-    if (parsedFormat !== FORMAT_MARKER) {
-        throw new InvalidSnapshotFormatError(parsedFormat, formatFile);
-    }
-
-    const currentReplicaFile = path.join(snapshotMetaDir, 'current_replica');
-    if (!(await capabilities.checker.fileExists(currentReplicaFile))) {
-        throw new InvalidSnapshotReplicaError(undefined, currentReplicaFile);
-    }
-
-    let parsedReplica;
-    try {
-        parsedReplica = await readJsonFromFile(capabilities, currentReplicaFile);
-    } catch {
-        const replicaRaw = await capabilities.reader.readFileAsText(currentReplicaFile);
-        throw new InvalidSnapshotReplicaError(replicaRaw, currentReplicaFile);
-    }
-    if (parsedReplica !== 'x' && parsedReplica !== 'y') {
-        throw new InvalidSnapshotReplicaError(parsedReplica, currentReplicaFile);
-    }
-
-    return parsedReplica;
-}
-
-/**
- * @param {Capabilities} capabilities
- * @param {RootDatabase} database
- * @param {string} workTree
- * @param {'x' | 'y'} snapshotReplica
- * @returns {Promise<void>}
- */
-async function importResetSnapshotIntoDatabase(capabilities, database, workTree, snapshotReplica) {
-    const snapshotRoot = path.join(workTree, DATABASE_SUBPATH);
-    const snapshotMetaDir = path.join(snapshotRoot, '_meta');
-    const rDir = path.join(snapshotRoot, 'r');
-
-    if (await capabilities.checker.directoryExists(rDir)) {
-        await scanFromFilesystem(
-            capabilities,
-            database,
-            rDir,
-            snapshotReplica
-        );
-    } else {
-        await database._rawDeleteSublevel(snapshotReplica);
-    }
-
-    await scanFromFilesystem(
-        capabilities,
-        database,
-        snapshotMetaDir,
-        '_meta'
-    );
-}
-
-/**
- * @param {Capabilities} capabilities
- * @param {string} workTree
- * @param {'x' | 'y'} snapshotReplica
- * @returns {Promise<void>}
- */
-async function replaceLiveDatabaseWithResetSnapshot(capabilities, workTree, snapshotReplica) {
-    const workingDirectory = capabilities.environment.workingDirectory();
-    const liveDatabasePath = path.join(
-        workingDirectory,
-        LIVE_DATABASE_WORKING_PATH
-    );
-    const resetWorkspace = await capabilities.creator.createTemporaryDirectory(
-        workingDirectory
-    );
-    const stagedDatabasePath = path.join(
-        resetWorkspace,
-        LIVE_DATABASE_WORKING_PATH
-    );
-    const backupDatabasePath = path.join(
-        resetWorkspace,
-        `${LIVE_DATABASE_WORKING_PATH}-backup`
-    );
-
-    /** @type {RootDatabase | undefined} */
-    let stagedDatabase;
-    let movedLiveToBackup = false;
-
-    try {
-        stagedDatabase = await makeRootDatabase(
-            capabilities,
-            stagedDatabasePath
-        );
-        await importResetSnapshotIntoDatabase(
-            capabilities,
-            stagedDatabase,
-            workTree,
-            snapshotReplica
-        );
-        await stagedDatabase.close();
-        stagedDatabase = undefined;
-
-        if (await capabilities.checker.directoryExists(liveDatabasePath)) {
-            await capabilities.mover.moveDirectory(
-                liveDatabasePath,
-                backupDatabasePath
-            );
-            movedLiveToBackup = true;
-        }
-
-        try {
-            await capabilities.mover.moveDirectory(
-                stagedDatabasePath,
-                liveDatabasePath
-            );
-        } catch (moveError) {
-            if (movedLiveToBackup) {
-                await capabilities.mover.moveDirectory(
-                    backupDatabasePath,
-                    liveDatabasePath
-                );
-            }
-            throw moveError;
-        }
-
-        if (movedLiveToBackup) {
-            await capabilities.deleter.deleteDirectory(backupDatabasePath);
-        }
-    } finally {
-        if (stagedDatabase !== undefined) {
-            await stagedDatabase.close();
-        }
-        if (await capabilities.checker.directoryExists(resetWorkspace)) {
-            await capabilities.deleter.deleteDirectory(resetWorkspace);
-        }
-    }
-}
-
-/**
- * @param {Capabilities} capabilities
- * @param {{ url: string }} remoteLocation
- * @returns {Promise<void>}
- */
-async function synchronizeResetToHostname(capabilities, remoteLocation) {
-    await transaction(
-        capabilities,
-        CHECKPOINT_WORKING_PATH,
-        remoteLocation,
-        async (store) => {
-            const workTree = await store.getWorkTree();
-            const snapshotMetaDir = path.join(workTree, DATABASE_SUBPATH, '_meta');
-            const snapshotReplica = await validateResetSnapshotMetadata(
-                capabilities,
-                snapshotMetaDir
-            );
-            await replaceLiveDatabaseWithResetSnapshot(
-                capabilities,
-                workTree,
-                snapshotReplica
-            );
-        }
-    );
-}
 
 /**
  * @param {Capabilities} capabilities

--- a/backend/src/generators/incremental_graph/database/synchronize_reset_snapshot.js
+++ b/backend/src/generators/incremental_graph/database/synchronize_reset_snapshot.js
@@ -1,0 +1,261 @@
+const path = require('path');
+const { transaction } = require('../../../gitstore');
+const {
+    CHECKPOINT_WORKING_PATH,
+    DATABASE_SUBPATH,
+    LIVE_DATABASE_WORKING_PATH,
+} = require('./gitstore');
+const { FORMAT_MARKER, makeRootDatabase } = require('./root_database');
+const { scanFromFilesystem } = require('./render');
+
+/** @typedef {import('./synchronize').Capabilities} Capabilities */
+/** @typedef {import('./root_database').RootDatabase} RootDatabase */
+
+/**
+ * Thrown when the snapshot's `_meta/current_replica` file is missing a valid
+ * replica name ("x" or "y"). This indicates a corrupted or incompatible snapshot.
+ */
+class InvalidSnapshotReplicaError extends Error {
+    /**
+     * @param {unknown} value - The invalid value that was read.
+     * @param {string} filePath - Path to the file that contained the bad value.
+     */
+    constructor(value, filePath) {
+        const renderedValue = value === undefined ? 'undefined' : JSON.stringify(value);
+        super(
+            `Snapshot _meta/current_replica has invalid value: ${renderedValue}. Expected "x" or "y". File: ${filePath}`
+        );
+        this.name = 'InvalidSnapshotReplicaError';
+        this.value = value;
+        this.filePath = filePath;
+    }
+}
+
+/**
+ * Thrown when the snapshot's `_meta/format` marker is missing or incompatible.
+ */
+class InvalidSnapshotFormatError extends Error {
+    /**
+     * @param {unknown} value - The invalid value that was read.
+     * @param {string} filePath - Path to the file that contained the bad value.
+     */
+    constructor(value, filePath) {
+        const renderedValue = value === undefined ? 'undefined' : JSON.stringify(value);
+        super(
+            `Snapshot _meta/format has invalid value: ${renderedValue}. Expected ${JSON.stringify(FORMAT_MARKER)}. File: ${filePath}`
+        );
+        this.name = 'InvalidSnapshotFormatError';
+        this.value = value;
+        this.filePath = filePath;
+    }
+}
+
+/**
+ * @param {unknown} object
+ * @returns {object is InvalidSnapshotReplicaError}
+ */
+function isInvalidSnapshotReplicaError(object) {
+    return object instanceof InvalidSnapshotReplicaError;
+}
+
+/**
+ * @param {unknown} object
+ * @returns {object is InvalidSnapshotFormatError}
+ */
+function isInvalidSnapshotFormatError(object) {
+    return object instanceof InvalidSnapshotFormatError;
+}
+
+/**
+ * @param {Capabilities} capabilities
+ * @param {string} filePath
+ * @returns {Promise<unknown>}
+ */
+async function readJsonFromFile(capabilities, filePath) {
+    const content = await capabilities.reader.readFileAsText(filePath);
+    return JSON.parse(content);
+}
+
+/**
+ * @param {Capabilities} capabilities
+ * @param {string} snapshotMetaDir
+ * @returns {Promise<'x' | 'y'>}
+ */
+async function validateResetSnapshotMetadata(capabilities, snapshotMetaDir) {
+    const formatFile = path.join(snapshotMetaDir, 'format');
+    if (!(await capabilities.checker.fileExists(formatFile))) {
+        throw new InvalidSnapshotFormatError(undefined, formatFile);
+    }
+
+    let parsedFormat;
+    try {
+        parsedFormat = await readJsonFromFile(capabilities, formatFile);
+    } catch {
+        const formatRaw = await capabilities.reader.readFileAsText(formatFile);
+        throw new InvalidSnapshotFormatError(formatRaw, formatFile);
+    }
+    if (parsedFormat !== FORMAT_MARKER) {
+        throw new InvalidSnapshotFormatError(parsedFormat, formatFile);
+    }
+
+    const currentReplicaFile = path.join(snapshotMetaDir, 'current_replica');
+    if (!(await capabilities.checker.fileExists(currentReplicaFile))) {
+        throw new InvalidSnapshotReplicaError(undefined, currentReplicaFile);
+    }
+
+    let parsedReplica;
+    try {
+        parsedReplica = await readJsonFromFile(capabilities, currentReplicaFile);
+    } catch {
+        const replicaRaw = await capabilities.reader.readFileAsText(currentReplicaFile);
+        throw new InvalidSnapshotReplicaError(replicaRaw, currentReplicaFile);
+    }
+    if (parsedReplica !== 'x' && parsedReplica !== 'y') {
+        throw new InvalidSnapshotReplicaError(parsedReplica, currentReplicaFile);
+    }
+
+    return parsedReplica;
+}
+
+/**
+ * @param {Capabilities} capabilities
+ * @param {RootDatabase} database
+ * @param {string} workTree
+ * @param {'x' | 'y'} snapshotReplica
+ * @returns {Promise<void>}
+ */
+async function importResetSnapshotIntoDatabase(capabilities, database, workTree, snapshotReplica) {
+    const snapshotRoot = path.join(workTree, DATABASE_SUBPATH);
+    const snapshotMetaDir = path.join(snapshotRoot, '_meta');
+    const rDir = path.join(snapshotRoot, 'r');
+
+    if (await capabilities.checker.directoryExists(rDir)) {
+        await scanFromFilesystem(
+            capabilities,
+            database,
+            rDir,
+            snapshotReplica
+        );
+    } else {
+        await database._rawDeleteSublevel(snapshotReplica);
+    }
+
+    await scanFromFilesystem(
+        capabilities,
+        database,
+        snapshotMetaDir,
+        '_meta'
+    );
+}
+
+/**
+ * @param {Capabilities} capabilities
+ * @param {string} workTree
+ * @param {'x' | 'y'} snapshotReplica
+ * @returns {Promise<void>}
+ */
+async function replaceLiveDatabaseWithResetSnapshot(capabilities, workTree, snapshotReplica) {
+    const workingDirectory = capabilities.environment.workingDirectory();
+    const liveDatabasePath = path.join(
+        workingDirectory,
+        LIVE_DATABASE_WORKING_PATH
+    );
+    const resetWorkspace = await capabilities.creator.createTemporaryDirectory(
+        workingDirectory
+    );
+    const stagedDatabasePath = path.join(
+        resetWorkspace,
+        LIVE_DATABASE_WORKING_PATH
+    );
+    const backupDatabasePath = path.join(
+        resetWorkspace,
+        `${LIVE_DATABASE_WORKING_PATH}-backup`
+    );
+
+    /** @type {RootDatabase | undefined} */
+    let stagedDatabase;
+    let movedLiveToBackup = false;
+
+    try {
+        stagedDatabase = await makeRootDatabase(
+            capabilities,
+            stagedDatabasePath
+        );
+        await importResetSnapshotIntoDatabase(
+            capabilities,
+            stagedDatabase,
+            workTree,
+            snapshotReplica
+        );
+        await stagedDatabase.close();
+        stagedDatabase = undefined;
+
+        if (await capabilities.checker.directoryExists(liveDatabasePath)) {
+            await capabilities.mover.moveDirectory(
+                liveDatabasePath,
+                backupDatabasePath
+            );
+            movedLiveToBackup = true;
+        }
+
+        try {
+            await capabilities.mover.moveDirectory(
+                stagedDatabasePath,
+                liveDatabasePath
+            );
+        } catch (moveError) {
+            if (movedLiveToBackup) {
+                await capabilities.mover.moveDirectory(
+                    backupDatabasePath,
+                    liveDatabasePath
+                );
+            }
+            throw moveError;
+        }
+
+        if (movedLiveToBackup) {
+            await capabilities.deleter.deleteDirectory(backupDatabasePath);
+        }
+    } finally {
+        if (stagedDatabase !== undefined) {
+            await stagedDatabase.close();
+        }
+        if (await capabilities.checker.directoryExists(resetWorkspace)) {
+            await capabilities.deleter.deleteDirectory(resetWorkspace);
+        }
+    }
+}
+
+/**
+ * @param {Capabilities} capabilities
+ * @param {{ url: string }} remoteLocation
+ * @returns {Promise<void>}
+ */
+async function synchronizeResetToHostname(capabilities, remoteLocation) {
+    await transaction(
+        capabilities,
+        CHECKPOINT_WORKING_PATH,
+        remoteLocation,
+        async (store) => {
+            const workTree = await store.getWorkTree();
+            const snapshotMetaDir = path.join(workTree, DATABASE_SUBPATH, '_meta');
+            const snapshotReplica = await validateResetSnapshotMetadata(
+                capabilities,
+                snapshotMetaDir
+            );
+            await replaceLiveDatabaseWithResetSnapshot(
+                capabilities,
+                workTree,
+                snapshotReplica
+            );
+        }
+    );
+}
+
+module.exports = {
+    synchronizeResetToHostname,
+    InvalidSnapshotFormatError,
+    isInvalidSnapshotFormatError,
+    InvalidSnapshotReplicaError,
+    isInvalidSnapshotReplicaError,
+};

--- a/backend/tests/scheduler_stories.test.js
+++ b/backend/tests/scheduler_stories.test.js
@@ -1430,20 +1430,22 @@ describe("scheduler stories", () => {
         stubEnvironment(capabilities);
         stubLogger(capabilities);
 
-        // Test scheduler behavior with first-time initialization
-        const retryDelay = fromMilliseconds(1000);
-        const registrations = [
-            ["test-task", "0 * * * *", jest.fn(), retryDelay]
-        ];
+        try {
+            // Test scheduler behavior with first-time initialization
+            const retryDelay = fromMilliseconds(1000);
+            const registrations = [
+                ["test-task", "0 * * * *", jest.fn(), retryDelay]
+            ];
 
-        // This should succeed as first-time initialization
-        await capabilities.scheduler.initialize(registrations);
+            // This should succeed as first-time initialization
+            await capabilities.scheduler.initialize(registrations);
 
-        // An out-of transaction operation to ensure that it doesn't mess up the scheduler.
-        await capabilities.state.transaction(() => 0);
-
-        await capabilities.scheduler.stop();
+            // An out-of transaction operation to ensure that it doesn't mess up the scheduler.
+            await capabilities.state.transaction(() => 0);
+        } finally {
+            await capabilities.scheduler.stop();
+        }
 
         expect(true).toBe(true); // Dummy assertion to mark test as passed
-    });
+    }, 15000);
 });

--- a/frontend/src/Sync/api.js
+++ b/frontend/src/Sync/api.js
@@ -101,6 +101,7 @@ function toSyncResult(data) {
  * @returns {Promise<PostSyncResult>}
  */
 async function pollRunningSync(currentData, onProgress) {
+    /** @type {SyncResponse | null} */
     let data = currentData;
 
     if (data?.status === "running" && data.steps) {


### PR DESCRIPTION
### Motivation
- Reduce flaky CI failures caused by a scheduler integration test that sometimes timed out under load. 
- Resolve a TypeScript/static-analysis failure triggered by an unexpected `null` from JSON parsing in sync polling code. 
- Satisfy the repository lint rule for maximum lines per file by extracting a large helper into a focused module. 

### Description
- Hardened the scheduler test `should tolerate parallel transactions on real storage without a safe delay` by wrapping initialization/use in a `try/finally` to always call `await capabilities.scheduler.stop()` and increased that test's timeout to `15000` ms (`backend/tests/scheduler_stories.test.js`).
- Fixed JSDoc/typing in `frontend/src/Sync/api.js` by allowing the polling state to be `null` with `/** @type {SyncResponse | null} */ let data = currentData;`, preventing `tsc` from failing when `response.json()` parsing returns `null` or throws.
- Split the large synchronization routine by extracting reset-snapshot validation/import/replace logic (including `InvalidSnapshotFormatError`, `InvalidSnapshotReplicaError`, and guards) into a new module `backend/src/generators/incremental_graph/database/synchronize_reset_snapshot.js` and updated `backend/src/generators/incremental_graph/database/synchronize.js` to import and re-export the errors/guards so external behavior remains unchanged.

### Testing
- Ran `npm install` successfully to populate dependencies. 
- Ran the focused scheduler test with `npx jest backend/tests/scheduler_stories.test.js --runInBand --testNamePattern "without a safe delay"` which passed. 
- Ran static analysis with `npm run static-analysis` which passed after the JSDoc and refactor fixes. 
- Built the frontend with `npm run build` which completed successfully. 
- Ran the full test suite with `npm test` which passed (Jest emitted a non-fatal worker-exit warning in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d843258050832e878490265935dad7)