### PR TITLE
Improve sync diagnostics for host snapshot format and replica metadata errors

### DIFF
--- a/backend/src/generators/incremental_graph/database/synchronize.js
+++ b/backend/src/generators/incremental_graph/database/synchronize.js
@@ -30,6 +30,7 @@ const {
 } = require('./synchronize_reset_snapshot');
 const { scanFromFilesystem } = require('./render');
 const { getRootDatabase } = require('./get_root_database');
+const { FORMAT_MARKER } = require('./root_database');
 const {
     mergeHostIntoReplica,
     SyncMergeAggregateError,
@@ -51,6 +52,58 @@ const {
 /** @typedef {import('../../../level_database').LevelDatabase} LevelDatabase */
 /** @typedef {import('../../../generators/interface').Interface} Interface */
 /** @typedef {import('./root_database').RootDatabase} RootDatabase */
+
+class IncompatibleHostSnapshotFormatError extends Error {
+    /**
+     * @param {string} hostname
+     * @param {unknown} value
+     * @param {string} formatFile
+     * @param {'missing' | 'invalid-json' | 'invalid-value'} reason
+     */
+    constructor(hostname, value, formatFile, reason) {
+        const renderedValue = value === undefined ? 'undefined' : JSON.stringify(value);
+        let details;
+        if (reason === 'missing') {
+            details = `missing _meta/format. Expected ${JSON.stringify(FORMAT_MARKER)}`;
+        } else if (reason === 'invalid-json') {
+            details = `invalid JSON in _meta/format: ${renderedValue}. Expected JSON string ${JSON.stringify(FORMAT_MARKER)}`;
+        } else {
+            details = `incompatible format ${renderedValue}. Expected ${JSON.stringify(FORMAT_MARKER)}`;
+        }
+        super(`Cannot merge host '${hostname}': ${details}. File: ${formatFile}`);
+        this.name = 'IncompatibleHostSnapshotFormatError';
+        this.hostname = hostname;
+        this.value = value;
+        this.formatFile = formatFile;
+        this.reason = reason;
+    }
+}
+
+/**
+ * @param {Capabilities} capabilities
+ * @param {string} hostname
+ * @param {string} tmpDir
+ * @returns {Promise<void>}
+ */
+async function validateHostSnapshotFormat(capabilities, hostname, tmpDir) {
+    const formatFile = path.join(tmpDir, DATABASE_SUBPATH, '_meta', 'format');
+    if (!(await capabilities.checker.fileExists(formatFile))) {
+        throw new IncompatibleHostSnapshotFormatError(hostname, undefined, formatFile, 'missing');
+    }
+
+    let parsedFormat;
+    try {
+        const formatRaw = await capabilities.reader.readFileAsText(formatFile);
+        parsedFormat = JSON.parse(formatRaw);
+    } catch {
+        const formatRaw = await capabilities.reader.readFileAsText(formatFile);
+        throw new IncompatibleHostSnapshotFormatError(hostname, formatRaw, formatFile, 'invalid-json');
+    }
+
+    if (parsedFormat !== FORMAT_MARKER) {
+        throw new IncompatibleHostSnapshotFormatError(hostname, parsedFormat, formatFile, 'invalid-value');
+    }
+}
 
 /**
  * @typedef {object} Capabilities
@@ -126,6 +179,8 @@ async function mergeRemoteHostBranches(capabilities, rootDatabase) {
                 'worktree', 'add', '--detach', tmpDir, remoteBranch
             );
             worktreeAdded = true;
+
+            await validateHostSnapshotFormat(capabilities, hostname, tmpDir);
 
             const remoteRDir = path.join(tmpDir, DATABASE_SUBPATH, 'r');
             await scanFromFilesystem(

--- a/backend/src/generators/incremental_graph/database/synchronize_reset_snapshot.js
+++ b/backend/src/generators/incremental_graph/database/synchronize_reset_snapshot.js
@@ -19,15 +19,23 @@ class InvalidSnapshotReplicaError extends Error {
     /**
      * @param {unknown} value - The invalid value that was read.
      * @param {string} filePath - Path to the file that contained the bad value.
+     * @param {'missing' | 'invalid-json' | 'invalid-value'} reason
      */
-    constructor(value, filePath) {
+    constructor(value, filePath, reason) {
         const renderedValue = value === undefined ? 'undefined' : JSON.stringify(value);
-        super(
-            `Snapshot _meta/current_replica has invalid value: ${renderedValue}. Expected "x" or "y". File: ${filePath}`
-        );
+        let message;
+        if (reason === 'missing') {
+            message = `Snapshot _meta/current_replica is missing. Expected a JSON string: "x" or "y". File: ${filePath}`;
+        } else if (reason === 'invalid-json') {
+            message = `Snapshot _meta/current_replica is not valid JSON: ${renderedValue}. Expected a JSON string: "x" or "y". File: ${filePath}`;
+        } else {
+            message = `Snapshot _meta/current_replica has invalid parsed value: ${renderedValue}. Expected "x" or "y". File: ${filePath}`;
+        }
+        super(message);
         this.name = 'InvalidSnapshotReplicaError';
         this.value = value;
         this.filePath = filePath;
+        this.reason = reason;
     }
 }
 
@@ -38,15 +46,23 @@ class InvalidSnapshotFormatError extends Error {
     /**
      * @param {unknown} value - The invalid value that was read.
      * @param {string} filePath - Path to the file that contained the bad value.
+     * @param {'missing' | 'invalid-json' | 'invalid-value'} reason
      */
-    constructor(value, filePath) {
+    constructor(value, filePath, reason) {
         const renderedValue = value === undefined ? 'undefined' : JSON.stringify(value);
-        super(
-            `Snapshot _meta/format has invalid value: ${renderedValue}. Expected ${JSON.stringify(FORMAT_MARKER)}. File: ${filePath}`
-        );
+        let message;
+        if (reason === 'missing') {
+            message = `Snapshot _meta/format is missing. Expected ${JSON.stringify(FORMAT_MARKER)}. File: ${filePath}`;
+        } else if (reason === 'invalid-json') {
+            message = `Snapshot _meta/format is not valid JSON: ${renderedValue}. Expected JSON string ${JSON.stringify(FORMAT_MARKER)}. File: ${filePath}`;
+        } else {
+            message = `Snapshot _meta/format has invalid parsed value: ${renderedValue}. Expected ${JSON.stringify(FORMAT_MARKER)}. File: ${filePath}`;
+        }
+        super(message);
         this.name = 'InvalidSnapshotFormatError';
         this.value = value;
         this.filePath = filePath;
+        this.reason = reason;
     }
 }
 
@@ -84,7 +100,7 @@ async function readJsonFromFile(capabilities, filePath) {
 async function validateResetSnapshotMetadata(capabilities, snapshotMetaDir) {
     const formatFile = path.join(snapshotMetaDir, 'format');
     if (!(await capabilities.checker.fileExists(formatFile))) {
-        throw new InvalidSnapshotFormatError(undefined, formatFile);
+        throw new InvalidSnapshotFormatError(undefined, formatFile, 'missing');
     }
 
     let parsedFormat;
@@ -92,15 +108,15 @@ async function validateResetSnapshotMetadata(capabilities, snapshotMetaDir) {
         parsedFormat = await readJsonFromFile(capabilities, formatFile);
     } catch {
         const formatRaw = await capabilities.reader.readFileAsText(formatFile);
-        throw new InvalidSnapshotFormatError(formatRaw, formatFile);
+        throw new InvalidSnapshotFormatError(formatRaw, formatFile, 'invalid-json');
     }
     if (parsedFormat !== FORMAT_MARKER) {
-        throw new InvalidSnapshotFormatError(parsedFormat, formatFile);
+        throw new InvalidSnapshotFormatError(parsedFormat, formatFile, 'invalid-value');
     }
 
     const currentReplicaFile = path.join(snapshotMetaDir, 'current_replica');
     if (!(await capabilities.checker.fileExists(currentReplicaFile))) {
-        throw new InvalidSnapshotReplicaError(undefined, currentReplicaFile);
+        throw new InvalidSnapshotReplicaError(undefined, currentReplicaFile, 'missing');
     }
 
     let parsedReplica;
@@ -108,10 +124,10 @@ async function validateResetSnapshotMetadata(capabilities, snapshotMetaDir) {
         parsedReplica = await readJsonFromFile(capabilities, currentReplicaFile);
     } catch {
         const replicaRaw = await capabilities.reader.readFileAsText(currentReplicaFile);
-        throw new InvalidSnapshotReplicaError(replicaRaw, currentReplicaFile);
+        throw new InvalidSnapshotReplicaError(replicaRaw, currentReplicaFile, 'invalid-json');
     }
     if (parsedReplica !== 'x' && parsedReplica !== 'y') {
-        throw new InvalidSnapshotReplicaError(parsedReplica, currentReplicaFile);
+        throw new InvalidSnapshotReplicaError(parsedReplica, currentReplicaFile, 'invalid-value');
     }
 
     return parsedReplica;

--- a/backend/tests/database_synchronize.test.js
+++ b/backend/tests/database_synchronize.test.js
@@ -315,6 +315,57 @@ describe("synchronizeNoLock", () => {
         }
     });
 
+    test("reports host format mismatch with explicit hostname when remote host uses legacy format", async () => {
+        const capabilities = getTestCapabilities();
+        const bobNodeArgs = '{"head":"event","args":["bob"]}';
+        const bobInputsKey = `!x!!inputs!${bobNodeArgs}`;
+        const bobTimestampsKey = `!x!!timestamps!${bobNodeArgs}`;
+
+        await stubIncrementalDatabaseRemoteBranches(capabilities, [
+            {
+                hostname: "test-host",
+                entries: [["!_meta!format", "xy-v2"]],
+            },
+            {
+                hostname: "bob",
+                entries: [
+                    ["!_meta!format", "xy-v2"],
+                    [`!x!!values!${bobNodeArgs}`, { source: "bob" }],
+                    [bobInputsKey, { inputs: [], inputCounters: [] }],
+                    [bobTimestampsKey, { createdAt: "2024-01-01T00:00:00.000Z", modifiedAt: "2024-01-01T00:00:00.000Z" }],
+                ],
+            },
+            {
+                hostname: "prismo",
+                entries: [
+                    ["!_meta!format", "xy-v1"],
+                ],
+            },
+        ]);
+
+        let error;
+        try {
+            await synchronizeNoLock(capabilities);
+        } catch (caught) {
+            error = caught;
+        }
+
+        expect(isSyncMergeAggregateError(error)).toBe(true);
+        expect(error.message).toContain("prismo");
+        expect(error.message).toContain('incompatible format "xy-v1"');
+        expect(error.message).not.toContain("input directory does not exist");
+
+        const reopened = await getRootDatabase(capabilities);
+        try {
+            const replica = reopened.currentReplicaName();
+            const activeBobKey = `!${replica}!!values!${bobNodeArgs}`;
+            const entries = await collectRawEntries(reopened);
+            expect(entries.get(activeBobKey)).toEqual({ source: "bob" });
+        } finally {
+            await reopened.close();
+        }
+    });
+
     test("throws InvalidSnapshotFormatError when snapshot has incompatible _meta/format", async () => {
         const capabilities = getTestCapabilities();
         const branch = `${capabilities.environment.hostname()}-main`;
@@ -403,7 +454,7 @@ describe("synchronizeNoLock", () => {
         }
     });
 
-    test("throws InvalidSnapshotReplicaError with unquoted undefined when _meta/current_replica is missing", async () => {
+    test("throws InvalidSnapshotReplicaError that clearly reports a missing _meta/current_replica", async () => {
         const capabilities = getTestCapabilities();
         const branch = `${capabilities.environment.hostname()}-main`;
         const remotePath = capabilities.environment.generatorsRepository();
@@ -439,8 +490,7 @@ describe("synchronizeNoLock", () => {
                 error = caught;
             }
             expect(isInvalidSnapshotReplicaError(error)).toBe(true);
-            expect(error.message).toContain('invalid value: undefined');
-            expect(error.message).not.toContain('"undefined"');
+            expect(error.message).toContain('Snapshot _meta/current_replica is missing.');
         } finally {
             await capabilities.deleter.deleteDirectory(workTree);
         }
@@ -499,7 +549,7 @@ describe("synchronizeNoLock", () => {
                 secondError = caught;
             }
             expect(isInvalidSnapshotFormatError(secondError)).toBe(true);
-            expect(secondError.message).toContain('Snapshot _meta/format has invalid value: "xy-v1".');
+            expect(secondError.message).toContain('Snapshot _meta/format has invalid parsed value: "xy-v1".');
             expect(await capabilities.checker.directoryExists(liveDbPath)).toBeNull();
         } finally {
             await capabilities.deleter.deleteDirectory(workTree);


### PR DESCRIPTION
### Motivation
- Remote host merges were failing with a misleading "input directory does not exist" error when the real cause was an incompatible snapshot format (e.g. legacy `xy-v1`), and the message did not name the host.  This obscures root causes during sync. 
- Replica/format parse errors produced ambiguous messages (e.g. showing the raw failing value in a way that looked like an allowed value), making diagnostics harder.

### Description
- Add per-host snapshot format validation before scanning `rendered/r`, and surface a clear host-specific error (`IncompatibleHostSnapshotFormatError`) for missing, non-JSON, or incompatible `_meta/format` cases; validate via `validateHostSnapshotFormat`. (`backend/src/generators/incremental_graph/database/synchronize.js`)
- Improve reset-snapshot metadata diagnostics by extending `InvalidSnapshotFormatError` and `InvalidSnapshotReplicaError` to accept a `reason` and render distinct messages for `missing`, `invalid-json`, and `invalid-value` cases. (`backend/src/generators/incremental_graph/database/synchronize_reset_snapshot.js`)
- Update synchronization tests to cover host-format mismatch reporting with explicit hostname and to assert clearer messaging for missing/invalid `_meta/format` and `_meta/current_replica`. (`backend/tests/database_synchronize.test.js`)

### Testing
- Ran `npm install` successfully to set up dependencies.
- Ran the focused test suite with `npx jest backend/tests/database_synchronize.test.js` which passed (`19 passed`).
- Ran static analysis with `npm run static-analysis` which completed successfully.
- Built the frontend with `npm run build` which completed successfully.
- Ran full `npm test` which failed due to unrelated existing timeouts in `from_input.*` tests in this environment; failures are unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d89511ba40832e855e2a088d9f4420)