### PR TITLE
Fix Termux CI npm install by switching to Node LTS

### DIFF
--- a/scripts/termux-ci-test.sh
+++ b/scripts/termux-ci-test.sh
@@ -8,9 +8,14 @@ cd -- "${0%/*}"/..
 
 apt-get update -qq
 apt-get -qq -y -o Dpkg::Options::="--force-confnew" upgrade
-apt-get install -q -y coreutils file nodejs git
+# Use nodejs-lts instead of nodejs (current in Termux is Node 25), because
+# npm bundled with the cutting-edge channel intermittently fails to expose
+# transitive lifecycle binaries (e.g. node-gyp-build) during npm ci.
+apt-get install -q -y coreutils file nodejs-lts git
 uname -a
 id -a
+node --version
+npm --version
 
 npm ci
 npm run build


### PR DESCRIPTION
### Motivation
- The Termux CI container intermittently fails during `npm ci` with lifecycle binaries (e.g. `node-gyp-build`) not being found when installing the cutting‑edge `nodejs` package, so the CI bootstrap should use a more stable runtime.

### Description
- Update `scripts/termux-ci-test.sh` to install `nodejs-lts` instead of `nodejs` and emit `node --version` and `npm --version` for easier debugging of future Termux runs.

### Testing
- Ran `npm install` locally which completed successfully. 
- Ran `npm run static-analysis` which passed. 
- Ran `npm run build` which passed. 
- Ran `npm test` which failed in this environment due to unrelated pre-existing module resolution issues inside `node_modules` and not caused by this script change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2e35b60ec832e87619ad554dba70b)