### PR TITLE
Fix pull-cycle watermark advancement and add format-aware PCM window cap

### DIFF
--- a/backend/src/live_diary/last_transcribed_range.js
+++ b/backend/src/live_diary/last_transcribed_range.js
@@ -1,0 +1,34 @@
+/**
+ * @typedef {import('./session_state').LastTranscribedRange} LastTranscribedRange
+ * @typedef {import('../temporary/database/types').LiveDiaryFragmentIndexEntry} LiveDiaryFragmentIndexEntry
+ */
+
+/**
+ * Compute the last-transcribed-range metadata from the current pull's fragments.
+ * Clamps firstStartMs to transcribedUntilMs so that already-transcribed audio
+ * is not counted in the new region (which would inflate the overlap estimate).
+ * Returns null if there are no new fragments in the processable range.
+ *
+ * @param {LiveDiaryFragmentIndexEntry[]} candidates
+ * @param {number} transcribedUntilMs
+ * @param {number} processableEndMs
+ * @returns {LastTranscribedRange | null}
+ */
+function computeNewLastRange(candidates, transcribedUntilMs, processableEndMs) {
+    const newFragments = candidates.filter(
+        (f) => f.startMs < processableEndMs && f.endMs > transcribedUntilMs
+    );
+    if (newFragments.length === 0) return null;
+    const firstNewFrag = newFragments[0];
+    const lastNewFrag = newFragments[newFragments.length - 1];
+    if (firstNewFrag === undefined || lastNewFrag === undefined) return null;
+    return {
+        firstStartMs: Math.max(firstNewFrag.startMs, transcribedUntilMs),
+        lastEndMs: Math.min(lastNewFrag.endMs, processableEndMs),
+        fragmentCount: newFragments.length,
+    };
+}
+
+module.exports = {
+    computeNewLastRange,
+};

--- a/backend/src/live_diary/pull_cycle.js
+++ b/backend/src/live_diary/pull_cycle.js
@@ -25,7 +25,6 @@ const {
     writeKnownGaps,
 } = require("./session_state");
 const { buildWav } = require("./wav_utils");
-const { planWindow } = require("./planner");
 const { assemblePcm } = require("./assembler");
 const { scanGaps } = require("./gap_tracker");
 const {
@@ -38,13 +37,14 @@ const {
     deduplicateQuestions,
 } = require("./text_processing");
 const { transcribeBuffer, loadFragmentPcm } = require("./pull_helpers");
+const { planWindowWithCaps } = require("./pull_window_planning");
+const { computeNewLastRange } = require("./last_transcribed_range");
 
 /** @typedef {import('../temporary').Temporary} Temporary */
 /** @typedef {import('../logger').Logger} Logger */
 /** @typedef {import('../ai/transcription').AITranscription} AITranscription */
 /** @typedef {import('../ai/diary_questions').AIDiaryQuestions} AIDiaryQuestions */
 /** @typedef {import('../ai/transcript_recombination').AITranscriptRecombination} AITranscriptRecombination */
-/** @typedef {import('./session_state').LastTranscribedRange} LastTranscribedRange */
 /** @typedef {import('../filesystem/creator').FileCreator} FileCreator */
 /** @typedef {import('../filesystem/writer').FileWriter} FileWriter */
 /** @typedef {import('../filesystem/reader').FileReader} FileReader */
@@ -141,11 +141,24 @@ async function _runPullCycle(capabilities, sessionId, deadlineMs, nowMs, stepTim
         ? lastRange.lastEndMs - lastRange.firstStartMs
         : null;
 
-    const { windowStartMs, windowEndMs, effectiveOverlapMs } = planWindow({
+    const windowPlan = planWindowWithCaps({
         transcribedUntilMs,
         processableEndMs,
         prevNewDurationMs,
+        candidates,
     });
+    if (windowPlan === null) {
+        return { status: "no_candidates" };
+    }
+    const {
+        windowStartMs,
+        plannedWindowEndMs,
+        committedThroughMs,
+        effectiveOverlapMs,
+        sampleRateHz,
+        channels,
+        bitDepth,
+    } = windowPlan;
 
     capabilities.logger.logDebug(
         {
@@ -153,30 +166,34 @@ async function _runPullCycle(capabilities, sessionId, deadlineMs, nowMs, stepTim
             transcribedUntilMs,
             processableEndMs,
             windowStartMs,
-            windowEndMs,
+            plannedWindowEndMs,
+            committedThroughMs,
             effectiveOverlapMs,
             hasDegradedGap: gapScan.hasDegradedGap,
         },
         "Pull cycle: window planned"
     );
 
-    // 6. Assemble PCM for [windowStartMs, windowEndMs].
-    const firstCandidate = candidates[0];
-    if (firstCandidate === undefined) {
-        // Unreachable: candidates.length > 0 was checked above.
-        return { status: "no_candidates" };
+    if (committedThroughMs <= transcribedUntilMs) {
+        capabilities.logger.logWarning(
+            { sessionId, transcribedUntilMs, windowStartMs, plannedWindowEndMs, committedThroughMs },
+            "Pull cycle: capped window does not include new audio; skipping cycle"
+        );
+        await writeKnownGaps(temporary, sessionId, gapScan.updatedGaps);
+        return { status: "degraded_transcription" };
     }
-    const { sampleRateHz, channels, bitDepth } = firstCandidate;
+
+    // 6. Assemble PCM for [windowStartMs, committedThroughMs].
 
     /** @type {import('./assembler').AssemblerFragment[]} */
     const assemblerFragments = [];
     let hasMissingBinaryInWindow = false;
     for (const frag of allFragments) {
-        if (frag.endMs <= windowStartMs || frag.startMs >= windowEndMs) continue;
+        if (frag.endMs <= windowStartMs || frag.startMs >= committedThroughMs) continue;
         const pcm = await loadFragmentPcm(temporary, sessionId, frag.sequence);
         if (pcm === null) {
             hasMissingBinaryInWindow = true;
-            capabilities.logger.logWarning({ sessionId, sequence: frag.sequence, fragmentStartMs: frag.startMs, fragmentEndMs: frag.endMs, windowStartMs, windowEndMs }, "Pull cycle: binary PCM missing for fragment in planned window — blocking watermark advance for this cycle");
+            capabilities.logger.logWarning({ sessionId, sequence: frag.sequence, fragmentStartMs: frag.startMs, fragmentEndMs: frag.endMs, windowStartMs, committedThroughMs }, "Pull cycle: binary PCM missing for fragment in planned window — blocking watermark advance for this cycle");
             continue;
         }
         assemblerFragments.push({ ...frag, pcm });
@@ -192,7 +209,7 @@ async function _runPullCycle(capabilities, sessionId, deadlineMs, nowMs, stepTim
         combinedPcm = assemblePcm({
             fragments: assemblerFragments,
             windowStartMs,
-            windowEndMs,
+            windowEndMs: committedThroughMs,
             sampleRateHz,
             channels,
             bitDepth,
@@ -236,12 +253,12 @@ async function _runPullCycle(capabilities, sessionId, deadlineMs, nowMs, stepTim
     }
 
     capabilities.logger.logDebug(
-        { sessionId, transcriptLength: newWindowTranscript.length, windowStartMs, windowEndMs },
+        { sessionId, transcriptLength: newWindowTranscript.length, windowStartMs, committedThroughMs },
         "Pull cycle: transcription result"
     );
 
     // Compute the new last-range metadata (clamped to the actual new region).
-    const newLastRange = _computeNewLastRange(candidates, transcribedUntilMs, processableEndMs);
+    const newLastRange = computeNewLastRange(candidates, transcribedUntilMs, committedThroughMs);
 
     if (!newWindowTranscript) {
         // Silent window — commit watermark + gaps but preserve transcript state.
@@ -249,7 +266,7 @@ async function _runPullCycle(capabilities, sessionId, deadlineMs, nowMs, stepTim
         const existingRunning = await readStringField(temporary, sessionId, RUNNING_TRANSCRIPT_KEY);
         const existingWordCount = await readStringField(temporary, sessionId, WORDS_SINCE_LAST_QUESTION_KEY);
         await commitPullState(temporary, sessionId, {
-            transcribedUntilMs: processableEndMs,
+            transcribedUntilMs: committedThroughMs,
             knownGaps: gapScan.updatedGaps,
             lastRange: newLastRange,
             lastWindowTranscript: existingLastWindowTranscript,
@@ -307,12 +324,11 @@ async function _runPullCycle(capabilities, sessionId, deadlineMs, nowMs, stepTim
             ? updatedRunningTranscript.slice(runningTranscript.length)
             : merged;
     const fragmentWordCount = newTranscriptPortion.split(/\s+/).filter(Boolean).length;
-    const storedWordCount = await readStringField(temporary, sessionId, WORDS_SINCE_LAST_QUESTION_KEY);
-    const cumulativeWordCount = (parseInt(storedWordCount, 10) || 0) + fragmentWordCount;
+    const cumulativeWordCount = (parseInt(await readStringField(temporary, sessionId, WORDS_SINCE_LAST_QUESTION_KEY), 10) || 0) + fragmentWordCount;
 
     /** @type {import('./session_state').PullStateCommit} */
     const baseBundle = {
-        transcribedUntilMs: processableEndMs,
+        transcribedUntilMs: committedThroughMs,
         knownGaps: gapScan.updatedGaps,
         lastRange: newLastRange,
         lastWindowTranscript: newWindowTranscript,
@@ -387,31 +403,6 @@ async function _runPullCycle(capabilities, sessionId, deadlineMs, nowMs, stepTim
     });
 
     return { status: "ok", degradedGap: gapScan.hasDegradedGap };
-}
-
-/**
- * Compute the last-transcribed-range metadata from the current pull's fragments.
- * Clamps firstStartMs to transcribedUntilMs so that already-transcribed audio
- * is not counted in the new region (which would inflate the overlap estimate).
- * Returns null if there are no new fragments in the processable range.
- * @param {import('../temporary/database/types').LiveDiaryFragmentIndexEntry[]} candidates
- * @param {number} transcribedUntilMs
- * @param {number} processableEndMs
- * @returns {LastTranscribedRange | null}
- */
-function _computeNewLastRange(candidates, transcribedUntilMs, processableEndMs) {
-    const newFragments = candidates.filter(
-        (f) => f.startMs < processableEndMs && f.endMs > transcribedUntilMs
-    );
-    if (newFragments.length === 0) return null;
-    const firstNewFrag = newFragments[0];
-    const lastNewFrag = newFragments[newFragments.length - 1];
-    if (firstNewFrag === undefined || lastNewFrag === undefined) return null;
-    return {
-        firstStartMs: Math.max(firstNewFrag.startMs, transcribedUntilMs),
-        lastEndMs: Math.min(lastNewFrag.endMs, processableEndMs),
-        fragmentCount: newFragments.length,
-    };
 }
 
 module.exports = {

--- a/backend/src/live_diary/pull_window_cap.js
+++ b/backend/src/live_diary/pull_window_cap.js
@@ -1,0 +1,36 @@
+/**
+ * Pull-cycle window capping based on raw PCM byte budget.
+ *
+ * @module live_diary/pull_window_cap
+ */
+
+/**
+ * Cap for assembled PCM bytes per pull cycle.
+ *
+ * Duration-only limits are format-sensitive: 20 minutes at 48kHz stereo
+ * consumes ~219MB raw PCM, which can still trigger memory pressure.
+ */
+const MAX_WINDOW_PCM_BYTES = 40 * 1024 * 1024; // 40 MiB
+
+/**
+ * Cap the planned window end by a maximum raw PCM byte budget.
+ *
+ * @param {number} windowStartMs
+ * @param {number} plannedWindowEndMs
+ * @param {number} sampleRateHz
+ * @param {number} channels
+ * @param {number} bitDepth
+ * @returns {number}
+ */
+function capWindowEndByPcmBudget(windowStartMs, plannedWindowEndMs, sampleRateHz, channels, bitDepth) {
+    const bytesPerSample = bitDepth / 8;
+    const bytesPerSecond = sampleRateHz * channels * bytesPerSample;
+    if (bytesPerSecond <= 0) return plannedWindowEndMs;
+    const maxDurationMs = Math.floor((MAX_WINDOW_PCM_BYTES * 1000) / bytesPerSecond);
+    return Math.min(plannedWindowEndMs, windowStartMs + maxDurationMs);
+}
+
+module.exports = {
+    MAX_WINDOW_PCM_BYTES,
+    capWindowEndByPcmBudget,
+};

--- a/backend/src/live_diary/pull_window_planning.js
+++ b/backend/src/live_diary/pull_window_planning.js
@@ -1,0 +1,64 @@
+const { planWindow } = require("./planner");
+const { capWindowEndByPcmBudget } = require("./pull_window_cap");
+
+/**
+ * @typedef {import('../temporary/database/types').LiveDiaryFragmentIndexEntry} LiveDiaryFragmentIndexEntry
+ */
+
+/**
+ * Plan pull-cycle window and apply PCM-byte-budget cap.
+ *
+ * @param {{
+ *   transcribedUntilMs: number,
+ *   processableEndMs: number,
+ *   prevNewDurationMs: number | null,
+ *   candidates: LiveDiaryFragmentIndexEntry[],
+ * }} input
+ * @returns {{
+ *   windowStartMs: number,
+ *   plannedWindowEndMs: number,
+ *   committedThroughMs: number,
+ *   effectiveOverlapMs: number,
+ *   sampleRateHz: number,
+ *   channels: number,
+ *   bitDepth: number,
+ * } | null}
+ */
+function planWindowWithCaps(input) {
+    const {
+        transcribedUntilMs,
+        processableEndMs,
+        prevNewDurationMs,
+        candidates,
+    } = input;
+    const firstCandidate = candidates[0];
+    if (firstCandidate === undefined) return null;
+
+    const { windowStartMs, windowEndMs, effectiveOverlapMs } = planWindow({
+        transcribedUntilMs,
+        processableEndMs,
+        prevNewDurationMs,
+    });
+
+    const { sampleRateHz, channels, bitDepth } = firstCandidate;
+    const cappedWindowEndMs = capWindowEndByPcmBudget(
+        windowStartMs,
+        windowEndMs,
+        sampleRateHz,
+        channels,
+        bitDepth
+    );
+    return {
+        windowStartMs,
+        plannedWindowEndMs: windowEndMs,
+        committedThroughMs: Math.min(processableEndMs, cappedWindowEndMs),
+        effectiveOverlapMs,
+        sampleRateHz,
+        channels,
+        bitDepth,
+    };
+}
+
+module.exports = {
+    planWindowWithCaps,
+};

--- a/backend/tests/live_diary_pull_cycle.test.js
+++ b/backend/tests/live_diary_pull_cycle.test.js
@@ -1,4 +1,6 @@
 const { _runPullCycle } = require("../src/live_diary/pull_cycle");
+const { MAX_WINDOW_DURATION_MS } = require("../src/live_diary/planner");
+const { MAX_WINDOW_PCM_BYTES } = require("../src/live_diary/pull_window_cap");
 const {
     writeFragmentIndex,
     writeKnownGaps,
@@ -117,6 +119,30 @@ async function putChunk(temporary, sessionId, sequence, byteLength = 16000) {
     await chunks.put(chunkKey(sequence), Buffer.alloc(byteLength, 0x01));
 }
 
+async function seedSingleLargeFragment(capabilities, params) {
+    const {
+        startMs = 0,
+        endMs = 10 * 60 * 60 * 1000,
+        sampleRateHz = TEST_PCM_FORMAT.sampleRateHz,
+        channels = TEST_PCM_FORMAT.channels,
+        bitDepth = TEST_PCM_FORMAT.bitDepth,
+        nowMs = 1_000_000,
+    } = params;
+    await startSession(capabilities, SESSION_ID);
+    await writeTranscribedUntilMs(capabilities.temporary, SESSION_ID, 0);
+    await writeKnownGaps(capabilities.temporary, SESSION_ID, []);
+    await writeFragmentIndex(capabilities.temporary, SESSION_ID, {
+        sequence: 0,
+        startMs,
+        endMs,
+        contentHash: "frag-large",
+        ingestedAtMs: nowMs - 5_000,
+        sampleRateHz,
+        channels,
+        bitDepth,
+    });
+}
+
 describe("_runPullCycle degraded exits", () => {
     it("does not advance watermark when a planned-window fragment index exists but binary chunk is missing", async () => {
         const caps = makeCapabilities();
@@ -199,5 +225,39 @@ describe("_runPullCycle degraded exits", () => {
         expect(gaps).toHaveLength(1);
         expect(gaps[0]?.startMs).toBe(10_000);
         expect(gaps[0]?.endMs).toBe(20_000);
+    });
+});
+
+describe("_runPullCycle window caps", () => {
+    it("advances watermark only to capped window end (not full processableEndMs)", async () => {
+        const caps = makeCapabilities();
+        const nowMs = 1_000_000;
+        await seedSingleLargeFragment(caps, { nowMs });
+        await putChunk(caps.temporary, SESSION_ID, 0);
+
+        const result = await _runPullCycle(caps, SESSION_ID, 10 * 60 * 60 * 1000, nowMs, 10_000);
+
+        expect(result.status).toBe("ok");
+        expect(await readTranscribedUntilMs(caps.temporary, SESSION_ID)).toBe(MAX_WINDOW_DURATION_MS);
+    });
+
+    it("applies additional PCM-byte budget cap for high-rate formats", async () => {
+        const caps = makeCapabilities();
+        const nowMs = 1_000_000;
+        await seedSingleLargeFragment(caps, {
+            nowMs,
+            sampleRateHz: 48_000,
+            channels: 2,
+            bitDepth: 16,
+        });
+        await putChunk(caps.temporary, SESSION_ID, 0);
+
+        const result = await _runPullCycle(caps, SESSION_ID, 10 * 60 * 60 * 1000, nowMs, 10_000);
+
+        expect(result.status).toBe("ok");
+        const watermark = await readTranscribedUntilMs(caps.temporary, SESSION_ID);
+        const expectedByPcmBudget = Math.floor((MAX_WINDOW_PCM_BYTES * 1000) / (48_000 * 2 * (16 / 8)));
+        expect(watermark).toBe(expectedByPcmBudget);
+        expect(watermark).toBeLessThan(MAX_WINDOW_DURATION_MS);
     });
 });


### PR DESCRIPTION
### Motivation
- Prevent the pull-cycle watermark from jumping past audio that was never transcribed when a planned window is capped, which caused permanent loss of transcript content.
- Prevent OOMs during long or high-bitrate diary recordings by bounding the assembled PCM by format-aware byte budget rather than duration alone.
- Improve modularity and testability of window planning and last-range computation.

### Description
- Change pull cycle to compute a `committedThroughMs` (the actual capped window end) and use it when committing `transcribedUntilMs` and computing last-range metadata, so the watermark never advances past untranscribed audio.
- Add a format-aware PCM byte-budget cap (40 MiB) and apply it on top of the existing duration cap so window sizing is bounded by `sampleRateHz`, `channels`, and `bitDepth`.
- Factor planning/capping and last-range logic into small modules: `pull_window_planning.js`, `pull_window_cap.js`, and `last_transcribed_range.js`, and update `pull_cycle.js` to consume the combined plan.
- Add unit tests that assert the watermark advances only to the capped window end and that high-rate formats trigger the PCM-byte budget cap below the planner duration cap.

### Testing
- Ran `npm install` which completed successfully.
- Ran `npx jest backend/tests/live_diary_pull_cycle.test.js` and the test suite passed (all tests in that file succeeded).
- Ran `npm run static-analysis` (TypeScript + ESLint) and it passed after refactoring the large file into smaller modules.
- Ran `npm run build` and the frontend build completed successfully.
- Ran the full `npm test` in this environment but it did not complete within the allotted timeout, so the complete test-suite run was not finished here; the targeted unit tests and static analysis/build were validated successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea4868bb5c832eb2a12ad72e24e966)