### PR TITLE
Skip sync replica switch when merge is a no-op

### DIFF
--- a/backend/src/generators/incremental_graph/database/sync_merge.js
+++ b/backend/src/generators/incremental_graph/database/sync_merge.js
@@ -24,7 +24,8 @@
  *      freshness overridden to `potentially-outdated`.
  *   7. Applies all decisions to T in one atomic batch, rebuilding the revdeps
  *      index from scratch.
- *   8. Switches the active replica pointer to T.
+ *   8. Switches the active replica pointer to T only when merge decisions
+ *      actually changed replica contents.
  *
  * Error handling policy:
  * - Version mismatch throws HostVersionMismatchError.
@@ -320,7 +321,8 @@ async function unifyRevdeps(T, mergedInputsMap) {
  *
  * Post-conditions (on success):
  * - The inactive replica contains the merged result.
- * - The active replica pointer is switched to the (previously inactive) replica.
+ * - The active replica pointer is switched to the (previously inactive)
+ *   replica only if the merge introduced data changes.
  * - Hostname staging storage is NOT cleared here; the caller is responsible.
  *
  * @param {Logger} logger
@@ -347,6 +349,7 @@ async function mergeHostIntoReplica(logger, rootDatabase, hostname) {
 
     const fromReplica = rootDatabase.currentReplicaName();
     const toReplica = rootDatabase.otherReplicaName();
+    let mergeChangedReplica = false;
 
     logger.logInfo(
         { hostname, fromReplica, toReplica },
@@ -514,6 +517,7 @@ async function mergeHostIntoReplica(logger, rootDatabase, hostname) {
 
     for (const [node, decision] of decisions) {
         if (decision === 'take') {
+            mergeChangedReplica = true;
             const takeOps = await buildTakeOps(T, H, node);
             pendingOps.push(...takeOps);
             // H-only nodes whose ancestors include a locally-kept (T-newer) node
@@ -521,7 +525,11 @@ async function mergeHostIntoReplica(logger, rootDatabase, hostname) {
             // data from H so the node exists in T and the revdeps index is
             // correct, but override freshness to force recomputation.
             if (hOnlyNeedsInvalidate.has(node)) {
-                pendingOps.push(T.freshness.putOp(node, 'potentially-outdated'));
+                const currentFreshness = await T.freshness.get(node);
+                if (currentFreshness !== 'potentially-outdated') {
+                    mergeChangedReplica = true;
+                    pendingOps.push(T.freshness.putOp(node, 'potentially-outdated'));
+                }
             }
         } else if (decision === 'invalidate') {
             // If the node was initially 'take' (H newer) but got tainted to
@@ -530,10 +538,15 @@ async function mergeHostIntoReplica(logger, rootDatabase, hostname) {
             // mergedInputsMap and rebuilt revdeps. We then force freshness to
             // potentially-outdated to trigger recomputation.
             if (initialDecisions.get(node) === 'take') {
+                mergeChangedReplica = true;
                 const takeOps = await buildTakeOps(T, H, node);
                 pendingOps.push(...takeOps);
             }
-            pendingOps.push(T.freshness.putOp(node, 'potentially-outdated'));
+            const currentFreshness = await T.freshness.get(node);
+            if (currentFreshness !== 'potentially-outdated') {
+                mergeChangedReplica = true;
+                pendingOps.push(T.freshness.putOp(node, 'potentially-outdated'));
+            }
             // Advance modifiedAt to H's value so the next sync does not see H as
             // newer and re-invalidate this node in an endless cycle.
             //
@@ -561,6 +574,13 @@ async function mergeHostIntoReplica(logger, rootDatabase, hostname) {
                         createdAt: tTimestamps?.createdAt ?? hTimestamps.createdAt,
                         modifiedAt: hTimestamps.modifiedAt,
                     };
+                    if (
+                        tTimestamps === undefined ||
+                        tTimestamps.createdAt !== advanced.createdAt ||
+                        tTimestamps.modifiedAt !== advanced.modifiedAt
+                    ) {
+                        mergeChangedReplica = true;
+                    }
                     pendingOps.push(T.timestamps.putOp(node, advanced));
                 }
             }
@@ -581,15 +601,17 @@ async function mergeHostIntoReplica(logger, rootDatabase, hostname) {
     // taint-propagated to 'invalidate' still use H.inputs for revdeps.
     await unifyRevdeps(T, mergedInputsMap);
 
-    // ── Step 8: Switch active replica pointer ────────────────────────────────
-    await rootDatabase.switchToReplica(toReplica);
+    // ── Step 8: Switch active replica pointer only if merge changed data ─────
+    if (mergeChangedReplica) {
+        await rootDatabase.switchToReplica(toReplica);
+    }
 
     const kept = [...decisions.values()].filter(d => d === 'keep').length;
     const taken = [...decisions.values()].filter(d => d === 'take').length;
     const invalidated = [...decisions.values()].filter(d => d === 'invalidate').length;
 
     logger.logInfo(
-        { hostname, fromReplica, toReplica, kept, taken, invalidated },
+        { hostname, fromReplica, toReplica, kept, taken, invalidated, mergeChangedReplica },
         'Graph merge completed for host'
     );
 }

--- a/backend/tests/sync_merge.test.js
+++ b/backend/tests/sync_merge.test.js
@@ -117,7 +117,7 @@ describe('mergeHostIntoReplica', () => {
             await mergeHostIntoReplica(logger, db, hostname);
 
             const newActive = db.currentReplicaName();
-            expect(newActive).toBe('y');
+            expect(newActive).toBe('x');
 
             const T = db.schemaStorageForReplica(newActive);
             const merged = await T.values.get(nodeA);
@@ -268,7 +268,7 @@ describe('mergeHostIntoReplica', () => {
         }
     });
 
-    test('replica pointer switches after successful merge', async () => {
+    test('replica pointer does not switch when merge introduces no changes', async () => {
         const capabilities = getTestCapabilities();
         let db;
         try {
@@ -278,6 +278,33 @@ describe('mergeHostIntoReplica', () => {
             const appVersionStr = db.version;
             await db.setMetaVersion(appVersionStr);
             await db.setHostnameMeta(hostname, 'version', appVersionStr);
+
+            const before = db.currentReplicaName();
+            expect(before).toBe('x');
+
+            await mergeHostIntoReplica(logger, db, hostname);
+
+            const after = db.currentReplicaName();
+            expect(after).toBe('x');
+        } finally {
+            if (db) await db.close();
+        }
+    });
+
+    test('replica pointer switches when merge introduces changes', async () => {
+        const capabilities = getTestCapabilities();
+        let db;
+        try {
+            db = await getRootDatabase(capabilities);
+            const logger = makeLogger();
+            const hostname = 'peer';
+            const appVersionStr = db.version;
+            await db.setMetaVersion(appVersionStr);
+            await db.setHostnameMeta(hostname, 'version', appVersionStr);
+
+            const nodeA = nk('a');
+            const H = db.hostnameSchemaStorage(hostname);
+            await writeNode(H, nodeA, TS1, [], { value: { id: 'a', type: 'test', description: 'remote' }, isDirty: false });
 
             const before = db.currentReplicaName();
             expect(before).toBe('x');
@@ -435,10 +462,10 @@ describe('mergeHostIntoReplica', () => {
             await db.setMetaVersion(appVersionStr);
             await db.setHostnameMeta(hostname1, 'version', appVersionStr);
 
-            // Merge first host (empty local replica → ops is empty).
+            // Merge first host (empty local replica and empty host input).
             await mergeHostIntoReplica(logger, db, hostname1);
-            // Replica pointer now points to 'y'.
-            expect(db.currentReplicaName()).toBe('y');
+            // No changes were introduced, so cutover is skipped.
+            expect(db.currentReplicaName()).toBe('x');
 
             // Second host: same version, with one node.
             const hostname2 = 'peer2';

--- a/docs/database-boot-sequence.md
+++ b/docs/database-boot-sequence.md
@@ -8,6 +8,8 @@ The protocol is intentionally fail-fast: it prefers crashing on ambiguous or str
 
 This document specifies **startup behavior only**. It does not specify steady-state synchronization, runtime merge behavior outside boot, or corruption-repair workflows.
 
+For clarity: steady-state sync merge now performs replica cutover only when merge writes actually change data. No-op sync merges keep `_meta/current_replica` unchanged. Migration cutover behavior is unchanged and still always switches because migration updates replica version metadata.
+
 ---
 
 ## 2) Data model and storage layers
@@ -260,4 +262,3 @@ These touchpoints are informative and do not define protocol semantics.
 2. Soft recovery from format mismatch.
 3. General corruption-repair workflow for malformed local/remote data.
 4. Expanding bootstrap fallback beyond the single explicit missing-hostname-branch condition.
-


### PR DESCRIPTION
### Motivation

- Prevent spurious replica pointer flips when a sync merge makes no effective changes to the inactive replica, which caused unnecessary toggles of `_meta/current_replica`.
- Keep migrations unchanged because they legitimately always bump version metadata and must still cut over.
- Make the check efficient by only observing keys touched during the merge decision/write path rather than re-scanning the whole database.

### Description

- Added a `mergeChangedReplica` flag to `mergeHostIntoReplica` and set it only when merge decisions would cause an effective write (value/freshness/timestamps differ or structural data is copied). 
- Made `switchToReplica(toReplica)` conditional so the replica pointer is updated only when `mergeChangedReplica === true` (no-op merges now skip cutover). 
- Added selective checks (e.g., check current freshness or timestamps before pushing a freshness/timestamp write) to avoid counting no-op writes as changes. 
- Updated tests in `backend/tests/sync_merge.test.js` and documentation in `docs/database-boot-sequence.md` to reflect conditional cutover behavior and to add explicit tests for both no-op and change-introducing merges.

### Testing

- Ran targeted tests: `npm test -- backend/tests/sync_merge.test.js`, which passed after the change. 
- Ran full test suite: `npm test`, which completed with all test suites passing. 
- Verified build: `npm run build` completed successfully for the frontend.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faf68eb6e0832e84c8c801eef60ee1)