### PR TITLE
Avoid switching incremental-graph replicas when sync merge is a no-op

### DIFF
--- a/backend/src/generators/incremental_graph/database/sync_merge.js
+++ b/backend/src/generators/incremental_graph/database/sync_merge.js
@@ -24,7 +24,8 @@
  *      freshness overridden to `potentially-outdated`.
  *   7. Applies all decisions to T in one atomic batch, rebuilding the revdeps
  *      index from scratch.
- *   8. Switches the active replica pointer to T.
+ *   8. Switches the active replica pointer to T only when the merge produced
+ *      graph changes; for pure no-op merges, keep the current replica.
  *
  * Error handling policy:
  * - Version mismatch throws HostVersionMismatchError.
@@ -575,21 +576,24 @@ async function mergeHostIntoReplica(logger, rootDatabase, hostname) {
         pendingOps = [];
     }
 
-    // Gently update revdeps using the merged inputs map.  Only changed entries
-    // are written; stale entries are deleted.  unifyRevdeps uses mergedInputsMap
-    // directly, ensuring nodes that were initially 'take' (H.inputs) but
-    // taint-propagated to 'invalidate' still use H.inputs for revdeps.
-    await unifyRevdeps(T, mergedInputsMap);
-
-    // ── Step 8: Switch active replica pointer ────────────────────────────────
-    await rootDatabase.switchToReplica(toReplica);
-
     const kept = [...decisions.values()].filter(d => d === 'keep').length;
     const taken = [...decisions.values()].filter(d => d === 'take').length;
     const invalidated = [...decisions.values()].filter(d => d === 'invalidate').length;
+    const hasChanges = taken > 0 || invalidated > 0;
+
+    if (hasChanges) {
+        // Gently update revdeps using the merged inputs map.  Only changed entries
+        // are written; stale entries are deleted.  unifyRevdeps uses mergedInputsMap
+        // directly, ensuring nodes that were initially 'take' (H.inputs) but
+        // taint-propagated to 'invalidate' still use H.inputs for revdeps.
+        await unifyRevdeps(T, mergedInputsMap);
+
+        // ── Step 8: Switch active replica pointer ────────────────────────────
+        await rootDatabase.switchToReplica(toReplica);
+    }
 
     logger.logInfo(
-        { hostname, fromReplica, toReplica, kept, taken, invalidated },
+        { hostname, fromReplica, toReplica, kept, taken, invalidated, switchedReplica: hasChanges },
         'Graph merge completed for host'
     );
 }

--- a/backend/tests/sync_merge.test.js
+++ b/backend/tests/sync_merge.test.js
@@ -9,7 +9,7 @@
  *     taken but freshness overridden to 'potentially-outdated'
  *   - missing timestamps in H: take emits del ops (no stale T timestamps survive)
  *   - version mismatch: HostVersionMismatchError thrown
- *   - replica pointer switches on success
+ *   - replica pointer switches only when merge introduces changes
  *   - invalidate: mixed-ancestry conflict marks freshness potentially-outdated
  */
 
@@ -117,7 +117,7 @@ describe('mergeHostIntoReplica', () => {
             await mergeHostIntoReplica(logger, db, hostname);
 
             const newActive = db.currentReplicaName();
-            expect(newActive).toBe('y');
+            expect(newActive).toBe('x');
 
             const T = db.schemaStorageForReplica(newActive);
             const merged = await T.values.get(nodeA);
@@ -268,7 +268,7 @@ describe('mergeHostIntoReplica', () => {
         }
     });
 
-    test('replica pointer switches after successful merge', async () => {
+    test('replica pointer does not switch after no-op merge', async () => {
         const capabilities = getTestCapabilities();
         let db;
         try {
@@ -285,7 +285,7 @@ describe('mergeHostIntoReplica', () => {
             await mergeHostIntoReplica(logger, db, hostname);
 
             const after = db.currentReplicaName();
-            expect(after).toBe('y');
+            expect(after).toBe('x');
         } finally {
             if (db) await db.close();
         }
@@ -435,10 +435,10 @@ describe('mergeHostIntoReplica', () => {
             await db.setMetaVersion(appVersionStr);
             await db.setHostnameMeta(hostname1, 'version', appVersionStr);
 
-            // Merge first host (empty local replica → ops is empty).
+            // Merge first host (empty local replica → no graph changes).
             await mergeHostIntoReplica(logger, db, hostname1);
-            // Replica pointer now points to 'y'.
-            expect(db.currentReplicaName()).toBe('y');
+            // No-op merge keeps the current replica pointer.
+            expect(db.currentReplicaName()).toBe('x');
 
             // Second host: same version, with one node.
             const hostname2 = 'peer2';

--- a/docs/database.md
+++ b/docs/database.md
@@ -162,5 +162,8 @@ Two higher-level operations are available:
 - **`synchronizeNoLock(capabilities, options)`** – renders the current database,
   synchronises the rendered repository with the remote generators repository,
   and then scans the updated rendered snapshot back into the live database.
+  During per-host graph merge, this sync path switches `_meta/current_replica`
+  only if the merge introduced graph changes (`take`/`invalidate` decisions).
+  Pure no-op merges keep the active replica pointer unchanged.
 
 See [`docs/gitstore.md`](./gitstore.md) for the gitstore primitives that back these operations.

--- a/docs/specs/migration.md
+++ b/docs/specs/migration.md
@@ -2,6 +2,10 @@
 
 This document describes the **migration system** for upgrading incremental-graph database state between application versions.
 
+> Note: this migration flow always performs a replica cutover on success. Even
+> when node values appear unchanged, migrations still bump `meta/version`, so
+> there is no no-op replica-switch optimization in the migration path.
+
 ## Overview
 
 When the application version changes, any computed values stored in the previous version's namespace may become stale or structurally incompatible with the new schema.  The migration system provides a strict, fail-fast API—`MigrationStorage`—that lets migration authors:


### PR DESCRIPTION
### Motivation
- The generators DB active replica pointer (`_meta/current_replica`) was being flipped during sync even when the per-host merge made no changes, causing unnecessary replica churn.
- The goal is to avoid mutating the replica pointer unless the merge actually introduced graph changes, while keeping the check efficient and not re-scanning the whole DB.
- Migrations remain a special case: they always cut over because they bump `meta/version` and cannot be optimized away. 

### Description
- Changed the per-host merge in `backend/src/generators/incremental_graph/database/sync_merge.js` to compute `hasChanges` from the already-computed decisions and only run `unifyRevdeps` and `rootDatabase.switchToReplica()` when `take` or `invalidate` decisions exist. 
- Kept the no-op path efficient by reusing computed `decisions` counts rather than scanning the DB again. 
- Added `switchedReplica` to the merge completion `logInfo` payload for observability. 
- Updated tests in `backend/tests/sync_merge.test.js` to assert that equal-timestamp / no-op merges do not switch replicas and adjusted related assertions for the empty-source/version scenario, and updated docs in `docs/database.md` and `docs/specs/migration.md` to describe the new behavior and the migration exception. 

### Testing
- Ran `npm test -- backend/tests/sync_merge.test.js` and the suite passed (1 test suite, 11 tests). 
- Ran `npm test -- backend/tests/database_synchronize.test.js` and the suite passed (1 test suite, 19 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faf68eb6e0832e84c8c801eef60ee1)