### PR TITLE
Migrate frontend markdown rendering from marked to markdown-it

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,7 @@
     "framer-motion": "^12.37.0",
     "jszip": "^3.10.1",
     "luxon": "^3.7.1",
-    "marked": "^15.0.12",
+    "markdown-it": "^14.1.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-router-dom": "^7.14.0"
@@ -22,6 +22,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@types/markdown-it": "^14.1.2",
     "@vitejs/plugin-react": "^4.0.0",
     "vite": "^5.0.0",
     "vite-plugin-pwa": "^1.0.0"

--- a/frontend/src/DiarySummary/DiarySummary.jsx
+++ b/frontend/src/DiarySummary/DiarySummary.jsx
@@ -8,7 +8,7 @@ import {
     Text,
     VStack,
 } from "@chakra-ui/react";
-import { marked } from "marked";
+import MarkdownIt from "markdown-it";
 import "./markdown.css";
 import { fetchDiarySummary, runDiarySummary } from "./api.js";
 import { DiarySummaryEntryList } from "./DiarySummaryEntryList.jsx";
@@ -19,6 +19,12 @@ import { useToast } from "../toast.jsx";
  * @typedef {import('./api.js').DiarySummaryRunEntry} DiarySummaryRunEntry
  */
 
+const markdownIt = new MarkdownIt({
+    html: false,
+    linkify: true,
+    typographer: true,
+});
+
 /**
  * @returns {DiarySummaryData | null}
  */
@@ -27,12 +33,12 @@ function getInitialSummary() {
 }
 
 /**
- * Renders the summary markdown using the marked library.
+ * Renders the summary markdown.
  * @param {{ markdown: string }} props
  * @returns {React.JSX.Element}
  */
 function MarkdownText({ markdown }) {
-    const html = marked.parse(markdown, { gfm: true });
+    const html = markdownIt.render(markdown);
     return (
         <Box
             className="markdown-body"

--- a/package-lock.json
+++ b/package-lock.json
@@ -139,7 +139,7 @@
         "framer-motion": "^12.37.0",
         "jszip": "^3.10.1",
         "luxon": "^3.7.1",
-        "marked": "^15.0.12",
+        "markdown-it": "^14.1.1",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-router-dom": "^7.14.0"
@@ -147,6 +147,7 @@
       "devDependencies": {
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
+        "@types/markdown-it": "^14.1.2",
         "@vitejs/plugin-react": "^4.0.0",
         "vite": "^5.0.0",
         "vite-plugin-pwa": "^1.0.0"
@@ -224,18 +225,6 @@
       "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
-      }
-    },
-    "frontend/node_modules/marked": {
-      "version": "15.0.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
-      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
-      "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 18"
       }
     },
     "frontend/node_modules/pretty-format": {
@@ -9155,12 +9144,30 @@
       "integrity": "sha512-HMwFiRujE5PjrgwHQ25+bsLJgowjGjm5Z8FVSf0N6PwgJrwxH0QxzHYDcKsTfV3wva0vzrpqMTJS2jXPr5BMEQ==",
       "license": "MIT"
     },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/luxon": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.7.1.tgz",
       "integrity": "sha512-H3iskjFIAn5SlJU7OuxUmTEpebK6TKB8rxZShDslBMZJ5u9S//KM1sbdAisiSrqwLQncVjnpi2OK2J51h+4lsg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
     },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
@@ -9170,6 +9177,13 @@
       "dependencies": {
         "@types/unist": "*"
       }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/mdx": {
       "version": "2.0.13",
@@ -22347,6 +22361,15 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/loader-runner": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
@@ -22585,6 +22608,41 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/markdown-it": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/markdown-table": {
@@ -23053,6 +23111,12 @@
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
       "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
       "license": "CC0-1.0"
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -28144,6 +28208,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/pupa": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/pupa/-/pupa-3.3.0.tgz",
@@ -31566,6 +31639,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
     },
     "node_modules/ufo": {
       "version": "1.6.1",


### PR DESCRIPTION
### Motivation
- The `marked` dependency caused compatibility problems with the frontend build and tests, so the markdown renderer was replaced with a more reliable implementation.

### Description
- Replaced `marked` with `markdown-it` in `frontend/src/DiarySummary/DiarySummary.jsx` and switched from `marked.parse()` to `markdown-it`'s `render()` while keeping the component's existing HTML rendering path.
- Configured `markdown-it` with `html: false`, `linkify: true`, and `typographer: true` for predictable, safer output.
- Updated `frontend/package.json` to remove `marked`, add `markdown-it`, and add `@types/markdown-it` to satisfy static analysis, and regenerated `package-lock.json` accordingly.
- Kept the component's CSS wrapper (`.markdown-body`) and rendering behavior intact to minimize UI changes.

### Testing
- Ran the focused frontend Jest tests `npx jest frontend/tests/DiarySummary.test.jsx frontend/tests/DiarySummary.api.test.js`, and they passed.
- Built the frontend with `npm run build` and the production build completed successfully.
- Attempted to run the full test suite and static analysis in this environment; targeted runs completed but the full `npm test` / `npm run static-analysis` executions did not produce completion output within the run window here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb999e1318832e9805d7866a252e51)