### PR TITLE
Add initial repository report at docs/report1.md

### DIFF
--- a/docs/report1.md
+++ b/docs/report1.md
@@ -1,0 +1,158 @@
+# Repository Report: `volodyslav`
+
+## 1) Executive Summary
+
+`volodyslav` is a JavaScript monorepo for personal event logging and media capture, combining:
+
+- a **Node.js/Express backend** for event APIs, media upload, and transcription;
+- a **React/Vite frontend** for event entry UX (including camera capture);
+- a **Docusaurus docs workspace** for project documentation.
+
+The repository emphasizes quality gates via Jest tests, ESLint, and TypeScript `checkJs` static typing across JavaScript files.
+
+---
+
+## 2) Monorepo & Workspace Layout
+
+Top-level npm workspaces:
+
+- `backend/`
+- `frontend/`
+- `docs/`
+
+Key top-level files:
+
+- `package.json` (workspace + scripts)
+- `jest.config.js` (test orchestration)
+- `tsconfig.json` (type checking for JS via `checkJs` patterns)
+- `Makefile` and `scripts/` utilities
+
+---
+
+## 3) Backend Overview
+
+### Primary responsibilities
+
+- Expose HTTP API routes for:
+  - health checks (`ping`)
+  - entry creation/listing
+  - periodic tasks
+  - static content
+  - upload/transcription workflows
+- Provide persistence/event-log abstraction (`event_log_storage`, `gitstore`)
+- Encapsulate filesystem and subprocess behavior in dedicated modules
+- Support scheduled task execution
+
+### Notable backend modules
+
+- Routing: `backend/src/routes/**`
+- Event domain modeling: `backend/src/event/**`, `backend/src/entry.js`
+- Storage and repository logic: `backend/src/event_log_storage/**`, `backend/src/gitstore/**`
+- IO boundaries:
+  - filesystem adapters: `backend/src/filesystem/**`
+  - subprocess wrappers: `backend/src/subprocess/**`
+- Cross-cutting concerns:
+  - config: `backend/src/config/**`
+  - logging: `backend/src/logger/**`
+  - capabilities root: `backend/src/capabilities/root.js`
+
+---
+
+## 4) Frontend Overview
+
+### Primary responsibilities
+
+- Provide event entry user interface and camera-assisted workflows
+- Manage input validation/error handling for description-entry interactions
+- Integrate with backend API for submission and configuration
+
+### Notable frontend modules
+
+- App shell: `frontend/src/App.jsx`, `frontend/src/index.jsx`
+- Camera feature: `frontend/src/Camera/**`
+- Description entry feature: `frontend/src/DescriptionEntry/**`
+  - tabs/help UI
+  - hooks and utility helpers
+  - API helpers + error abstractions
+
+Build toolchain is Vite (`frontend/vite.config.js`) with Jest + React Testing Library for tests.
+
+---
+
+## 5) Documentation Workspace
+
+`docs/` appears to be a Docusaurus site, including:
+
+- `docs/docusaurus.config.js`
+- `docs/sidebars.js`
+- markdown content such as `docs/index.md`, `docs/entries.md`, `docs/PWA_TERMUX_CONFIGURATION.md`
+
+Top-level scripts include docs dev/build commands via workspace forwarding.
+
+---
+
+## 6) Tooling & Quality Gates
+
+Top-level npm scripts (root):
+
+- `npm run dev` — runs development server script
+- `npm run build` — TypeScript compile + frontend build
+- `npm test` — Jest suite (backend + frontend)
+- `npm run static-analysis` — `tsc --noEmit` + ESLint
+- `npm run docs:dev` / `npm run docs:build`
+
+The repository uses:
+
+- Jest for tests
+- ESLint (`react`, `jest`, import rules)
+- TypeScript in JS-checking mode for static guarantees
+
+---
+
+## 7) Test Surface Snapshot
+
+There is broad test coverage across backend and frontend concerns:
+
+- backend route behavior (`ping`, `upload`, `entries`, `periodic`, `static`)
+- event parsing/validation and error class behavior
+- storage and git-backed repository behavior
+- frontend component behavior and camera flow
+- frontend photo storage unit/integration tests
+
+Test files are distributed under:
+
+- `backend/tests/*.test.js`
+- `frontend/tests/*.test.jsx|.js`
+
+---
+
+## 8) Architectural Characteristics
+
+1. **Clear boundary modules** for filesystem, subprocesses, and storage.
+2. **Feature-centric frontend organization** around `DescriptionEntry` and `Camera`.
+3. **Monorepo ergonomics** with shared root commands and workspace-specific builds.
+4. **Strong QA culture** indicated by extensive tests and mandatory static analysis.
+
+---
+
+## 9) Risks / Follow-Up Opportunities
+
+1. **Complexity concentration** in parsing/input/error modules likely warrants continued targeted tests.
+2. **Operational observability** should remain a priority around transcription/upload workflows (rate limits, retries, timeouts).
+3. **Docs maintenance** can be strengthened by regularly syncing README operational guidance with Docusaurus docs.
+
+---
+
+## 10) Quick Start (Current Command Surface)
+
+From repository root:
+
+```bash
+npm install
+npm test
+npm run static-analysis
+npm run build
+npm run dev
+```
+
+This sequence matches the expected setup/validation flow and provides confidence that backend + frontend + shared tooling are functioning.


### PR DESCRIPTION
### Motivation
- Provide a concise repository analysis and onboarding reference describing the monorepo layout, architecture, and developer workflow.

### Description
- Add `docs/report1.md` containing an executive summary, workspace layout, backend and frontend overviews, tooling and QA gates, test surface snapshot, architectural characteristics, risks, and a quick-start command flow.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbc778e3f4832eafd175c13dfbeae9)