### PR TITLE
Abort timed-out live diary transcription requests

### DIFF
--- a/backend/src/live_diary/transcribe_utils.js
+++ b/backend/src/live_diary/transcribe_utils.js
@@ -69,6 +69,27 @@ function isLiveDiaryTranscriptionTimeoutError(object) {
 }
 
 /**
+ * @param {AbortSignal} signal
+ * @param {AbortController} timeoutController
+ * @returns {() => void}
+ */
+function connectTimeoutAbort(signal, timeoutController) {
+    const abortDueToSignal = () => {
+        timeoutController.abort(signal.reason);
+    };
+
+    if (signal.aborted) {
+        abortDueToSignal();
+        return () => {};
+    }
+
+    signal.addEventListener("abort", abortDueToSignal, { once: true });
+    return () => {
+        signal.removeEventListener("abort", abortDueToSignal);
+    };
+}
+
+/**
  * Write a Buffer to a named temp file, transcribe it, then delete the temp file.
  * Returns the raw transcript string (trimmed).
  * @param {Buffer} audioBuffer
@@ -97,21 +118,29 @@ async function transcribeBuffer(audioBuffer, mimeType, capabilities, signal) {
         let result;
         const timeoutMs = computeTranscriptionTimeoutMs(audioBuffer.length);
         const timeoutError = new LiveDiaryTranscriptionTimeoutError(timeoutMs);
+        const timeoutController = new AbortController();
+        const disconnectAbortForwarding = connectTimeoutAbort(signal, timeoutController);
+
         /** @type {ReturnType<typeof setTimeout> | undefined} */
         let timer;
         const timeoutPromise = new Promise((_resolve, reject) => {
             timer = setTimeout(() => {
+                timeoutController.abort(timeoutError);
                 reject(timeoutError);
                 fileStream.destroy(timeoutError);
             }, timeoutMs);
         });
         try {
             result = await Promise.race([
-                capabilities.aiTranscription.transcribeStreamPreciseDetailed(fileStream, signal),
+                capabilities.aiTranscription.transcribeStreamPreciseDetailed(
+                    fileStream,
+                    timeoutController.signal
+                ),
                 timeoutPromise,
             ]);
         } finally {
             if (timer !== undefined) clearTimeout(timer);
+            disconnectAbortForwarding();
             fileStream.destroy();
         }
 

--- a/backend/tests/live_diary_transcribe_utils.test.js
+++ b/backend/tests/live_diary_transcribe_utils.test.js
@@ -1,19 +1,84 @@
+const { EventEmitter } = require("events");
 const {
     computeTranscriptionTimeoutMs,
+    isLiveDiaryTranscriptionTimeoutError,
+    transcribeBuffer,
 } = require("../src/live_diary/transcribe_utils");
+
+class FakeStream extends EventEmitter {
+    destroy() {}
+}
+
+function makeCapabilities(transcribeStreamPreciseDetailed) {
+    return {
+        aiTranscription: { transcribeStreamPreciseDetailed },
+        logger: { logDebug() {}, logWarning() {}, logError() {} },
+        creator: {
+            async createTemporaryDirectory() { return "/tmp/live-diary"; },
+            async createFile() { return "/tmp/live-diary/diary.wav"; },
+        },
+        writer: { async writeBuffer() {} },
+        reader: {
+            createReadStream() {
+                const stream = new FakeStream();
+                setImmediate(() => stream.emit("open"));
+                return stream;
+            },
+        },
+        deleter: { async deleteDirectory() {} },
+    };
+}
 
 describe("computeTranscriptionTimeoutMs", () => {
     it("increases timeout with audio byte size", () => {
         const small = computeTranscriptionTimeoutMs(1_000_000);
         const large = computeTranscriptionTimeoutMs(10_000_000);
-
         expect(large).toBeGreaterThan(small);
     });
 
     it("caps generation component for very large uploads", () => {
         const timeout = computeTranscriptionTimeoutMs(500_000_000);
         const expectedUploadMs = Math.ceil(500_000_000 / (1024 * 1024 / 1000));
-        const expected = expectedUploadMs + 80_000 + 10_000;
-        expect(timeout).toBe(expected);
+        expect(timeout).toBe(expectedUploadMs + 80_000 + 10_000);
+    });
+});
+
+describe("transcribeBuffer", () => {
+    it("aborts the sdk signal when timeout fires", async () => {
+        /** @type {AbortSignal | undefined} */
+        let receivedSignal;
+        const capabilities = makeCapabilities(async (_stream, signal) => {
+            receivedSignal = signal;
+            return new Promise(() => {});
+        });
+
+        const timeoutSpy = jest.spyOn(global, "setTimeout").mockImplementation((fn) => {
+            fn();
+            return /** @type {ReturnType<typeof setTimeout>} */ (1);
+        });
+
+        const error = await transcribeBuffer(
+            Buffer.alloc(1),
+            "audio/wav",
+            capabilities,
+            new AbortController().signal
+        ).catch((caught) => caught);
+
+        timeoutSpy.mockRestore();
+
+        expect(isLiveDiaryTranscriptionTimeoutError(error)).toBe(true);
+        expect(receivedSignal && receivedSignal.aborted).toBe(true);
+    });
+
+    it("forwards caller abort signal to the sdk call", async () => {
+        const outerController = new AbortController();
+
+        const capabilities = makeCapabilities(async (_stream, signal) => {
+            outerController.abort("stop");
+            return { structured: { transcript: signal.aborted ? "aborted" : "running" } };
+        });
+
+        const result = await transcribeBuffer(Buffer.alloc(1), "audio/wav", capabilities, outerController.signal);
+        expect(result).toBe("aborted");
     });
 });


### PR DESCRIPTION
### Motivation
- Fix a bug where the per-call timeout path rejected a local promise and destroyed the file stream but did not abort the `AbortSignal` given to the transcription SDK, causing in-flight OpenAI transcription requests to continue running in the background.
- Ensure both timeout-driven cancellations and caller-provided aborts stop the same underlying SDK request to avoid accumulating concurrent, wasted transcriptions.

### Description
- Add a helper `connectTimeoutAbort(signal, timeoutController)` to forward the caller-provided `AbortSignal` into an internal timeout `AbortController` so both sources of cancellation share the same controller. 
- Create a `timeoutController` inside `transcribeBuffer`, call `timeoutController.abort(timeoutError)` when the timeout fires, and pass `timeoutController.signal` into `capabilities.aiTranscription.transcribeStreamPreciseDetailed` so the SDK call is actually aborted on timeout. 
- Preserve cleanup semantics by clearing the timer, disconnecting abort forwarding, and destroying the file stream in a `finally` block, and keep the existing `LiveDiaryTranscriptionTimeoutError` semantics.
- Expand `backend/tests/live_diary_transcribe_utils.test.js` to verify that the SDK signal is aborted when the timeout fires and that the caller abort signal is forwarded to the SDK call.

### Testing
- Ran the focused unit tests with `npx jest backend/tests/live_diary_transcribe_utils.test.js` and they passed. 
- Ran the full test suite with `npm test` and the run completed successfully (all tests passed). 
- Ran static analysis with `npm run static-analysis` and it completed without errors. 
- Built the frontend with `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbceed781c832ea6d3c2990d2100f7)