### PR TITLE
Fix diary questions timeout cleanup on client setup failure

### DIFF
--- a/backend/src/ai/diary_questions.js
+++ b/backend/src/ai/diary_questions.js
@@ -217,15 +217,14 @@ async function generateQuestions(makeClient, capabilities, transcriptSoFar, aske
 
     const timeoutMs = computeQuestionsTimeoutMs(transcriptSoFar, clampedMax);
     const controller = new AbortController();
-    const timerId = setTimeout(() => controller.abort(), timeoutMs);
-
-    const apiKey = capabilities.environment.openaiAPIKey();
-    const client = makeClient(apiKey);
-
     const messages = makeQuestionsMessages(transcriptSoFar, askedQuestions, clampedMax);
 
     let rawText;
+    let timerId;
     try {
+        timerId = setTimeout(() => controller.abort(), timeoutMs);
+        const apiKey = capabilities.environment.openaiAPIKey();
+        const client = makeClient(apiKey);
         const response = await client.chat.completions.create({
             model: DIARY_QUESTIONS_MODEL,
             messages,
@@ -244,7 +243,9 @@ async function generateQuestions(makeClient, capabilities, transcriptSoFar, aske
             error
         );
     } finally {
-        clearTimeout(timerId);
+        if (timerId !== undefined) {
+            clearTimeout(timerId);
+        }
     }
 
     if (!rawText) {


### PR DESCRIPTION
### Motivation
- Starting the abort timer before OpenAI client setup meant a thrown error from `capabilities.environment.openaiAPIKey()` could exit the function before `finally` ran, leaving a pending timer that could keep the Node.js event loop alive.

### Description
- Move `setTimeout` and the OpenAI API key/client creation inside the same `try` block so timer cleanup in `finally` always runs if setup fails.
- Add a defensive `timerId !== undefined` check before calling `clearTimeout` in the `finally` block.

### Testing
- Ran `npx jest backend/tests/ai_diary_questions.test.js --runInBand` and the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbd5cdde1c832e9af51e35b28c6bf3)