### PR TITLE
Prune processed live-diary fragments after pull commits

### DIFF
--- a/backend/src/live_diary/pull_cycle.js
+++ b/backend/src/live_diary/pull_cycle.js
@@ -23,6 +23,7 @@ const {
     readLastTranscribedRange,
     readKnownGaps,
     writeKnownGaps,
+    pruneFragmentsBeforeMs,
 } = require("./session_state");
 const { buildWav } = require("./wav_utils");
 const { assemblePcm } = require("./assembler");
@@ -270,6 +271,7 @@ async function _runPullCycle(capabilities, sessionId, deadlineMs, nowMs) {
             wordsSinceLastQuestion: parseInt(existingWordCount, 10) || 0,
             questionCommit: null,
         });
+        await pruneProcessedFragments(capabilities, sessionId, committedThroughMs);
         capabilities.logger.logDebug(
             { sessionId },
             "Pull cycle: silent window — watermark advanced without transcript update"
@@ -326,6 +328,7 @@ async function _runPullCycle(capabilities, sessionId, deadlineMs, nowMs) {
 
     if (cumulativeWordCount < 10) {
         await commitPullState(temporary, sessionId, baseBundle);
+        await pruneProcessedFragments(capabilities, sessionId, committedThroughMs);
         capabilities.logger.logDebug(
             { sessionId, cumulativeWordCount },
             "Pull cycle: word count below threshold; skipping question generation"
@@ -336,6 +339,7 @@ async function _runPullCycle(capabilities, sessionId, deadlineMs, nowMs) {
     const existingPending = await readPendingQuestions(temporary, sessionId);
     if (existingPending.length > 0) {
         await commitPullState(temporary, sessionId, baseBundle);
+        await pruneProcessedFragments(capabilities, sessionId, committedThroughMs);
         capabilities.logger.logDebug(
             { sessionId, pendingCount: existingPending.length },
             "Pull cycle: skipping question generation — previous batch not yet fetched"
@@ -377,8 +381,33 @@ async function _runPullCycle(capabilities, sessionId, deadlineMs, nowMs) {
         ...baseBundle,
         questionCommit: { askedQuestions, newQuestions, cumulativeWordCount, existingPending },
     });
+    await pruneProcessedFragments(capabilities, sessionId, committedThroughMs);
 
     return { status: "ok", degradedGap: gapScan.hasDegradedGap };
+}
+
+/**
+ * Prune fragment metadata and binary PCM that are safely behind the committed watermark.
+ * Keeps a bounded retention buffer so overlap windows and delayed retries stay reliable.
+ *
+ * @param {Capabilities} capabilities
+ * @param {string} sessionId
+ * @param {number} committedThroughMs
+ * @returns {Promise<void>}
+ */
+async function pruneProcessedFragments(capabilities, sessionId, committedThroughMs) {
+    const RETAIN_BEHIND_WATERMARK_MS = 120_000;
+    const safeBeforeMs = committedThroughMs - RETAIN_BEHIND_WATERMARK_MS;
+    if (safeBeforeMs <= 0) {
+        return;
+    }
+    const pruned = await pruneFragmentsBeforeMs(capabilities.temporary, sessionId, safeBeforeMs);
+    if (pruned > 0) {
+        capabilities.logger.logDebug(
+            { sessionId, pruned, safeBeforeMs },
+            "Pull cycle: pruned processed live-diary fragments"
+        );
+    }
 }
 
 module.exports = {

--- a/backend/src/live_diary/session_state.js
+++ b/backend/src/live_diary/session_state.js
@@ -12,6 +12,8 @@ const {
     CURRENT_SESSION_KEY,
     indexSublevel,
     sessionSublevel,
+    chunksBinarySublevel,
+    chunkKey,
 } = require("../audio_recording_session");
 const { stringToTempKey } = require("../temporary");
 
@@ -256,6 +258,35 @@ async function listFragmentIndex(temporary, sessionId) {
     return fragments;
 }
 
+/**
+ * Prune old fragment-index metadata and corresponding binary PCM chunks that are
+ * no longer needed for future overlap windows.
+ *
+ * Fragments ending at or before `safeBeforeMs` are deleted.
+ *
+ * @param {Temporary} temporary
+ * @param {string} sessionId
+ * @param {number} safeBeforeMs
+ * @returns {Promise<number>} Number of pruned fragments.
+ */
+async function pruneFragmentsBeforeMs(temporary, sessionId, safeBeforeMs) {
+    const keys = await fragmentIndexSublevel(temporary, sessionId).listKeys();
+    let pruned = 0;
+    for (const key of keys) {
+        const entry = await fragmentIndexSublevel(temporary, sessionId).get(key);
+        if (entry === undefined || entry.type !== "live_diary_fragment_index") {
+            continue;
+        }
+        if (entry.endMs > safeBeforeMs) {
+            continue;
+        }
+        await fragmentIndexSublevel(temporary, sessionId).del(key);
+        await chunksBinarySublevel(temporary, sessionId).del(chunkKey(entry.sequence));
+        pruned += 1;
+    }
+    return pruned;
+}
+
 // ---------------------------------------------------------------------------
 // Watermark
 // ---------------------------------------------------------------------------
@@ -451,6 +482,7 @@ module.exports = {
     writeFragmentIndex,
     readFragmentIndex,
     listFragmentIndex,
+    pruneFragmentsBeforeMs,
     readTranscribedUntilMs,
     writeTranscribedUntilMs,
     readLastTranscribedRange,


### PR DESCRIPTION
### Motivation
- Long `/record-diary` recordings caused the live-diary pull pipeline to repeatedly scan and retain an ever-growing set of fragment metadata and PCM blobs, producing heavy GC churn and eventual V8 OOMs. 
- The fix bounds retained temporary state behind the moving transcription watermark so each pull cycle works on a bounded working set. 
- Keep a short retention window to preserve overlap/retry correctness while preventing unbounded temporary storage growth.

### Description
- Add `pruneFragmentsBeforeMs` to `backend/src/live_diary/session_state.js` to delete fragment-index entries and their matching PCM chunk blobs from the temporary store. 
- Wire a `pruneProcessedFragments` helper into `backend/src/live_diary/pull_cycle.js` and invoke it after every successful pull-state commit path (`silent window`, `low-word-count` path, `pending-questions` path, and successful `question generation`) so processed fragments are removed as the watermark advances. 
- Use a conservative retention buffer of `120_000` ms (120 seconds) behind the committed watermark to preserve overlap and retry semantics while bounding storage. 
- Import `chunksBinarySublevel` and `chunkKey` and use the existing `del` API on sublevels for binary deletions to satisfy static typing and implementation details.

### Testing
- Ran the focused test `npx jest backend/tests/live_diary_pull_cycle.test.js` and it passed. 
- Ran the full suite with `npm test` and all test suites passed. 
- Ran static analysis with `npm run static-analysis` (TypeScript + ESLint) and it passed after adjusting to the sublevel `del` API. 
- Verified frontend build with `npm run build` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc2b20c408832eaeef93ccf2056a52)