### PR TITLE
Discard audio session after diary submission to release temporary PCM/live-diary state

### DIFF
--- a/frontend/src/AudioDiary/AudioDiary.jsx
+++ b/frontend/src/AudioDiary/AudioDiary.jsx
@@ -22,7 +22,7 @@ import RecorderStatusBadge from "./RecorderStatusBadge.jsx";
 import LiveQuestionsPanel from "./LiveQuestionsPanel.jsx";
 import { useDiaryLiveQuestioningController } from "./useDiaryLiveQuestioningController.js";
 import { submitDiaryAudio } from "./diary_audio_api.js";
-import { initializeLiveQuestions } from "./session_api.js";
+import { discardSession, initializeLiveQuestions } from "./session_api.js";
 
 const pulseRing = keyframes`
     0%   { box-shadow: 0 0 0 0 rgba(229, 62, 62, 0.5); }
@@ -128,6 +128,11 @@ export default function AudioDiary() {
 
             if (!isMountedRef.current) {
                 return;
+            }
+
+            const completedSessionId = sessionIdRef.current;
+            if (completedSessionId) {
+                void discardSession(completedSessionId).catch(() => {});
             }
 
             if (result.entry && result.entry.id) {


### PR DESCRIPTION
### Motivation
- Long recordings leave large temporary audio-session state (PCM chunk binaries and live-diary metadata) behind if the session is not explicitly discarded, increasing memory/disk pressure and contributing to OOM behavior. 

### Description
- Import `discardSession` from `session_api.js` in `frontend/src/AudioDiary/AudioDiary.jsx`. 
- After a successful `submitDiaryAudio(...)`, read `sessionIdRef.current` and call `discardSession(completedSessionId)` as a fire-and-forget cleanup before navigating away. 
- Keep cleanup best-effort (non-blocking) so submission success and navigation are not delayed by cleanup failures. 
- Fix duplicate-import lint warning by consolidating `session_api` imports.

### Testing
- Ran `npx jest frontend/tests/AudioDiary.test.jsx` and the suite passed. 
- Ran `npm run static-analysis` (TypeScript + ESLint) and it passed with the duplicate-import fixed. 
- Ran `npm run build` for the frontend and the build completed successfully. 
- Attempted `npm test` (full suite) in this environment but the run did not complete within the session constraints (no conclusive pass/fail).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc2d4551a0832eab40e542597abab1)