### PR TITLE
Add random.variableName generator and tests; update plan to use variableName

### DIFF
--- a/backend/src/random/index.js
+++ b/backend/src/random/index.js
@@ -1,5 +1,6 @@
 const { string } = require("./string");
 const { defaultGenerator } = require("./default");
+const { variableName } = require("./variable_name");
 const seed = require("./seed");
 
 /**
@@ -9,5 +10,6 @@ const seed = require("./seed");
 module.exports = {
     defaultGenerator,
     string,
+    variableName,
     seed,
 };

--- a/backend/src/random/variable_name.js
+++ b/backend/src/random/variable_name.js
@@ -1,0 +1,44 @@
+// Generates a pseudo-random identifier matching /^[a-z_][a-z0-9_]*$/.
+// Note: this uses a seeded PRNG and is not suitable for cryptographic purposes.
+
+const { defaultGenerator } = require('./default');
+
+const FIRST_CHAR_OPTIONS = 'abcdefghijklmnopqrstuvwxyz_';
+const NEXT_CHAR_OPTIONS = '0123456789abcdefghijklmnopqrstuvwxyz_';
+
+/** @typedef {import('./seed').NonDeterministicSeed} NonDeterministicSeed */
+
+/**
+ * @typedef {object} Capabilities
+ * @property {NonDeterministicSeed} seed - A random number generator instance.
+ */
+
+/**
+ * Generates a random identifier matching /^[a-z_][a-z0-9_]*$/.
+ *
+ * @param {Capabilities} capabilities - An object containing a random number generator.
+ * @param {number} [length=16] - The length of the generated identifier. Must be a positive integer.
+ * @returns {string} A random identifier of specified length.
+ * @throws {TypeError} If the length is not a positive integer.
+ */
+function variableName(capabilities, length = 16) {
+    if (!Number.isInteger(length) || length < 1) {
+        throw new TypeError('Length must be a positive integer');
+    }
+
+    const rng = defaultGenerator(capabilities);
+    const result = new Array(length);
+
+    const firstIdx = rng.nextInt(0, FIRST_CHAR_OPTIONS.length - 1);
+    result[0] = FIRST_CHAR_OPTIONS[firstIdx];
+
+    const nextCharLen = NEXT_CHAR_OPTIONS.length;
+    for (let i = 1; i < length; i++) {
+        const idx = rng.nextInt(0, nextCharLen - 1);
+        result[i] = NEXT_CHAR_OPTIONS[idx];
+    }
+
+    return result.join('');
+}
+
+module.exports = { variableName };

--- a/backend/tests/random_variable_name.test.js
+++ b/backend/tests/random_variable_name.test.js
@@ -1,0 +1,29 @@
+const random = require("../src/random");
+
+const capabilities = {
+    seed: ({
+        generate: () => 42,
+    }),
+};
+
+describe("random.variableName", () => {
+    test("generates an identifier of default length 16", () => {
+        const name = random.variableName(capabilities);
+        expect(typeof name).toBe("string");
+        expect(name).toHaveLength(16);
+        expect(/^[a-z_][a-z0-9_]*$/.test(name)).toBe(true);
+    });
+
+    test("generates an identifier of custom length", () => {
+        const name = random.variableName(capabilities, 32);
+        expect(name).toHaveLength(32);
+        expect(/^[a-z_][a-z0-9_]*$/.test(name)).toBe(true);
+    });
+
+    test("throws a TypeError when length is not a positive integer", () => {
+        expect(() => random.variableName(capabilities, 0)).toThrow(TypeError);
+        expect(() => random.variableName(capabilities, -5)).toThrow(TypeError);
+        expect(() => random.variableName(capabilities, 1.5)).toThrow(TypeError);
+        expect(() => random.variableName(capabilities, "16")).toThrow(TypeError);
+    });
+});

--- a/docs/plan1.md
+++ b/docs/plan1.md
@@ -11,9 +11,8 @@ in one place and enforces it consistently.
 - [ ] Add a `NodeIdentifier` nominal type module modeled on the existing `backend/src/event/id.js`
 - [ ] Define construction and parsing around the exact full-string validity rule from the design: `/^[a-z_][a-z0-9_]*$/`
 - [ ] Reject invalid identifiers during construction, parsing, and before persistence, including explicit rejection of any string that does not match the entire validity rule
-- [ ] Delete `backend/src/random/string.js` and its test `backend/tests/random_string.test.js`
 - [ ] Add `backend/src/random/variable_name.js` that generates identifiers matching `/^[a-z_][a-z0-9_]*$/` using the repository's capabilities-driven seed pattern
-- [ ] Export `variableName` from `backend/src/random/index.js` (removing the `string` export)
+- [ ] Export `variableName` from `backend/src/random/index.js`
 - [ ] Migrate every existing caller of `random.string` (`backend/src/event/id.js`, `backend/src/runtime_identifier.js`) to use `random.variableName` instead
 
 ## 2. Database shape and lookup metadata


### PR DESCRIPTION
### Motivation

- Implement a dedicated identifier generator that produces names matching `/^[a-z_][a-z0-9_]*$/` for use as stable node identifiers and other variable-like IDs.  
- Reuse the existing seeded-RNG pattern used by `random.string` so the generator integrates with the repository's capabilities-driven seed system.  
- Adjust the project plan so it requires using `variableName` without any leftover requirement to delete `string.js` so the plan reads as if designed that way originally.

### Description

- Added `backend/src/random/variable_name.js`, a `variableName(capabilities, length = 16)` generator that validates `length` as a positive integer and uses `defaultGenerator` to produce identifiers that match `/^[a-z_][a-z0-9_]*$/`.  
- Exported `variableName` from `backend/src/random/index.js` alongside existing exports.  
- Added tests in `backend/tests/random_variable_name.test.js` that verify default/custom lengths, regex conformance, and invalid-length errors.  
- Updated `docs/plan1.md` to remove the prior checkbox that required deleting `backend/src/random/string.js` and to require `variableName` usage in a way that leaves no remnants of the older requirement.

### Testing

- Ran `npm install` successfully to prepare the environment.  
- Ran `npx jest backend/tests/random_variable_name.test.js` and the new test suite passed (`1 passed`).  
- Ran the full test suite with `npm test`, which failed due to existing unrelated timeout failures in `backend/tests/interface.test.js` and not due to these changes.  
- Ran `npm run static-analysis` and `npm run build`, both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe25caab90832e8c48a69900b94efb)