### PR TITLE
docs: fix stale keys design path in plan1

### DIFF
--- a/docs/plan1.md
+++ b/docs/plan1.md
@@ -1,7 +1,7 @@
 # Plan: implement internal node identifiers for IncrementalGraph
 
 This plan describes the concrete implementation work needed to realize the design in
-`docs/spec/keys-design.md`, and the more general transition from `NodeKey`-based
+`docs/specs/keys-design.md`, and the more general transition from `NodeKey`-based
 storage to `NodeIdentifier`-based storage in IncrementalGraph.
 
 ## 1. Identifier type and validity


### PR DESCRIPTION
### Motivation
- The plan referenced a non-existent design path which would block implementers from finding the authoritative `NodeIdentifier` design; updating the path prevents confusion at the start of the work.

### Description
- Update the reference in `docs/plan1.md` to point to the existing design document at `docs/specs/keys-design.md` (replaced `docs/spec/keys-design.md`).

### Testing
- No automated tests were necessary for this docs-only change; no test suite was run because the change only fixes a file path reference and does not touch production code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe5e2228a0832ea8b63d4d716ec8be)