### PR TITLE
docs: require preserving inputs/inputCounters order in NodeIdentifier migration plan

### DIFF
--- a/docs/plan1.md
+++ b/docs/plan1.md
@@ -36,6 +36,7 @@ state and graph-to-graph references to `NodeIdentifier`.
 - [ ] Add atomic helper(s) to resolve or allocate an identifier for a `NodeKeyString`
 - [ ] Keep `IncrementalGraph` and `Interface` APIs unchanged by translating `NodeKey` ↔ `NodeIdentifier` at the storage boundary; `NodeKey` must not appear in any internal storage logic beyond this translation step
 - [ ] Update `inputs` and `revdeps` persistence so all stored references are `NodeIdentifier[]`
+  - [ ] When rewriting `inputs`, preserve original input order so `inputs[i]` still corresponds to `inputCounters[i]`; only translate each element from `NodeKeyString` to `NodeIdentifier` without reordering.
 - [ ] Preserve deterministic revdeps ordering by sorting `NodeIdentifier` values in ascending lexicographic order (do not consult `NodeKey` for ordering)
   - Replace comparator plumbing with `compareNodeIdentifier(a, b)` implemented as string lexical compare on validated ID strings.
   - Update all revdeps materialization points (`graph_storage`, `migration_runner`, topo/unification where relevant) to enforce this order.


### PR DESCRIPTION
### Motivation
- Prevent a migration/refactor bug where translating `inputs` from `NodeKeyString` to `NodeIdentifier` could reorder entries and desynchronize `inputs[i]` from `inputCounters[i]`, which the recompute logic relies on.

### Description
- Add a single focused checklist item to `docs/plan1.md` that requires preserving the original `inputs` order when rewriting `inputs` to `NodeIdentifier[]`, ensuring each `inputs[i]` still corresponds to `inputCounters[i]` during migration.

### Testing
- No automated tests were run because this is a documentation-only change; the edit is limited to `docs/plan1.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe6016a2b8832e814d7955e6166e20)