### PR TITLE
Clarify concrete-node HTTP route migration in plan1

### DIFF
--- a/docs/plan1.md
+++ b/docs/plan1.md
@@ -66,6 +66,7 @@ identifier-addressed storage model directly.
 
 - [ ] Change the HTTP inspection API so concrete-node operations address nodes by `NodeIdentifier`, not by `head/args`
 - [ ] Update the HTTP graph API spec, route shapes, handlers, and tests to the identifier-based concrete-node model
+  - [ ] Replace concrete-node `head/args` routes (`/graph/nodes/:head`, `/graph/nodes/:head/*` and the matching POST/DELETE handlers) with identifier-addressed concrete-node routes so handlers no longer parse concrete args from URL path segments. Keep `/graph/schemas` endpoints head-based.
 - [ ] Keep the schema-oriented HTTP endpoints aligned with the public graph model where they are still head-based rather than concrete-node based
 
 ## 6. Filesystem snapshot simplification


### PR DESCRIPTION
### Motivation
- Remove ambiguity in the HTTP-inspection migration step by explicitly naming the existing concrete-node route family that must be replaced to avoid a partial/incorrect migration.

### Description
- Add one focused checklist item to `docs/plan1.md` (Section 5) requiring replacement of the concrete-node `head/args` routes (`/graph/nodes/:head`, `/graph/nodes/:head/*`) and their POST/DELETE handlers with identifier-addressed concrete-node routes while keeping `/graph/schemas` head-based.

### Testing
- No automated tests were run because this is a documentation-only change; production code and tests were not modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe62b2ae20832e940f2f5ead640e5d)