### PR TITLE
docs(plan1): include sync_merge in revdeps ordering scope

### DIFF
--- a/docs/plan1.md
+++ b/docs/plan1.md
@@ -39,7 +39,7 @@ state and graph-to-graph references to `NodeIdentifier`.
   - [ ] When rewriting `inputs`, preserve original input order so `inputs[i]` still corresponds to `inputCounters[i]`; only translate each element from `NodeKeyString` to `NodeIdentifier` without reordering.
 - [ ] Preserve deterministic revdeps ordering by sorting `NodeIdentifier` values in ascending lexicographic order (do not consult `NodeKey` for ordering)
   - Replace comparator plumbing with `compareNodeIdentifier(a, b)` implemented as string lexical compare on validated ID strings.
-  - Update all revdeps materialization points (`graph_storage`, `migration_runner`, topo/unification where relevant) to enforce this order.
+  - Update all revdeps materialization points (`graph_storage`, `migration_runner`, `database/sync_merge.js`, topo/unification where relevant) to enforce this order.
   - Add invariant tests: inserting dependencies in random order yields persisted revdeps sorted by identifier lexical order.
 - [ ] Update `listMaterializedNodes()` and inspection helpers to map stored ids back to public node keys
 - [ ] Update invalidation and recompute paths to reuse existing identifiers and never allocate duplicates


### PR DESCRIPTION
### Motivation
- Prevent a missed write-path during implementation by explicitly calling out `backend/src/generators/incremental_graph/database/sync_merge.js` as a revdeps materialization point that must enforce identifier-lexicographic ordering.

### Description
- Made a single-line edit to `docs/plan1.md` to add `database/sync_merge.js` to the list of revdeps materialization points that must be updated to use `NodeIdentifier`-based lexicographic ordering.

### Testing
- No automated unit tests were run; the change was validated by inspecting `backend/src/generators/incremental_graph/database/sync_merge.js` to confirm it rebuilds/writes revdeps and by diffing `docs/plan1.md` to ensure a single, focused documentation update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe63aa1d14832e9dc40aa6d465f972)