### PR TITLE
Clarify NodeIdentifier-only migration requirements in design docs

### DIFF
--- a/docs/plan1.md
+++ b/docs/plan1.md
@@ -51,13 +51,13 @@ state and graph-to-graph references to `NodeIdentifier`.
 Preserve the current migration callback surface while making the persisted data
 identifier-addressed and keeping identifier stability where required by the design.
 
-- [ ] Update migration code so migration callbacks become `NodeIdentifier`-based
+- [ ] Update migration code so **all migration callbacks and migration-internal graph references** are `NodeIdentifier`-based (no `NodeKey`-addressed migration inputs/outputs anywhere)
 - [ ] Preserve node identifiers across `keep`, `override`, and `invalidate` migration decisions
 - [ ] Allocate fresh identifiers for migration `create`
 - [ ] Remove both lookup entries and all identifier-keyed state for migration `delete`
 
 Then, write a single migration that will migrate the database from `NodeKey`-based storage to `NodeIdentifier`-based one.
-This requires stepping of the existing migration API, just for this one migration.
+This requires changing the existing migration API for all future migrations so the migration surface is consistently `NodeIdentifier`-based; do not keep a mixed `NodeKey`/`NodeIdentifier` migration mode, even temporarily.
 
 ## 5. HTTP inspection API
 

--- a/docs/specs/keys-design.md
+++ b/docs/specs/keys-design.md
@@ -46,6 +46,17 @@ internal logic. Inside the storage layer, all node addressing, sorting, and
 edge-following uses `NodeIdentifier` only. `NodeKey` values appear only as arguments
 or return values of user-facing API calls and in the bijection lookup tables.
 
+
+### Migration API boundary
+
+Migration code is internal storage logic, so migrations are fully `NodeIdentifier`-addressed.
+
+- Migration callbacks must receive and return concrete-node references as `NodeIdentifier` values.
+- Migration-produced `inputs`/`revdeps` must contain only `NodeIdentifier` values.
+- Migration control decisions (`keep`, `override`, `invalidate`, `create`, `delete`) operate on `NodeIdentifier`-addressed state, with `NodeKey` used only via the lookup bijection when needed for external API translation.
+
+There is no mixed-mode migration API: `NodeKey`-addressed migration payloads are out of scope and unsupported.
+
 ### HTTP inspection API
 
 The HTTP inspection API is not a user-facing API. It is an internal development and
@@ -95,7 +106,7 @@ This applies to:
 - keys in all graph-state sublevels
 - values inside `inputs`
 - values inside `revdeps`
-- migration-produced state
+- all migration callback payloads and migration-produced state
 - filesystem-rendered snapshots
 - HTTP API addressing of concrete nodes
 


### PR DESCRIPTION
### Motivation

- Remove ambiguity about whether migrations may use `NodeKey`-addressed payloads by requiring a single, consistent `NodeIdentifier`-based migration surface across plan and spec. 
- Prevent future conflicts and accidental mixed-mode implementations by making migration addressing rules explicit in both the implementation plan and the keys design spec.

### Description

- Updated `docs/plan1.md` to require that **all** migration callbacks and migration-internal graph references are `NodeIdentifier`-based and to forbid mixed `NodeKey`/`NodeIdentifier` migration payloads. 
- Clarified in `docs/plan1.md` that the migration API change is forward-looking and should apply to all future migrations rather than being a one-off step. 
- Added a dedicated "Migration API boundary" section to `docs/specs/keys-design.md` and expanded the persisted storage language so migration callback inputs/outputs and migration-produced state are explicitly `NodeIdentifier`-addressed.

### Testing

- No automated tests were run because this is a documentation-only change. 
- Changes were inspected in the modified files to confirm the new `NodeIdentifier`-only migration language is present and consistent across the plan and spec.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe67a07100832ea522a68d9b7a6123)