### PR TITLE
docs: clarify migration callback head-filtering during NodeIdentifier migration

### DIFF
--- a/docs/plan1.md
+++ b/docs/plan1.md
@@ -52,6 +52,7 @@ Preserve the current migration callback surface while making the persisted data
 identifier-addressed and keeping identifier stability where required by the design.
 
 - [ ] Update migration code so **all migration callbacks and migration-internal graph references** are `NodeIdentifier`-based (no `NodeKey`-addressed migration inputs/outputs anywhere)
+  - [ ] Keep migration decisions (`keep`/`delete`/`override`/`invalidate`/`create`) `NodeIdentifier`-addressed, but add an explicit lookup helper for callbacks that need schema/head-based selection (current `migration.js` does `deserializeNodeKey(nodeKey).head` in `keepNodeType`/`deleteNodeType`). Without this helper, porting the existing migration callback will either break head-based filtering or incorrectly reintroduce `NodeKey`-addressed decision APIs.
 - [ ] Preserve node identifiers across `keep`, `override`, and `invalidate` migration decisions
 - [ ] Allocate fresh identifiers for migration `create`
 - [ ] Remove both lookup entries and all identifier-keyed state for migration `delete`


### PR DESCRIPTION
### Motivation
- The current migration callbacks (`keepNodeType`/`deleteNodeType`) inspect `NodeKey` by doing `deserializeNodeKey(nodeKey).head`, so moving migration decisions to `NodeIdentifier`-addressed callbacks risks losing head-based filtering or forcing reintroduction of `NodeKey`-addressed decision APIs; the plan must explicitly require a sanctioned lookup helper to avoid this pitfall.

### Description
- Added a single focused requirement to `docs/plan1.md` (section 4) that mandates keeping migration decisions `NodeIdentifier`-addressed while providing an explicit `NodeIdentifier -> NodeKey` lookup helper for callbacks that need schema/head-based selection, referencing the existing `migration.js` pattern that deserializes node keys.

### Testing
- No automated tests were run because this is a documentation-only change; verification consisted of repository file inspections (`docs/plan1.md`, `docs/specs/keys-design.md`, and `backend/src/generators/incremental_graph/migration.js`) to confirm the rationale and the existing code pattern.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe6fa2c100832eb013d77da4d1ed2e)