### PR TITLE
Clarify migration plan to require replacing NodeKey migration API

### DIFF
--- a/docs/plan1.md
+++ b/docs/plan1.md
@@ -48,8 +48,7 @@ state and graph-to-graph references to `NodeIdentifier`.
 
 ## 4. Migration behavior
 
-Preserve the current migration callback surface while making the persisted data
-identifier-addressed and keeping identifier stability where required by the design.
+Replace (not preserve) the current `NodeKey`-addressed migration callback surface with a fully `NodeIdentifier`-addressed one, while keeping identifier stability where required by the design.
 
 - [ ] Update migration code so **all migration callbacks and migration-internal graph references** are `NodeIdentifier`-based (no `NodeKey`-addressed migration inputs/outputs anywhere)
   - [ ] Keep migration decisions (`keep`/`delete`/`override`/`invalidate`/`create`) `NodeIdentifier`-addressed, but add an explicit lookup helper for callbacks that need schema/head-based selection (current `migration.js` does `deserializeNodeKey(nodeKey).head` in `keepNodeType`/`deleteNodeType`). Without this helper, porting the existing migration callback will either break head-based filtering or incorrectly reintroduce `NodeKey`-addressed decision APIs.


### PR DESCRIPTION
### Motivation
- The original text in `docs/plan1.md` section 4 said to "Preserve the current migration callback surface" which contradicted subsequent bullets that require a fully `NodeIdentifier`-addressed migration API, risking a mixed-mode implementation bug if left ambiguous.  This one-line clarification prevents that confusion. 

### Description
- Replace the lead sentence of section 4 in `docs/plan1.md` so it now explicitly instructs implementers to replace the `NodeKey`-addressed migration callback surface with a fully `NodeIdentifier`-addressed one (while preserving identifier stability where required). 

### Testing
- No automated tests were executed because this is a documentation-only change; repository artifacts inspected to verify context include `docs/specs/keys-design.md`, `backend/src/generators/incremental_graph/migration.js`, and `backend/src/routes/graph.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe708fb08c832e9710803df95e7172)