### PR TITLE
docs: require identifier-based topo tie-breakers in plan1

### DIFF
--- a/docs/plan1.md
+++ b/docs/plan1.md
@@ -41,6 +41,7 @@ state and graph-to-graph references to `NodeIdentifier`.
 - [ ] Preserve deterministic revdeps ordering by sorting `NodeIdentifier` values in ascending lexicographic order (do not consult `NodeKey` for ordering)
   - Replace comparator plumbing with `compareNodeIdentifier(a, b)` implemented as string lexical compare on validated ID strings.
   - Update all revdeps materialization points (`graph_storage`, `migration_runner`, `database/sync_merge.js`, topo/unification where relevant) to enforce this order.
+  - Update topological ordering tie-breakers (`database/topo_sort.js` and merge logic in `database/sync_merge.js`) to compare `NodeIdentifier` lexically, otherwise migration/sync decisions can remain `NodeKey`-ordered even after revdeps are identifier-ordered.
   - Add invariant tests: inserting dependencies in random order yields persisted revdeps sorted by identifier lexical order.
 - [ ] Update `listMaterializedNodes()` and inspection helpers to map stored ids back to public node keys
 - [ ] Update invalidation and recompute paths to reuse existing identifiers and never allocate duplicates


### PR DESCRIPTION
### Motivation
- The plan moves persisted graph ordering to `NodeIdentifier` but did not explicitly require topological tie-breakers to switch from `NodeKey`-based comparison, which risks leaving migration and sync decision determinism tied to `NodeKey` ordering used in `database/topo_sort.js` and consumed by `database/sync_merge.js` rather than the intended `NodeIdentifier` ordering.

### Description
- Edited `docs/plan1.md` to add one focused requirement: update topological ordering tie-breakers in `database/topo_sort.js` and merge logic in `database/sync_merge.js` to compare `NodeIdentifier` lexically so migration/sync decisions use identifier ordering. 

### Testing
- No automated tests were run because this is a documentation-only change; change verified by inspecting `docs/specs/keys-design.md`, `backend/src/generators/incremental_graph/database/topo_sort.js`, and `backend/src/generators/incremental_graph/database/sync_merge.js`, and by committing the single-line edit to `docs/plan1.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe7535c0c8832e9ad4ddad16def938)