### PR TITLE
docs: require schema adapters to include identifiers_keys_map in migration plan

### DIFF
--- a/docs/plan1.md
+++ b/docs/plan1.md
@@ -27,6 +27,11 @@ Extend the root database so graph state is identifier-addressed and the semantic
 - [ ] The cache should be stored in a two-way hashmap structure for efficient lookups in both directions, and should be the authoritative source for the bijection while the database is open.
 - [ ] Expand batch builder type to include `metaIdentifiers` operations so identifier allocation/removal can commit in the same physical batch as graph-state updates.
   - [ ] Add integration tests for failure injection: if a batch write fails, neither state sublevels nor lookup metadata should advance.
+- [ ] Update every schema-storage adapter to carry the identifiers map as first-class replica data, not as an out-of-band special case.
+  - [ ] Extend `database/root_database.js` `SchemaStorage` and `buildSchemaStorage()` with a typed store for `identifiers_keys_map`, and ensure it is present for both active and inactive replicas.
+  - [ ] Mirror the same typed store in `database/hostname_storage.js`; migration/sync code uses hostname-backed storages and will silently drop lookup metadata unless this path is updated too.
+  - [ ] Update `database/unification/db_to_db.js` so `identifiers_keys_map` participates in copy/unify operations; otherwise sync can copy `inputs`/`revdeps` that reference ids absent from the destination lookup table.
+  - [ ] Add focused tests that perform sync/unification between replicas and assert both directions of the bijection survive, not just graph-state sublevels.
 
 ## 3. Storage boundary and lifecycle behavior
 


### PR DESCRIPTION
### Motivation
- The plan must explicitly prevent a migration that moves `inputs`/`revdeps` to `NodeIdentifier` without also moving the `NodeKey ↔ NodeIdentifier` bijection, because existing schema adapters (active replica, hostname staging, and db-to-db unification) currently enumerate only data sublevels and would silently omit the lookup table; this is visible in `backend/src/generators/incremental_graph/database/root_database.js` and `hostname_storage.js` which list `values`, `freshness`, `inputs`, `revdeps`, `counters`, `timestamps` but not the identifiers map, and in `database/unification/db_to_db.js` which hardcodes `DATA_SUBLEVELS`.
- Making this explicit in the plan prevents a concrete risk where sync/unify paths produce dangling identifier references and hard-to-debug corruption during or after migration.

### Description
- Updated `docs/plan1.md` (section “Database shape and lookup metadata”) to add a focused checklist requiring every `SchemaStorage` adapter to treat `identifiers_keys_map` as first-class replica data and to enumerate the concrete places to update: `database/root_database.js`, `database/hostname_storage.js`, and `database/unification/db_to_db.js`.
- The new checklist also requires focused tests asserting that sync/unification preserves both directions of the bijection, not just graph-state sublevels, so that `inputs`/`revdeps` never reference ids missing from the destination lookup table.
- This change is documentation-only and was committed as `docs: add schema-adapter safeguards for identifier map migration`.

### Testing
- No automated tests were run because this is a documentation-only change; implementation work should add the focused sync/unification tests described above when code changes are made.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe75ff66ec832ea0cfc05cce417836)