### PR TITLE
docs: require identifier-keyed snapshot encoding in plan1

### DIFF
--- a/docs/plan1.md
+++ b/docs/plan1.md
@@ -86,6 +86,10 @@ lookup tables carrying the `NodeKey ↔ NodeIdentifier` relationship.
 - [ ] Remove the concrete-node path encoding/decoding model entirely
 - [ ] Delete any code whose job is converting concrete node keys to filesystem paths or back
 - [ ] Simplify `database/encoding.js`, render helpers, scan helpers, and unification helpers around the direct identifier-path snapshot format
+  - [ ] In `database/encoding.js`, remove the NodeKey JSON path contract for data sublevels: `keyToRelativePath()` and `relativePathToKey()` must treat `values|freshness|inputs|revdeps|counters|timestamps` keys as single identifier segments (`.../<id>`), not `head/arg...` expansions.
+  - [ ] Remove `serializeNodeKey` / `deserializeNodeKey` usage from graph-state path encoding/decoding; after this change those conversions are only allowed for reading/writing `/${current_replica}/global/identifiers_keys_map`, not for graph-state files.
+  - [ ] Update `backend/tests/database_render.test.js` cases that currently enforce “expected NodeKey JSON” for data sublevels; those assertions become wrong once keys are opaque identifiers and will otherwise force accidental reintroduction of NodeKey-based path decoding.
+  - [ ] Add a render/scan regression test that seeds raw keys like `!x!!values!nodeid1` + `!x!!inputs!nodeid1`, verifies rendered files are `rendered/x/values/nodeid1` / `rendered/x/inputs/nodeid1`, and round-trips back without any `head`/`args` directories.
 
 This requires careful audit to avoid leaving hidden key-path transforms.
 


### PR DESCRIPTION
### Motivation
- Prevent a concrete implementation bug where runtime storage moves to `NodeIdentifier` but snapshot `render()`/`scan()`/encoding still treat graph-state keys as `NodeKey` JSON `head/args` paths.
- The current codebase shows this mismatch is likely because `backend/src/generators/incremental_graph/database/encoding.js` presently decomposes NodeKey JSON for data sublevels and tests in `backend/tests/database_render.test.js` assert that behavior, while the target design in `docs/specs/keys-design.md` requires direct identifier paths like `rendered/r/values/nodeid1`.
- Making the snapshot-encoding requirement explicit in the plan reduces the risk of accidentally preserving legacy path-decoding and forces test updates that would otherwise mask the incorrect behavior.

### Description
- Edited `docs/plan1.md` (Filesystem snapshot simplification section) to expand the encoding bullet into concrete sub-steps that require `database/encoding.js` to treat `values|freshness|inputs|revdeps|counters|timestamps` keys as single identifier segments (`.../<id>`) rather than `head/arg...` expansions.
- The new sub-steps explicitly forbid `serializeNodeKey`/`deserializeNodeKey` usage for graph-state path encoding/decoding except when reading/writing `/${current_replica}/global/identifiers_keys_map` and call out the exact test file `backend/tests/database_render.test.js` that must be updated.
- The plan also adds a targeted regression test requirement that seeds raw LevelDB keys like `!x!!values!nodeid1` and asserts rendered files are `rendered/x/values/nodeid1` and that scanning round-trips without `head/args` directories.
- This change is documentation-only and does not modify production code.

### Testing
- No automated tests were run as part of this documentation-only change; the edit is intended to guide subsequent implementation and test updates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe76a0bf08832e8cdb33702bec858c)