### PR TITLE
Stop rendering/scanning `_meta` in replica snapshot flows

### DIFF
--- a/backend/src/generators/incremental_graph/database/gitstore.js
+++ b/backend/src/generators/incremental_graph/database/gitstore.js
@@ -162,12 +162,6 @@ async function checkpointDatabase(
                     path.join(workDir, DATABASE_SUBPATH, 'r'),
                     activeReplica
                 );
-                await renderToFilesystem(
-                    capabilities,
-                    database,
-                    path.join(workDir, DATABASE_SUBPATH, '_meta'),
-                    '_meta'
-                );
                 capabilities.logger.logDebug({ message }, "Rendered database snapshot for checkpoint, committing");
                 await commit(message);
                 capabilities.logger.logDebug({ message }, "Checkpoint committed");
@@ -226,12 +220,6 @@ async function checkpointMigration(
                 path.join(workDir, DATABASE_SUBPATH, 'r'),
                 rootDatabase.currentReplicaName()
             );
-            await renderToFilesystem(
-                capabilities,
-                rootDatabase,
-                path.join(workDir, DATABASE_SUBPATH, '_meta'),
-                '_meta'
-            );
             capabilities.logger.logDebug({ preMessage, postMessage }, "Committing pre-migration snapshot");
             await commit(preMessage);
             capabilities.logger.logDebug({ preMessage, postMessage }, "Pre-migration snapshot committed, running migration callback");
@@ -242,12 +230,6 @@ async function checkpointMigration(
                 rootDatabase,
                 path.join(workDir, DATABASE_SUBPATH, 'r'),
                 rootDatabase.currentReplicaName()
-            );
-            await renderToFilesystem(
-                capabilities,
-                rootDatabase,
-                path.join(workDir, DATABASE_SUBPATH, '_meta'),
-                '_meta'
             );
             capabilities.logger.logDebug({ preMessage, postMessage }, "Committing post-migration snapshot");
             await commit(postMessage);

--- a/backend/src/generators/incremental_graph/database/synchronize_reset_snapshot.js
+++ b/backend/src/generators/incremental_graph/database/synchronize_reset_snapshot.js
@@ -142,7 +142,6 @@ async function validateResetSnapshotMetadata(capabilities, snapshotMetaDir) {
  */
 async function importResetSnapshotIntoDatabase(capabilities, database, workTree, snapshotReplica) {
     const snapshotRoot = path.join(workTree, DATABASE_SUBPATH);
-    const snapshotMetaDir = path.join(snapshotRoot, '_meta');
     const rDir = path.join(snapshotRoot, 'r');
 
     if (await capabilities.checker.directoryExists(rDir)) {
@@ -156,12 +155,6 @@ async function importResetSnapshotIntoDatabase(capabilities, database, workTree,
         await database._rawDeleteSublevel(snapshotReplica);
     }
 
-    await scanFromFilesystem(
-        capabilities,
-        database,
-        snapshotMetaDir,
-        '_meta'
-    );
 }
 
 /**

--- a/backend/tests/database_gitstore.test.js
+++ b/backend/tests/database_gitstore.test.js
@@ -162,7 +162,7 @@ describe("checkpointDatabase", () => {
 
     test("creates a commit when called for the first time", async () => {
         const capabilities = getTestCapabilities();
-        const db = await seedDatabase(capabilities, [["!_meta!format", "xy-v1"]]);
+        const db = await seedDatabase(capabilities, [['!x!!values!{"head":"event","args":["init"]}', { ok: true }]]);
         try {
             await checkpointDatabase(capabilities, "initial checkpoint", db);
 
@@ -176,7 +176,7 @@ describe("checkpointDatabase", () => {
 
     test("commit message matches the provided message", async () => {
         const capabilities = getTestCapabilities();
-        const db = await seedDatabase(capabilities, [["!_meta!format", "xy-v1"]]);
+        const db = await seedDatabase(capabilities, [['!x!!values!{"head":"event","args":["init"]}', { ok: true }]]);
         try {
             await checkpointDatabase(capabilities, "my checkpoint message", db);
 
@@ -252,12 +252,9 @@ describe("checkpointDatabase", () => {
             await checkpointDatabase(capabilities, "empty repo checkpoint", db);
 
             const gitDir = checkpointGitDir(capabilities);
-            expect(commitCount(capabilities, gitDir)).toBe(2);
-            expect(topLevelEntries(capabilities, gitDir)).toEqual([DATABASE_SUBPATH]);
-            expect(allTrackedFiles(capabilities, gitDir)).toEqual([
-                `${DATABASE_SUBPATH}/_meta/current_replica`,
-                `${DATABASE_SUBPATH}/_meta/format`,
-            ]);
+            expect(commitCount(capabilities, gitDir)).toBe(1);
+            expect(topLevelEntries(capabilities, gitDir)).toEqual([]);
+            expect(allTrackedFiles(capabilities, gitDir)).toEqual([]);
         } finally {
             await db.close();
         }
@@ -293,7 +290,6 @@ describe("checkpointDatabase", () => {
 
             const gitDir = checkpointGitDir(capabilities);
             const tracked = allTrackedFiles(capabilities, gitDir);
-            expect(tracked).toContain(`${DATABASE_SUBPATH}/_meta/format`);
             expect(tracked).toContain(
                 `${DATABASE_SUBPATH}/${renderedKeyPath('!x!!values!{"head":"event","args":["one"]}')}`
             );

--- a/backend/tests/database_synchronize.test.js
+++ b/backend/tests/database_synchronize.test.js
@@ -621,18 +621,6 @@ describe("synchronizeNoLock", () => {
                     !isInvalidSnapshotFormatError(error) &&
                     !isInvalidSnapshotReplicaError(error),
             },
-            {
-                name: "invalid JSON payload in rendered _meta subtree after metadata checks",
-                files: [
-                    { path: "_meta/format", content: JSON.stringify("xy-v2") },
-                    { path: "_meta/current_replica", content: JSON.stringify("x") },
-                    { path: "_meta/another_key", content: "not-json" },
-                ],
-                expectedErrorGuard: (error) =>
-                    error instanceof Error &&
-                    !isInvalidSnapshotFormatError(error) &&
-                    !isInvalidSnapshotReplicaError(error),
-            },
         ];
 
         test.each(scenarios)(


### PR DESCRIPTION
### Motivation
- Snapshot IO for migrations and checkpoints must only include the active replica subtree (`r`), never the `_meta` sublevel, to match recent design guidance about migrations and syncing.

### Description
- Removed rendering of the `_meta` sublevel from checkpoint flows in `backend/src/generators/incremental_graph/database/gitstore.js` so checkpoints only persist the active replica under `rendered/r`.
- Removed scanning of the `_meta` sublevel during reset-snapshot import in `backend/src/generators/incremental_graph/database/synchronize_reset_snapshot.js` so import only scans the replica `r` directory and never imports `_meta` from snapshots.
- This change enforces the rule: do not render or scan `_meta` in snapshot paths used for migrations/sync; only the replica sublevel is processed.

### Testing
- Ran `npm install` (succeeded).
- Ran `npm run static-analysis` (TypeScript/ESLint) (succeeded).
- Ran `npm run build` (frontend build) (succeeded).
- Ran targeted tests via `npx jest backend/tests/database_gitstore.test.js backend/tests/database_synchronize.test.js --runInBand` which exposed failing assertions because several tests still expect `_meta` files to be produced/tracked in checkpoint snapshots (tests currently failing).
- Ran the full test suite with `npm test` and observed failing tests related to the old `_meta` snapshot expectations (CI not yet green until tests are updated to align with the new snapshot behaviour).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fece68dbc8832e9eda4ba2addc1281)