### PR TITLE
Remove reset import dependency on `_meta/current_replica`

### DIFF
--- a/backend/src/generators/incremental_graph/database/index.js
+++ b/backend/src/generators/incremental_graph/database/index.js
@@ -15,8 +15,6 @@ const {
 } = require('./gitstore');
 const {
     synchronizeNoLock,
-    InvalidSnapshotReplicaError,
-    isInvalidSnapshotReplicaError,
     isSyncMergeAggregateError,
 } = require('./synchronize');
 const { renderToFilesystem, scanFromFilesystem, keyToRelativePath, relativePathToKey } = require('./render');
@@ -67,8 +65,6 @@ module.exports = {
     versionToString,
     stringToVersion,
     synchronizeNoLock,
-    InvalidSnapshotReplicaError,
-    isInvalidSnapshotReplicaError,
     isSyncMergeAggregateError,
     renderToFilesystem,
     scanFromFilesystem,

--- a/backend/src/generators/incremental_graph/database/synchronize.js
+++ b/backend/src/generators/incremental_graph/database/synchronize.js
@@ -23,8 +23,6 @@ const {
 } = require('./gitstore');
 const {
     synchronizeResetToHostname,
-    InvalidSnapshotReplicaError,
-    isInvalidSnapshotReplicaError,
 } = require('./synchronize_reset_snapshot');
 const { scanFromFilesystem } = require('./render');
 const { getRootDatabase } = require('./get_root_database');
@@ -260,7 +258,5 @@ async function synchronizeNoLock(capabilities, options) {
 
 module.exports = {
     synchronizeNoLock,
-    InvalidSnapshotReplicaError,
-    isInvalidSnapshotReplicaError,
     isSyncMergeAggregateError,
 };

--- a/backend/src/generators/incremental_graph/database/synchronize_reset_snapshot.js
+++ b/backend/src/generators/incremental_graph/database/synchronize_reset_snapshot.js
@@ -12,108 +12,36 @@ const { scanFromFilesystem } = require('./render');
 /** @typedef {import('./root_database').RootDatabase} RootDatabase */
 
 /**
- * Thrown when the snapshot's `_meta/current_replica` file is missing a valid
- * replica name ("x" or "y"). This indicates a corrupted or incompatible snapshot.
- */
-class InvalidSnapshotReplicaError extends Error {
-    /**
-     * @param {unknown} value - The invalid value that was read.
-     * @param {string} filePath - Path to the file that contained the bad value.
-     * @param {'missing' | 'invalid-json' | 'invalid-value'} reason
-     */
-    constructor(value, filePath, reason) {
-        const renderedValue = value === undefined ? 'undefined' : JSON.stringify(value);
-        let message;
-        if (reason === 'missing') {
-            message = `Snapshot _meta/current_replica is missing. Expected a JSON string: "x" or "y". File: ${filePath}`;
-        } else if (reason === 'invalid-json') {
-            message = `Snapshot _meta/current_replica is not valid JSON: ${renderedValue}. Expected a JSON string: "x" or "y". File: ${filePath}`;
-        } else {
-            message = `Snapshot _meta/current_replica has invalid parsed value: ${renderedValue}. Expected "x" or "y". File: ${filePath}`;
-        }
-        super(message);
-        this.name = 'InvalidSnapshotReplicaError';
-        this.value = value;
-        this.filePath = filePath;
-        this.reason = reason;
-    }
-}
-
-/**
- * @param {unknown} object
- * @returns {object is InvalidSnapshotReplicaError}
- */
-function isInvalidSnapshotReplicaError(object) {
-    return object instanceof InvalidSnapshotReplicaError;
-}
-
-/**
- * @param {Capabilities} capabilities
- * @param {string} filePath
- * @returns {Promise<unknown>}
- */
-async function readJsonFromFile(capabilities, filePath) {
-    const content = await capabilities.reader.readFileAsText(filePath);
-    return JSON.parse(content);
-}
-
-/**
- * @param {Capabilities} capabilities
- * @param {string} snapshotMetaDir
- * @returns {Promise<'x' | 'y'>}
- */
-async function validateResetSnapshotMetadata(capabilities, snapshotMetaDir) {
-    const currentReplicaFile = path.join(snapshotMetaDir, 'current_replica');
-    if (!(await capabilities.checker.fileExists(currentReplicaFile))) {
-        throw new InvalidSnapshotReplicaError(undefined, currentReplicaFile, 'missing');
-    }
-
-    let parsedReplica;
-    try {
-        parsedReplica = await readJsonFromFile(capabilities, currentReplicaFile);
-    } catch {
-        const replicaRaw = await capabilities.reader.readFileAsText(currentReplicaFile);
-        throw new InvalidSnapshotReplicaError(replicaRaw, currentReplicaFile, 'invalid-json');
-    }
-    if (parsedReplica !== 'x' && parsedReplica !== 'y') {
-        throw new InvalidSnapshotReplicaError(parsedReplica, currentReplicaFile, 'invalid-value');
-    }
-
-    return parsedReplica;
-}
-
-/**
  * @param {Capabilities} capabilities
  * @param {RootDatabase} database
  * @param {string} workTree
- * @param {'x' | 'y'} snapshotReplica
  * @returns {Promise<void>}
  */
-async function importResetSnapshotIntoDatabase(capabilities, database, workTree, snapshotReplica) {
+async function importResetSnapshotIntoDatabase(capabilities, database, workTree) {
     const snapshotRoot = path.join(workTree, DATABASE_SUBPATH);
     const rDir = path.join(snapshotRoot, 'r');
+    const targetReplica = 'x';
 
     if (await capabilities.checker.directoryExists(rDir)) {
         await scanFromFilesystem(
             capabilities,
             database,
             rDir,
-            snapshotReplica
+            targetReplica
         );
     } else {
-        await database._rawDeleteSublevel(snapshotReplica);
+        await database._rawDeleteSublevel(targetReplica);
     }
 
-    await database.switchToReplica(snapshotReplica);
+    await database.switchToReplica(targetReplica);
 }
 
 /**
  * @param {Capabilities} capabilities
  * @param {string} workTree
- * @param {'x' | 'y'} snapshotReplica
  * @returns {Promise<void>}
  */
-async function replaceLiveDatabaseWithResetSnapshot(capabilities, workTree, snapshotReplica) {
+async function replaceLiveDatabaseWithResetSnapshot(capabilities, workTree) {
     const workingDirectory = capabilities.environment.workingDirectory();
     const liveDatabasePath = path.join(
         workingDirectory,
@@ -143,8 +71,7 @@ async function replaceLiveDatabaseWithResetSnapshot(capabilities, workTree, snap
         await importResetSnapshotIntoDatabase(
             capabilities,
             stagedDatabase,
-            workTree,
-            snapshotReplica
+            workTree
         );
         await stagedDatabase.close();
         stagedDatabase = undefined;
@@ -197,15 +124,9 @@ async function synchronizeResetToHostname(capabilities, remoteLocation) {
         remoteLocation,
         async (store) => {
             const workTree = await store.getWorkTree();
-            const snapshotMetaDir = path.join(workTree, DATABASE_SUBPATH, '_meta');
-            const snapshotReplica = await validateResetSnapshotMetadata(
-                capabilities,
-                snapshotMetaDir
-            );
             await replaceLiveDatabaseWithResetSnapshot(
                 capabilities,
-                workTree,
-                snapshotReplica
+                workTree
             );
         }
     );
@@ -213,6 +134,4 @@ async function synchronizeResetToHostname(capabilities, remoteLocation) {
 
 module.exports = {
     synchronizeResetToHostname,
-    InvalidSnapshotReplicaError,
-    isInvalidSnapshotReplicaError,
 };

--- a/backend/tests/database_synchronize.test.js
+++ b/backend/tests/database_synchronize.test.js
@@ -1,7 +1,6 @@
 const path = require("path");
 const {
     synchronizeNoLock,
-    isInvalidSnapshotReplicaError,
     isSyncMergeAggregateError,
     getRootDatabase,
     CHECKPOINT_WORKING_PATH,
@@ -336,130 +335,18 @@ describe("synchronizeNoLock", () => {
         expect(error.message).toContain("input directory does not exist");
     });
 
-    test("throws InvalidSnapshotReplicaError when snapshot has incompatible _meta/current_replica", async () => {
+    test("resetToHostname succeeds when snapshot omits _meta/current_replica", async () => {
         const capabilities = getTestCapabilities();
-        const branch = `${capabilities.environment.hostname()}-main`;
-        const remotePath = capabilities.environment.generatorsRepository();
-        const workTree = await capabilities.creator.createTemporaryDirectory();
-        try {
-            await capabilities.git.call("init", "--bare", "--", remotePath);
-            await capabilities.git.call("init", "--initial-branch", branch, "--", workTree);
+        await seedHostnameBranchWithRenderedFiles(capabilities, [
+            { path: "r/values/%7B%22head%22%3A%22event%22%2C%22args%22%3A%5B%22present%22%5D%7D", content: JSON.stringify({ marker: true }) },
+        ]);
 
-            const currentReplicaFile = await capabilities.creator.createFile(
-                path.join(workTree, DATABASE_SUBPATH, "_meta", "current_replica")
-            );
-            await capabilities.writer.writeFile(currentReplicaFile, JSON.stringify("z"));
-
-            await capabilities.git.call("-C", workTree, "add", "--all");
-            await capabilities.git.call(
-                "-C",
-                workTree,
-                "-c",
-                "user.name=volodyslav",
-                "-c",
-                "user.email=volodyslav",
-                "commit",
-                "-m",
-                "seed snapshot without current_replica"
-            );
-            await capabilities.git.call("-C", workTree, "remote", "add", "origin", "--", remotePath);
-            await capabilities.git.call("-C", workTree, "push", "origin", branch);
-
-            let error;
-            try {
-                await synchronizeNoLock(capabilities, { resetToHostname: "test-host" });
-            } catch (caught) {
-                error = caught;
-            }
-            expect(isInvalidSnapshotReplicaError(error)).toBe(true);
-        } finally {
-            await capabilities.deleter.deleteDirectory(workTree);
-        }
+        await expect(
+            synchronizeNoLock(capabilities, { resetToHostname: "test-host" })
+        ).resolves.toBeUndefined();
     });
 
-    test("throws InvalidSnapshotReplicaError for invalid JSON in _meta/current_replica", async () => {
-        const capabilities = getTestCapabilities();
-        const branch = `${capabilities.environment.hostname()}-main`;
-        const remotePath = capabilities.environment.generatorsRepository();
-        const workTree = await capabilities.creator.createTemporaryDirectory();
-        try {
-            await capabilities.git.call("init", "--bare", "--", remotePath);
-            await capabilities.git.call("init", "--initial-branch", branch, "--", workTree);
-
-            const currentReplicaFile = await capabilities.creator.createFile(
-                path.join(workTree, DATABASE_SUBPATH, "_meta", "current_replica")
-            );
-            await capabilities.writer.writeFile(currentReplicaFile, "not-json");
-
-            await capabilities.git.call("-C", workTree, "add", "--all");
-            await capabilities.git.call(
-                "-C",
-                workTree,
-                "-c",
-                "user.name=volodyslav",
-                "-c",
-                "user.email=volodyslav",
-                "commit",
-                "-m",
-                "seed invalid current_replica"
-            );
-            await capabilities.git.call("-C", workTree, "remote", "add", "origin", "--", remotePath);
-            await capabilities.git.call("-C", workTree, "push", "origin", branch);
-
-            let error;
-            try {
-                await synchronizeNoLock(capabilities, { resetToHostname: "test-host" });
-            } catch (caught) {
-                error = caught;
-            }
-            expect(isInvalidSnapshotReplicaError(error)).toBe(true);
-        } finally {
-            await capabilities.deleter.deleteDirectory(workTree);
-        }
-    });
-
-    test("throws InvalidSnapshotReplicaError that clearly reports a missing _meta/current_replica", async () => {
-        const capabilities = getTestCapabilities();
-        const branch = `${capabilities.environment.hostname()}-main`;
-        const remotePath = capabilities.environment.generatorsRepository();
-        const workTree = await capabilities.creator.createTemporaryDirectory();
-        try {
-            await capabilities.git.call("init", "--bare", "--", remotePath);
-            await capabilities.git.call("init", "--initial-branch", branch, "--", workTree);
-            const markerFile = await capabilities.creator.createFile(
-                path.join(workTree, DATABASE_SUBPATH, "r", "placeholder")
-            );
-            await capabilities.writer.writeFile(markerFile, JSON.stringify("placeholder"));
-
-            await capabilities.git.call("-C", workTree, "add", "--all");
-            await capabilities.git.call(
-                "-C",
-                workTree,
-                "-c",
-                "user.name=volodyslav",
-                "-c",
-                "user.email=volodyslav",
-                "commit",
-                "-m",
-                "seed snapshot without current_replica"
-            );
-            await capabilities.git.call("-C", workTree, "remote", "add", "origin", "--", remotePath);
-            await capabilities.git.call("-C", workTree, "push", "origin", branch);
-
-            let error;
-            try {
-                await synchronizeNoLock(capabilities, { resetToHostname: "test-host" });
-            } catch (caught) {
-                error = caught;
-            }
-            expect(isInvalidSnapshotReplicaError(error)).toBe(true);
-            expect(error.message).toContain('Snapshot _meta/current_replica is missing.');
-        } finally {
-            await capabilities.deleter.deleteDirectory(workTree);
-        }
-    });
-
-    test("repeat reset bootstrap failures remain deterministic and do not create live database", async () => {
+    test("repeat reset bootstrap with invalid _meta/current_replica succeeds and keeps live database available", async () => {
         const capabilities = getTestCapabilities();
         const branch = `${capabilities.environment.hostname()}-main`;
         const remotePath = capabilities.environment.generatorsRepository();
@@ -498,8 +385,8 @@ describe("synchronizeNoLock", () => {
             } catch (caught) {
                 firstError = caught;
             }
-            expect(isInvalidSnapshotReplicaError(firstError)).toBe(true);
-            expect(await capabilities.checker.directoryExists(liveDbPath)).toBeNull();
+            expect(firstError).toBeUndefined();
+            expect(await capabilities.checker.directoryExists(liveDbPath)).not.toBeNull();
 
             let secondError;
             try {
@@ -507,9 +394,8 @@ describe("synchronizeNoLock", () => {
             } catch (caught) {
                 secondError = caught;
             }
-            expect(isInvalidSnapshotReplicaError(secondError)).toBe(true);
-            expect(secondError.message).toContain('Snapshot _meta/current_replica has invalid parsed value: "z".');
-            expect(await capabilities.checker.directoryExists(liveDbPath)).toBeNull();
+            expect(secondError).toBeUndefined();
+            expect(await capabilities.checker.directoryExists(liveDbPath)).not.toBeNull();
         } finally {
             await capabilities.deleter.deleteDirectory(workTree);
         }
@@ -517,7 +403,7 @@ describe("synchronizeNoLock", () => {
 
     describe("resetToHostname no-healing scenario matrix", () => {
         /**
-         * @typedef {{ name: string, files: Array<{ path: string, content: string }>, expectedErrorGuard: (error: unknown) => boolean }} ResetFailureScenario
+         * @typedef {{ name: string, files: Array<{ path: string, content: string }>, expectedErrorGuard: (error: unknown) => boolean, createsLiveDatabase: boolean }} ResetFailureScenario
          */
 
         /** @type {ResetFailureScenario[]} */
@@ -527,21 +413,24 @@ describe("synchronizeNoLock", () => {
                 files: [
                     { path: "r/placeholder", content: JSON.stringify("placeholder") },
                 ],
-                expectedErrorGuard: isInvalidSnapshotReplicaError,
+                expectedErrorGuard: (error) => error instanceof Error,
+                createsLiveDatabase: false,
             },
             {
                 name: "invalid JSON in _meta/current_replica",
                 files: [
                     { path: "_meta/current_replica", content: "not-json" },
                 ],
-                expectedErrorGuard: isInvalidSnapshotReplicaError,
+                expectedErrorGuard: (error) => error === undefined,
+                createsLiveDatabase: true,
             },
             {
                 name: "invalid _meta/current_replica value",
                 files: [
                     { path: "_meta/current_replica", content: JSON.stringify("z") },
                 ],
-                expectedErrorGuard: isInvalidSnapshotReplicaError,
+                expectedErrorGuard: (error) => error === undefined,
+                createsLiveDatabase: true,
             },
             {
                 name: "invalid JSON payload in rendered r/ subtree",
@@ -551,14 +440,14 @@ describe("synchronizeNoLock", () => {
                 ],
                 expectedErrorGuard: (error) =>
                     error instanceof Error &&
-                    !isInvalidSnapshotReplicaError(error) &&
                     !isSyncMergeAggregateError(error),
+                createsLiveDatabase: false,
             },
         ];
 
         test.each(scenarios)(
             "does not heal for scenario: $name",
-            async ({ files, expectedErrorGuard }) => {
+            async ({ files, expectedErrorGuard, createsLiveDatabase }) => {
                 const capabilities = getTestCapabilities();
                 const liveDbPath = path.join(
                     capabilities.environment.workingDirectory(),
@@ -575,7 +464,11 @@ describe("synchronizeNoLock", () => {
                 }
 
                 expect(expectedErrorGuard(firstError)).toBe(true);
-                expect(await capabilities.checker.directoryExists(liveDbPath)).toBeNull();
+                if (createsLiveDatabase) {
+                    expect(await capabilities.checker.directoryExists(liveDbPath)).not.toBeNull();
+                } else {
+                    expect(await capabilities.checker.directoryExists(liveDbPath)).toBeNull();
+                }
 
                 let secondError;
                 try {
@@ -585,7 +478,11 @@ describe("synchronizeNoLock", () => {
                 }
 
                 expect(expectedErrorGuard(secondError)).toBe(true);
-                expect(await capabilities.checker.directoryExists(liveDbPath)).toBeNull();
+                if (createsLiveDatabase) {
+                    expect(await capabilities.checker.directoryExists(liveDbPath)).not.toBeNull();
+                } else {
+                    expect(await capabilities.checker.directoryExists(liveDbPath)).toBeNull();
+                }
             }
         );
 


### PR DESCRIPTION
### Motivation
- `checkpointDatabase` now writes only the rendered `r/` subtree, so `_meta/current_replica` is not produced by a normal sync and `resetToHostname` could not be used later because `validateResetSnapshotMetadata` required that file.
- The reset flow must import rendered snapshot data without depending on a metadata file that may be absent.

### Description
- Stop reading and validating `_meta/current_replica` during reset import and remove the `InvalidSnapshotReplicaError` type and its public exports.
- Change `importResetSnapshotIntoDatabase` to always load `rendered/r/**` into replica `x` (delete `x` if missing) and switch the database to replica `x` after import in `synchronize_reset_snapshot.js`.
- Remove now-obsolete imports/exports of `InvalidSnapshotReplicaError` / `isInvalidSnapshotReplicaError` from `synchronize.js` and the public `database` index.
- Update `backend/tests/database_synchronize.test.js` to reflect the new behavior: add success case for snapshots without `_meta/current_replica`, and adjust the scenario-matrix and repeated-reset expectations so missing/invalid `_meta/current_replica` no longer blocks reset imports unless the rendered `r/` payload itself is malformed.

### Testing
- Ran the focused test file with `npm test -- backend/tests/database_synchronize.test.js` and all tests in that suite passed. 
- Updated tests exercise both the new successful-import path when `_meta/current_replica` is absent and failure cases when the `r/` payload is invalid; the updated assertions passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0210b03650832e9989382a60b1e0f8)