### PR TITLE
Use gentle reset snapshot import and remove sublevel delete API

### DIFF
--- a/backend/src/generators/incremental_graph/database/root_database.js
+++ b/backend/src/generators/incremental_graph/database/root_database.js
@@ -501,21 +501,6 @@ class RootDatabaseClass {
     }
 
     /**
-     * This is equivalent to iterating every key with the `!<sublevelName>!` prefix
-     * and deleting them, but delegates to abstract-level's `sublevel.clear()` so
-     * the operation is handled in a single efficient range-delete rather than a
-     * chunked batch.
-     *
-     * @param {string} sublevelName - Top-level sublevel name (e.g. "x", "_meta").
-     * @returns {Promise<void>}
-     */
-    async _rawDeleteSublevel(sublevelName) {
-        /** @type {SchemaSublevelType} */
-        const sublevel = this.db.sublevel(sublevelName, { valueEncoding: 'json' });
-        await sublevel.clear();
-    }
-
-    /**
      * Iterates over all raw key/value pairs belonging to one top-level LevelDB
      * sublevel.  Unlike `_rawEntries()`, this method only reads the requested
      * sublevel (via abstract-level's built-in range scoping) instead of scanning

--- a/backend/src/generators/incremental_graph/database/synchronize_reset_snapshot.js
+++ b/backend/src/generators/incremental_graph/database/synchronize_reset_snapshot.js
@@ -22,16 +22,21 @@ async function importResetSnapshotIntoDatabase(capabilities, database, workTree)
     const rDir = path.join(snapshotRoot, 'r');
     const nextReplica = database.otherReplicaName();
 
-    if (await capabilities.checker.directoryExists(rDir)) {
-        await scanFromFilesystem(
-            capabilities,
-            database,
-            rDir,
-            nextReplica
-        );
-    } else {
-        await database._rawDeleteSublevel(nextReplica);
+    const hasSnapshotReplicaDirectory = await capabilities.checker.directoryExists(rDir);
+    const importDirectory = hasSnapshotReplicaDirectory
+        ? rDir
+        : path.join(workTree, DATABASE_SUBPATH, '_empty_reset_snapshot');
+
+    if (!hasSnapshotReplicaDirectory) {
+        await capabilities.creator.createDirectory(importDirectory);
     }
+
+    await scanFromFilesystem(
+        capabilities,
+        database,
+        importDirectory,
+        nextReplica
+    );
 
     await database.switchToReplica(nextReplica);
 }


### PR DESCRIPTION
### Motivation
- Ensure the reset-to-hostname code path performs a gentle unification (via the FS→DB unification flow) instead of directly clearing LevelDB sublevels. 
- Remove a private database API that allowed callers to bypass unification and perform a direct sublevel clear. 

### Description
- Deleted the `_rawDeleteSublevel` method from `RootDatabaseClass` to eliminate the direct sublevel-clear API. 
- Updated `importResetSnapshotIntoDatabase` in `synchronize_reset_snapshot.js` to always call `scanFromFilesystem` for the target replica, and to create an `_empty_reset_snapshot` directory when the snapshot `r/` directory is absent. 
- When `r/` is missing the code now creates the empty import directory with `capabilities.creator.createDirectory(...)` and runs the same `scanFromFilesystem` unification used for non-empty snapshots. 
- This keeps reset logic unified and prevents callers from bypassing the unification adapters. 

### Testing
- Ran `npm install` which completed successfully. 
- Ran the focused interface tests with `npx jest backend/tests/interface.test.js --runInBand --testTimeout=30000` and the suite passed. 
- Ran targeted suites `npx jest backend/tests/working_repository.reset_mode.test.js backend/tests/generators_repository_setup.test.js --runInBand` and they passed. 
- Ran `npm run static-analysis` (TypeScript + ESLint) and `npm run build` and both completed successfully. 
- Note: an initial parallel `npm test` run showed timeouts in default parallel execution; focused in-band test runs were used to validate the modified code paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a021dfc31fc832e93476e752f98dfff)