### PR TITLE
Log Volodyslav version during server boot

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -18,6 +18,7 @@ const diarySummaryRouter = routes.diarySummary;
 const expressApp = require("./express_app");
 const { scheduleAll, ensureDailyTasksAvailable } = require("./jobs");
 const { getBasePath } = require("./base_path");
+const runtimeIdentifier = require("./runtime_identifier");
 
 /** @typedef {import('./filesystem/deleter').FileDeleter} FileDeleter */
 /** @typedef {import('./random/seed').NonDeterministicSeed} NonDeterministicSeed */
@@ -130,6 +131,8 @@ function addressToString(address) {
  */
 async function startWithCapabilities(capabilities) {
     await capabilities.logger.setup();
+    const { version } = await runtimeIdentifier(capabilities);
+    capabilities.logger.logInfo({ version }, `Volodyslav version: ${version}`);
     const app = expressApp.make();
     // The following line is commented out because HTTP call logging is too verbose by default.
     // TODO: configure a better logging strategy for HTTP calls.


### PR DESCRIPTION
### Motivation
- Print the application version immediately after the logger is initialized to improve boot-time observability and make debugging startup issues easier.

### Description
- Import `runtime_identifier` in `backend/src/server.js` and call it right after `await capabilities.logger.setup()` to obtain `version` and log it with `capabilities.logger.logInfo({ version }, `Volodyslav version: ${version}`)` before creating the Express app.

### Testing
- Ran `npx jest backend/tests/cli.test.js --runInBand`, which passed (1 test suite, 2 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a023e93f954832e9f19aa97e940f9a8)