### PR TITLE
Log Volodyslav version immediately after logger setup

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -16,6 +16,7 @@ const assetsRouter = routes.assets;
 const audioRecordingSessionRouter = routes.audioRecordingSession;
 const diarySummaryRouter = routes.diarySummary;
 const expressApp = require("./express_app");
+const { getVersion } = require("./version");
 const { scheduleAll, ensureDailyTasksAvailable } = require("./jobs");
 const { getBasePath } = require("./base_path");
 
@@ -130,6 +131,8 @@ function addressToString(address) {
  */
 async function startWithCapabilities(capabilities) {
     await capabilities.logger.setup();
+    const volodyslavVersion = await getVersion(capabilities);
+    capabilities.logger.logInfo({ version: volodyslavVersion }, `Volodyslav version: ${volodyslavVersion}`);
     const app = expressApp.make();
     // The following line is commented out because HTTP call logging is too verbose by default.
     // TODO: configure a better logging strategy for HTTP calls.

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -131,8 +131,8 @@ function addressToString(address) {
  */
 async function startWithCapabilities(capabilities) {
     await capabilities.logger.setup();
-    const volodyslavVersion = await getVersion(capabilities);
-    capabilities.logger.logInfo({ version: volodyslavVersion }, `Volodyslav version: ${volodyslavVersion}`);
+    const version = await getVersion(capabilities);
+    capabilities.logger.logInfo({ version }, `Volodyslav version: ${version}`);
     const app = expressApp.make();
     // The following line is commented out because HTTP call logging is too verbose by default.
     // TODO: configure a better logging strategy for HTTP calls.


### PR DESCRIPTION
### Motivation
- Ensure the application prints the current Volodyslav version to the project logger at boot right after the logger is initialized for easier diagnostics and monitoring.

### Description
- Import `getVersion` and call it in `startWithCapabilities` immediately after `await capabilities.logger.setup()`, then log the resolved version via `capabilities.logger.logInfo` before creating the Express app.

### Testing
- Ran `npm run build` which completed successfully; `npm test -- --runInBand` was started but did not complete within the session, so full test-suite status could not be confirmed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a023e93f954832e9f19aa97e940f9a8)