### PR TITLE
Add diagnostics for incremental-graph boot, migration, and sync decisions

### DIFF
--- a/backend/src/generators/incremental_graph/database/synchronize.js
+++ b/backend/src/generators/incremental_graph/database/synchronize.js
@@ -209,9 +209,11 @@ async function mergeRemoteHostBranches(capabilities, rootDatabase) {
  */
 async function synchronizeNoLock(capabilities, options) {
     const remotePath = capabilities.environment.generatorsRepository();
+    capabilities.logger.logDebug({ remotePath, options }, 'Sync: starting synchronizeNoLock');
     const remoteLocation = { url: remotePath };
 
     if (options?.resetToHostname !== undefined) {
+        capabilities.logger.logDebug({ resetToHostname: options.resetToHostname }, 'Sync: reset-to-hostname mode selected');
         await workingRepository.synchronize(
             capabilities,
             CHECKPOINT_WORKING_PATH,
@@ -225,6 +227,8 @@ async function synchronizeNoLock(capabilities, options) {
         );
         return;
     }
+
+    capabilities.logger.logDebug({}, 'Sync: normal mode selected (checkpoint + merge path)');
 
     /** @type {RootDatabase | undefined} */
     let rootDatabase;

--- a/backend/src/generators/incremental_graph/migration_runner.js
+++ b/backend/src/generators/incremental_graph/migration_runner.js
@@ -324,19 +324,45 @@ async function runMigration(capabilities, rootDatabase, nodeDefs, callback) {
  */
 async function runMigrationUnsafe(capabilities, rootDatabase, nodeDefs, callback)
 {
+    const currentVersion = rootDatabase.version;
+    const activeReplica = rootDatabase.currentReplicaName();
+    const inactiveReplica = rootDatabase.otherReplicaName();
+
+    capabilities.logger.logDebug(
+        {
+            currentVersion,
+            activeReplica,
+            inactiveReplica,
+            nodeDefinitionCount: nodeDefs.length,
+        },
+        'Migration check: evaluating whether migration is required'
+    );
+
     /** @type {Version | undefined} */
     const prevVersion = await rootDatabase.getGlobalVersion();
     if (prevVersion === undefined) {
+        capabilities.logger.logDebug(
+            { currentVersion, activeReplica },
+            'Migration not required: no stored version found in active replica; marking fresh database with current version'
+        );
         // No previous version recorded; fresh database: record current version, nothing to migrate.
         await rootDatabase.setGlobalVersion(rootDatabase.version);
         return;
     }
 
-    const currentVersion = rootDatabase.version;
     if (prevVersion === currentVersion) {
+        capabilities.logger.logDebug(
+            { prevVersion, currentVersion, activeReplica },
+            'Migration not required: stored version already matches current application version'
+        );
         // Already on the current version.
         return;
     }
+
+    capabilities.logger.logDebug(
+        { prevVersion, currentVersion, fromReplica: activeReplica, toReplica: inactiveReplica },
+        'Migration required: stored version differs from current version; preparing replica cutover migration'
+    );
 
     capabilities.logger.logInfo({
         prevVersion, currentVersion

--- a/backend/src/generators/interface/lifecycle.js
+++ b/backend/src/generators/interface/lifecycle.js
@@ -207,6 +207,7 @@ async function internalEnsureInitializedWithMigration(
     }
 
     const capabilities = interfaceInstance._getCapabilities();
+    capabilities.logger.logDebug({}, 'Initialization: opening root database for graph lifecycle');
     const database = await getRootDatabase(capabilities);
     const configBox = config.makeBox();
     const allEventsBox = allEvents.makeBox();
@@ -220,12 +221,14 @@ async function internalEnsureInitializedWithMigration(
         ontologyBox
     );
     try {
+        capabilities.logger.logDebug({}, 'Initialization: running migration gate before graph construction');
         await runMigrationProcedure(
             capabilities,
             database,
             nodeDefs,
             migrationCallback(capabilities),
         );
+        capabilities.logger.logDebug({}, 'Initialization: migration gate completed, constructing incremental graph');
         const incrementalGraph = makeIncrementalGraph(
             capabilities,
             database,
@@ -268,6 +271,7 @@ async function internalSynchronizeDatabase(interfaceInstance, options) {
  */
 async function internalSynchronizeDatabaseNoLock(interfaceInstance, options) {
     const capabilities = interfaceInstance._getCapabilities();
+    capabilities.logger.logDebug({ options }, 'Synchronize: entering no-lock synchronization path');
     const database = interfaceInstance._database;
     const incrementalGraph = interfaceInstance._incrementalGraph;
     const allEventsBox = interfaceInstance._allEventsBox;
@@ -275,6 +279,7 @@ async function internalSynchronizeDatabaseNoLock(interfaceInstance, options) {
     const diarySummaryBox = interfaceInstance._diarySummaryBox;
     const ontologyBox = interfaceInstance._ontologyBox;
     if (database === null) {
+        capabilities.logger.logDebug({ options }, 'Synchronize: interface database is not open; synchronizing directly');
         await synchronizeNoLock(capabilities, options);
         return;
     }
@@ -287,6 +292,7 @@ async function internalSynchronizeDatabaseNoLock(interfaceInstance, options) {
     interfaceInstance._ontologyBox = null;
 
     try {
+        capabilities.logger.logDebug({ options }, 'Synchronize: closing currently opened database before sync/reset');
         await database.close();
     } catch (error) {
         interfaceInstance._database = database;
@@ -301,6 +307,7 @@ async function internalSynchronizeDatabaseNoLock(interfaceInstance, options) {
     let synchronizeFailure = null;
 
     try {
+        capabilities.logger.logDebug({ options }, 'Synchronize: running synchronizeNoLock');
         await synchronizeNoLock(capabilities, options);
     } catch (error) {
         synchronizeFailure = error;
@@ -308,6 +315,7 @@ async function internalSynchronizeDatabaseNoLock(interfaceInstance, options) {
 
     let reopenFailure = null;
     try {
+        capabilities.logger.logDebug({ options }, 'Synchronize: reopening interface and re-running migration gate after sync/reset');
         await internalEnsureInitializedWithMigration(
             interfaceInstance,
             runMigrationUnsafe


### PR DESCRIPTION
### Motivation
- Make startup, migration, and sync behavior observable so a system admin can understand why a migration ran or was skipped and which sync path (reset vs normal) was chosen.
- Provide contextual information (replica names, stored vs current version, migration rationale) to aid debugging of replica cutover and bootstrap flows.

### Description
- Added debug logging in `runMigrationUnsafe` to record `currentVersion`, active/inactive replica names, `nodeDefinitionCount`, and explicit reasons for skipping or running a migration (fresh DB / version match / version mismatch).  (`backend/src/generators/incremental_graph/migration_runner.js`)
- Added lifecycle debug markers around opening the root DB, running the migration gate, and constructing the incremental graph to clarify boot sequencing. (`backend/src/generators/interface/lifecycle.js`)
- Added debug logs in the synchronize path to record a top-level start, to distinguish `reset-to-hostname` mode from the normal checkpoint+merge path, and to mark the close/sync/reopen phases during `internalSynchronizeDatabaseNoLock`. (`backend/src/generators/incremental_graph/database/synchronize.js`, `backend/src/generators/interface/lifecycle.js`)

### Testing
- Ran the focused test suites with `npm test -- --runTestsByPath backend/tests/migration_runner_timestamps.test.js backend/tests/interface.test.js`, and both test suites passed.
- Verified the frontend build with `npm run build`, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a025505d068832ea4152f87b76e92e6)