### PR TITLE
Add migration/sync boot diagnostics for IncrementalGraph database decisions

### DIFF
--- a/backend/src/generators/incremental_graph/database/synchronize.js
+++ b/backend/src/generators/incremental_graph/database/synchronize.js
@@ -210,8 +210,13 @@ async function mergeRemoteHostBranches(capabilities, rootDatabase) {
 async function synchronizeNoLock(capabilities, options) {
     const remotePath = capabilities.environment.generatorsRepository();
     const remoteLocation = { url: remotePath };
+    const resetToHostname = options?.resetToHostname;
 
-    if (options?.resetToHostname !== undefined) {
+    if (resetToHostname !== undefined) {
+        capabilities.logger.logDebug(
+            { remotePath, resetToHostname },
+            'Synchronization mode: reset-to-hostname path selected'
+        );
         await workingRepository.synchronize(
             capabilities,
             CHECKPOINT_WORKING_PATH,
@@ -225,6 +230,11 @@ async function synchronizeNoLock(capabilities, options) {
         );
         return;
     }
+
+    capabilities.logger.logDebug(
+        { remotePath },
+        'Synchronization mode: standard merge path selected'
+    );
 
     /** @type {RootDatabase | undefined} */
     let rootDatabase;

--- a/backend/src/generators/incremental_graph/migration_runner.js
+++ b/backend/src/generators/incremental_graph/migration_runner.js
@@ -326,17 +326,41 @@ async function runMigrationUnsafe(capabilities, rootDatabase, nodeDefs, callback
 {
     /** @type {Version | undefined} */
     const prevVersion = await rootDatabase.getGlobalVersion();
+    const currentVersion = rootDatabase.version;
+    const activeReplica = rootDatabase.currentReplicaName();
+
+    capabilities.logger.logDebug(
+        {
+            prevVersion: prevVersion === undefined ? null : prevVersion,
+            currentVersion,
+            activeReplica,
+        },
+        'Migration check: evaluated database version state before startup migration decision'
+    );
+
     if (prevVersion === undefined) {
         // No previous version recorded; fresh database: record current version, nothing to migrate.
+        capabilities.logger.logDebug(
+            { currentVersion, activeReplica },
+            'Migration not initiated: no stored replica version found (fresh or reset database), recording current version only'
+        );
         await rootDatabase.setGlobalVersion(rootDatabase.version);
         return;
     }
 
-    const currentVersion = rootDatabase.version;
     if (prevVersion === currentVersion) {
         // Already on the current version.
+        capabilities.logger.logDebug(
+            { prevVersion, currentVersion, activeReplica },
+            'Migration not initiated: stored replica version already matches the running application version'
+        );
         return;
     }
+
+    capabilities.logger.logDebug(
+        { prevVersion, currentVersion, activeReplica },
+        'Migration initiated: stored replica version differs from running application version'
+    );
 
     capabilities.logger.logInfo({
         prevVersion, currentVersion
@@ -350,6 +374,11 @@ async function runMigrationUnsafe(capabilities, rootDatabase, nodeDefs, callback
         async () => {
             const fromReplica = rootDatabase.currentReplicaName();
             const toReplica = rootDatabase.otherReplicaName();
+
+            capabilities.logger.logDebug(
+                { fromReplica, toReplica },
+                'Migration execution: prepared source and target replicas for two-phase migration'
+            );
 
             const prevStorage = rootDatabase.schemaStorageForReplica(fromReplica);
 
@@ -373,6 +402,11 @@ async function runMigrationUnsafe(capabilities, rootDatabase, nodeDefs, callback
 
             // Finalize: propagate deletes, check fan-in, check completeness.
             const decisions = await migrationStorage.finalize();
+
+            capabilities.logger.logDebug(
+                { decisionCount: decisions.size },
+                'Migration execution: callback decisions finalized'
+            );
 
             const toStorage = rootDatabase.schemaStorageForReplica(toReplica);
 

--- a/backend/src/generators/interface/lifecycle.js
+++ b/backend/src/generators/interface/lifecycle.js
@@ -219,6 +219,10 @@ async function internalEnsureInitializedWithMigration(
         diarySummaryBox,
         ontologyBox
     );
+    capabilities.logger.logDebug(
+        { nodeDefinitions: nodeDefs.length },
+        'Startup: created graph definition; evaluating migration requirements before graph initialization'
+    );
     try {
         await runMigrationProcedure(
             capabilities,
@@ -274,6 +278,10 @@ async function internalSynchronizeDatabaseNoLock(interfaceInstance, options) {
     const configBox = interfaceInstance._configBox;
     const diarySummaryBox = interfaceInstance._diarySummaryBox;
     const ontologyBox = interfaceInstance._ontologyBox;
+    capabilities.logger.logDebug(
+        { hasOpenDatabase: database !== null, options: options ?? null },
+        'Sync/reset request: entering synchronizeDatabaseNoLock'
+    );
     if (database === null) {
         await synchronizeNoLock(capabilities, options);
         return;


### PR DESCRIPTION
### Motivation
- Improve observability of the IncrementalGraph boot and synchronization sequence by adding diagnostics that explain why a migration was started (or skipped) and which sync path was chosen.

### Description
- Add debug-level logging in `runMigrationUnsafe` to record `prevVersion`, `currentVersion`, and the active replica and to explain why migration is not initiated (fresh DB or already up-to-date) or why it is initiated (version mismatch).  (file: `backend/src/generators/incremental_graph/migration_runner.js`)
- Log replica names (`fromReplica`, `toReplica`) and the finalized migration decision count after the migration callback completes to aid post-mortem and troubleshooting of the two-phase migration.  (file: `backend/src/generators/incremental_graph/migration_runner.js`)
- Add startup debug log in the lifecycle before evaluating migration requirements to report the computed graph definition size.  (file: `backend/src/generators/interface/lifecycle.js`)
- Add entry debug logging to the synchronize path to distinguish the `reset-to-hostname` flow from the standard merge flow and log whether a DB was open when a sync/reset request arrives.  (files: `backend/src/generators/incremental_graph/database/synchronize.js`, `backend/src/generators/interface/lifecycle.js`)

### Testing
- Ran `npm install` successfully to prepare the environment. 
- Ran `npx jest backend/tests/migration_runner_timestamps.test.js --runInBand` and all tests in that suite passed. 
- Ran `npm run build` and the frontend build completed successfully. 
- A full `npm test` and `npm run static-analysis` were attempted but were long-running in this session and did not produce a final completion status here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a025505d068832ea4152f87b76e92e6)