### PR TITLE
docs: tighten migration plan around storage-level identifier port

### DIFF
--- a/docs/plan1.md
+++ b/docs/plan1.md
@@ -58,6 +58,7 @@ state and graph-to-graph references to `NodeIdentifier`.
 Replace (not preserve) the current `NodeKey`-addressed migration callback surface with a fully `NodeIdentifier`-addressed one, while keeping identifier stability where required by the design.
 
 - [ ] Update migration code so **all migration callbacks and migration-internal graph references** are `NodeIdentifier`-based (no `NodeKey`-addressed migration inputs/outputs anywhere)
+  - [ ] Port `migration_storage.js` helpers and decision signatures to identifiers end-to-end (`readInputsRecord`, `readDependents`, `Decision` callback params, and `materializedNodes/decisions` collections). Leaving any of these as `NodeKeyString` will silently keep `inputs`/`revdeps` and propagation logic key-addressed even after callback APIs are switched.
   - [ ] Keep migration decisions (`keep`/`delete`/`override`/`invalidate`/`create`) `NodeIdentifier`-addressed, but add an explicit lookup helper for callbacks that need schema/head-based selection (current `migration.js` does `deserializeNodeKey(nodeKey).head` in `keepNodeType`/`deleteNodeType`). Without this helper, porting the existing migration callback will either break head-based filtering or incorrectly reintroduce `NodeKey`-addressed decision APIs.
 - [ ] Preserve node identifiers across `keep`, `override`, and `invalidate` migration decisions
 - [ ] Allocate fresh identifiers for migration `create`


### PR DESCRIPTION
### Motivation
- Prevent a subtle mixed-mode migration bug by calling out that `migration_storage.js` internals must be ported end-to-end from `NodeKeyString` to `NodeIdentifier`, since the existing migration storage helpers and decision maps are currently key-addressed and would silently preserve key-based propagation if left unchanged (`readInputsRecord`, `readDependents`, `Decision` signatures, `materializedNodes`, `decisions`).

### Description
- Added a single focused checklist item to `docs/plan1.md` (Section 4, Migration behavior) requiring that `migration_storage.js` helpers and decision signatures be ported to identifiers end-to-end so migration internals do not remain `NodeKeyString`-typed and key-addressed.

### Testing
- No unit or integration tests were modified or added as this is a documentation-only change; repository validations performed: verified `docs/specs/keys-design.md` exists and inspected `backend/src/generators/incremental_graph/migration_storage.js` to confirm the presence of `NodeKeyString`-typed helpers that motivated the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0501316988832eae9359db4da0ac14)