### PR TITLE
docs: require migrating identifiers map during replica cutover

### DIFF
--- a/docs/plan1.md
+++ b/docs/plan1.md
@@ -69,6 +69,11 @@ Replace (not preserve) the current `NodeKey`-addressed migration callback surfac
 - [ ] Preserve node identifiers across `keep`, `override`, and `invalidate` migration decisions
 - [ ] Allocate fresh identifiers for migration `create`
 - [ ] Remove both lookup entries and all identifier-keyed state for migration `delete`
+- [ ] Update migration replication source/unification so identifier lookup metadata is copied during cutover, not just graph-state sublevels.
+  - [ ] `migration_runner.js` currently builds a lazy source whose `global.keys()` yields only `version`; after introducing `identifiers_keys_map`, that source must also expose the lookup-map key or cutover to the inactive replica will drop all `NodeIdentifier ↔ NodeKey` metadata.
+  - [ ] Ensure the migration source can return both global entries (`version` and `identifiers_keys_map`) in a deterministic order, and that `db_to_db` unification writes both keys into the destination replica before pointer switch.
+  - [ ] Add a migration-runner regression test that executes a migration using the lazy source path, switches replicas, and asserts the destination replica still has a readable `identifiers_keys_map` entry plus graph-state keys that reference those identifiers.
+  - [ ] Add a negative-path test that would fail with the old behavior (global source exposing only `version`): destination replica contains identifier-keyed `inputs`/`revdeps` but missing `identifiers_keys_map`; assert this is rejected/fails fast.
 
 Then, write a single migration that will migrate the database from `NodeKey`-based storage to `NodeIdentifier`-based one.
 This requires changing the existing migration API for all future migrations so the migration surface is consistently `NodeIdentifier`-based; do not keep a mixed `NodeKey`/`NodeIdentifier` migration mode, even temporarily.


### PR DESCRIPTION
### Motivation
- Prevent a real cutover bug where a lazy migration source exposes only `version` and the destination replica receives identifier-keyed `inputs`/`revdeps` but not the `identifiers_keys_map` needed to decode them. 
- This risk is concrete because `migration_runner.js` builds a lazy source that currently yields only `version` and `db_to_db` unification copies whatever global keys the source exposes. 

### Description
- Edited `docs/plan1.md` to add a focused checklist item requiring the migration lazy source/unification to include `identifiers_keys_map` in `global` so identifier lookup metadata is preserved during replica cutover. 
- Added sub-bullets requiring deterministic emission/order of `version` and `identifiers_keys_map`, a positive migration-runner regression test, and a negative-path test that would have failed under the old behavior. 
- The change is documentation-only and does not modify production code or tests.

### Testing
- Ran repository validation commands: verified `docs/specs/keys-design.md` exists (`test -f`), searched relevant code (`rg`), inspected `docs/plan1.md` (`sed`), reviewed diffs (`git diff`), and committed the change (`git commit`), all of which succeeded. 
- No automated unit/integration test suite was executed as part of this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a050c50d8e8832e93a077632e4e265f)