### PR TITLE
docs: preserve identifiers_keys_map during migration

### DIFF
--- a/docs/plan1.md
+++ b/docs/plan1.md
@@ -66,6 +66,12 @@ Replace (not preserve) the current `NodeKey`-addressed migration callback surfac
 - [ ] Update migration code so **all migration callbacks and migration-internal graph references** are `NodeIdentifier`-based (no `NodeKey`-addressed migration inputs/outputs anywhere)
   - [ ] Port `migration_storage.js` helpers and decision signatures to identifiers end-to-end (`readInputsRecord`, `readDependents`, `Decision` callback params, and `materializedNodes/decisions` collections). Leaving any of these as `NodeKeyString` will silently keep `inputs`/`revdeps` and propagation logic key-addressed even after callback APIs are switched.
   - [ ] Keep migration decisions (`keep`/`delete`/`override`/`invalidate`/`create`) `NodeIdentifier`-addressed, but add an explicit lookup helper for callbacks that need schema/head-based selection (current `migration.js` does `deserializeNodeKey(nodeKey).head` in `keepNodeType`/`deleteNodeType`). Without this helper, porting the existing migration callback will either break head-based filtering or incorrectly reintroduce `NodeKey`-addressed decision APIs.
+  - [ ] Preserve global lookup metadata during migration-source projection, not only `global/version`.
+    - Current `migration_runner.js` lazy source hardcodes `global.keys()` to yield only `version`; if left unchanged, `unifyStores` will delete `/${inactive_replica}/global/identifiers_keys_map` during migration because it is absent from the source view.
+    - Update lazy migration source global handling to pass through all required global keys, including `identifiers_keys_map`, while still overriding `version` to the target app version.
+    - Ensure copy semantics are explicit: non-version global keys should come from previous storage unless migration logic intentionally rewrites them.
+    - Add a regression test that seeds previous replica `global` with both `version` and `identifiers_keys_map`, runs migration, and asserts the inactive replica retains the identifiers map after unify + cutover.
+    - Add a regression test that runs migration where callbacks do not touch lookup metadata and verifies no accidental deletion of `identifiers_keys_map` occurs.
 - [ ] Preserve node identifiers across `keep`, `override`, and `invalidate` migration decisions
 - [ ] Allocate fresh identifiers for migration `create`
 - [ ] Remove both lookup entries and all identifier-keyed state for migration `delete`


### PR DESCRIPTION
### Motivation
- The migration lazy source currently exposes only `global/version`, which risks `unifyStores` deleting other global keys such as `identifiers_keys_map` during replica cutover. 
- Preserving the `NodeKey ↔ NodeIdentifier` lookup map across migration is necessary to avoid silently breaking identifier-based storage and post-migration graph functionality.

### Description
- Edited `docs/plan1.md` to add a focused checklist item under the Migration behavior section requiring migration-source projection to preserve `/${current_replica}/global/identifiers_keys_map` in addition to `version`.
- The new checklist explicitly calls out updating the lazy migration source in `migration_runner.js` to pass through required global keys (including `identifiers_keys_map`) while still overriding `version`, enforcing explicit copy semantics for non-version global keys, and adding two regression tests that assert the identifier map survives unify + cutover and is not deleted when callbacks do not touch it.
- This change is documentation-only and references the concrete implementation targets to make the risk and required fixes unambiguous (`migration_runner.js`, `db_to_db.js`, and the `global` sublevel handling).

### Testing
- No automated unit/integration tests were run because this is a documentation-only change; repository inspections and file reads were performed to validate the referenced code paths and design document exist.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a050c50d8e8832e93a077632e4e265f)