### PR TITLE
docs: harden plan for identifier-based HTTP routes

### DIFF
--- a/docs/plan1.md
+++ b/docs/plan1.md
@@ -86,7 +86,12 @@ identifier-addressed storage model directly.
 
 - [ ] Change the HTTP inspection API so concrete-node operations address nodes by `NodeIdentifier`, not by `head/args`
 - [ ] Update the HTTP graph API spec, route shapes, handlers, and tests to the identifier-based concrete-node model
-  - [ ] Replace concrete-node `head/args` routes (`/graph/nodes/:head`, `/graph/nodes/:head/*` and the matching POST/DELETE handlers) with identifier-addressed concrete-node routes so handlers no longer parse concrete args from URL path segments. Keep `/graph/schemas` endpoints head-based.
+  - [ ] Replace concrete-node `head/args` routes (`/graph/nodes/:head`, `/graph/nodes/:head/*` and the matching POST/DELETE handlers) with identifier-addressed concrete-node routes, and remove all URL-arg decoding logic tied to concrete-node addressing.
+    - Current handlers rely on wildcard path parsing (`req.params[0]`) plus `getArgsFromRequest()` in `backend/src/routes/graph_helpers.js` to recover `ConstValue[]` from URL segments (including encoded `/` and `~`-prefixed non-strings). If this helper path is left in place after route migration, identifier endpoints can accidentally continue treating identifiers as split arg vectors or apply JSON-ish decoding to IDs.
+    - Define explicit concrete-node routes that take one opaque identifier segment (for example `GET/POST/DELETE /graph/nodes/id/:nodeIdentifier`) and ensure handlers call identifier-based interface methods directly rather than reconstructing `(head, args)` from the URL.
+    - Keep schema endpoints head-based (`/graph/schemas`, `/graph/schemas/:head`) and do not route them through identifier parsing.
+    - Update route registration order/comments in `backend/src/routes/graph.js`: wildcard-first ordering is currently required only for `:head/*`; once identifier routes are used, preserve only the ordering constraints that still apply.
+    - Replace route tests that currently assert head/args parsing behavior (including encoded slash and `~` decoding cases) with identifier-focused tests that assert identifiers are passed through as opaque strings and never decoded as `ConstValue` arguments.
 - [ ] Keep the schema-oriented HTTP endpoints aligned with the public graph model where they are still head-based rather than concrete-node based
 
 ## 6. Filesystem snapshot simplification


### PR DESCRIPTION
### Motivation
- The plan's HTTP migration item was underspecified and could allow legacy wildcard `head/args` decoding to persist, which would cause opaque `NodeIdentifier` values to be accidentally split or JSON-decoded by existing helpers.
- The repository currently implements wildcard path parsing and URL-arg decoding in `backend/src/routes/graph.js` and `backend/src/routes/graph_helpers.js`, so a partial route rename without removing that logic is a realistic source of silent bugs.

### Description
- Updated `docs/plan1.md` (Section 5) to replace the simple "replace routes" bullet with a detailed requirement to remove URL-arg decoding tied to concrete-node addressing and to define explicit identifier-opaque routes (examples and handler expectations included).
- The new text calls out the specific risky helpers (`req.params[0]`, `getArgsFromRequest()`), requires a single opaque identifier route (e.g. `GET/POST/DELETE /graph/nodes/id/:nodeIdentifier`), and mandates corresponding test updates and route-ordering comments in `backend/src/routes/graph.js`.
- This is a documentation-only change intended to prevent an implementation mistake; no production code was modified.

### Testing
- No automated unit or integration tests were executed because this is a docs-only change; the change does not modify runtime behavior.
- I validated repository references and context by reading `docs/specs/keys-design.md`, `backend/src/routes/graph.js`, `backend/src/routes/graph_helpers.js`, and related tests under `backend/tests/graph_routes.test.js`, and committed the updated `docs/plan1.md` successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06179a638c832eb801a51a68bee24c)