### PR TITLE
docs(plan1): require identifier-addressed HTTP response payloads

### DIFF
--- a/docs/plan1.md
+++ b/docs/plan1.md
@@ -97,6 +97,12 @@ identifier-addressed storage model directly.
     - Keep schema endpoints head-based (`/graph/schemas`, `/graph/schemas/:head`) and do not route them through identifier parsing.
     - Update route registration order/comments in `backend/src/routes/graph.js`: wildcard-first ordering is currently required only for `:head/*`; once identifier routes are used, preserve only the ordering constraints that still apply.
     - Replace route tests that currently assert head/args parsing behavior (including encoded slash and `~` decoding cases) with identifier-focused tests that assert identifiers are passed through as opaque strings and never decoded as `ConstValue` arguments.
+  - [ ] Update list/read response payloads so concrete-node records returned by HTTP inspection are identifier-addressed, not `(head,args)`-addressed.
+    - Current `GET /graph/nodes` and `GET /graph/nodes/:head` handlers in `backend/src/routes/graph.js` enumerate materialized nodes from `interface.listMaterializedNodes()` and emit `{ head, args, freshness, ... }` objects. After route migration, this payload shape leaves clients unable to call identifier-addressed pull/delete/invalidate endpoints without recomputing keys.
+    - Introduce interface/inspection methods that can enumerate concrete nodes by `NodeIdentifier` (with freshness/value/timestamps), and have HTTP handlers read from those methods directly instead of re-keying from `(head,args)`.
+    - Keep any schema-oriented responses head-based, but require concrete-node response objects (lists and single-node reads) to carry `nodeIdentifier` as the addressing field used by follow-up concrete-node operations.
+    - Update `backend/tests/graph_routes.test.js` assertions to reject legacy concrete-node payloads that omit `nodeIdentifier` and to verify round-trip workflow (`list` → `GET/POST/DELETE by id`) without any `head/args` URL construction.
+    - Add at least one regression test for encoded-looking identifiers (for example containing `%2F` as literal characters) to prove response-to-route flow treats identifiers as opaque and never applies argument-decoding semantics.
 - [ ] Keep the schema-oriented HTTP endpoints aligned with the public graph model where they are still head-based rather than concrete-node based
 
 ## 6. Filesystem snapshot simplification


### PR DESCRIPTION
### Motivation
- Prevent a migration-time API mismatch where routes are changed to `GET/POST/DELETE /graph/nodes/id/:nodeIdentifier` but listing/read endpoints still return `{ head, args }`, which would force clients to re-derive `NodeIdentifier` from `(head,args)` and break round-trip workflows; the current handlers in `backend/src/routes/graph.js` show this risk.  

### Description
- Updated `docs/plan1.md` (HTTP inspection API section) to require concrete-node list/read responses to be identifier-addressed (include `nodeIdentifier`) and to add concrete implementation/testing guidance pointing at `backend/src/routes/graph.js`, `backend/src/routes/graph_helpers.js`, and `backend/tests/graph_routes.test.js` so handlers and tests are changed together.  

### Testing
- No runtime/unit tests were executed because this is a documentation-only change, and the edit was validated by inspecting the affected files and related code paths (`docs/plan1.md`, `backend/src/routes/graph.js`, `backend/src/routes/graph_helpers.js`, `backend/src/generators/incremental_graph/*`, and `backend/tests/graph_routes.test.js`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06552672d4832e89cd55eb807510fc)