### PR TITLE
Split global sublevel keys from NodeKeyString typing

### DIFF
--- a/backend/src/generators/incremental_graph/database/hostname_storage.js
+++ b/backend/src/generators/incremental_graph/database/hostname_storage.js
@@ -100,7 +100,7 @@ function buildBareSchemaStorage(namespaceSublevel) {
     const countersSublevel = namespaceSublevel.sublevel('counters', { valueEncoding: 'json' });
     /** @type {SimpleSublevel<TimestampRecord>} */
     const timestampsSublevel = namespaceSublevel.sublevel('timestamps', { valueEncoding: 'json' });
-    /** @type {SimpleSublevel<Version>} */
+    /** @type {import('abstract-level').AbstractSublevel<SchemaSublevelType, import('./types').SublevelFormat, string, Version>} */
     const globalSublevel = namespaceSublevel.sublevel('global', { valueEncoding: 'json' });
 
     /** @type {(operations: DatabaseBatchOperation[]) => Promise<void>} */

--- a/backend/src/generators/incremental_graph/database/root_database.js
+++ b/backend/src/generators/incremental_graph/database/root_database.js
@@ -43,14 +43,12 @@ const {
  * so it can represent both the root database and any nested sublevel.
  * Used as a looser parameter type for internal helpers that only need the shared
  * abstract-level API (sublevel(), batch(), etc.).
- * @typedef {import('abstract-level').AbstractLevel<SublevelFormat, NodeKeyString, DatabaseStoredValue>} AnyLevelType
+ * @typedef {import('abstract-level').AbstractLevel<SublevelFormat, string, DatabaseStoredValue>} AnyLevelType
  */
 
 /**
  * Sublevel for storing replica-level global state (e.g., version).
- * Uses NodeKeyString as the key type to satisfy the generic typed-database
- * interface; in practice only the 'version' key is stored here.
- * @typedef {import('abstract-level').AbstractSublevel<SchemaSublevelType, SublevelFormat, NodeKeyString, Version>} GlobalSublevelType
+ * @typedef {import('abstract-level').AbstractSublevel<SchemaSublevelType, SublevelFormat, string, Version>} GlobalSublevelType
  */
 
 /**
@@ -73,21 +71,22 @@ function assertNeverReplicaName(name) {
 
 /**
  * @template T
- * @typedef {import('./typed_database').GenericDatabase<T>} GenericDatabase
+ * @template K
+ * @typedef {import('./typed_database').GenericDatabase<T, K>} GenericDatabase
  */
 
 /**
  * Database for storing node output values.
  * Key: canonical node name (e.g., "user('alice')")
  * Value: the computed value (object with type field)
- * @typedef {GenericDatabase<ComputedValue>} ValuesDatabase
+ * @typedef {GenericDatabase<ComputedValue, NodeKeyString>} ValuesDatabase
  */
 
 /**
  * Database for storing node freshness state.
  * Key: canonical node name (e.g., "user('alice')")
  * Value: freshness state ('up-to-date' | 'potentially-outdated')
- * @typedef {GenericDatabase<Freshness>} FreshnessDatabase
+ * @typedef {GenericDatabase<Freshness, NodeKeyString>} FreshnessDatabase
  */
 
 /**
@@ -101,35 +100,35 @@ function assertNeverReplicaName(name) {
  * Database for storing node input dependencies.
  * Key: canonical node name
  * Value: inputs record with array of dependency names
- * @typedef {GenericDatabase<InputsRecord>} InputsDatabase
+ * @typedef {GenericDatabase<InputsRecord, NodeKeyString>} InputsDatabase
  */
 
 /**
  * Database for reverse dependency index.
  * Key: canonical input node name
  * Value: array of canonical dependent node names
- * @typedef {GenericDatabase<NodeKeyString[]>} RevdepsDatabase
+ * @typedef {GenericDatabase<NodeKeyString[], NodeKeyString>} RevdepsDatabase
  */
 
 /**
  * Database for storing node counters.
  * Key: canonical node name
  * Value: counter (monotonic integer tracking value changes)
- * @typedef {GenericDatabase<Counter>} CountersDatabase
+ * @typedef {GenericDatabase<Counter, NodeKeyString>} CountersDatabase
  */
 
 /**
  * Database for storing node timestamps (creation and modification times).
  * Key: canonical node name
  * Value: timestamp record with createdAt and modifiedAt ISO strings
- * @typedef {GenericDatabase<TimestampRecord>} TimestampsDatabase
+ * @typedef {GenericDatabase<TimestampRecord, NodeKeyString>} TimestampsDatabase
  */
 
 /**
  * Database for storing replica-level global state (e.g., version).
  * Key: plain string (e.g., 'version')
  * Value: version string
- * @typedef {GenericDatabase<Version>} GlobalVersionDatabase
+ * @typedef {GenericDatabase<Version, string>} GlobalVersionDatabase
  */
 
 /**
@@ -190,10 +189,10 @@ function buildSchemaStorage(namespaceSublevel, globalSublevel, version) {
             return;
         }
         if (!touchedSchema) {
-            const existing = await globalSublevel.get(stringToNodeKeyString('version'));
+            const existing = await globalSublevel.get('version');
             if (existing === undefined) {
                 // New or freshly-cleared namespace: write version to global to initialise.
-                await globalSublevel.put(stringToNodeKeyString('version'), version);
+                await globalSublevel.put('version', version);
             } else if (existing !== version) {
                 // Version mismatch indicates a logic error in migration or usage of staging namespace.
                 throw new SchemaBatchVersionError(versionToString(version), versionToString(existing));
@@ -401,7 +400,7 @@ class RootDatabaseClass {
         } else {
             return assertNeverReplicaName(current);
         }
-        return await globalSublevel.get(stringToNodeKeyString('version'));
+        return await globalSublevel.get('version');
     }
 
     /**
@@ -419,7 +418,7 @@ class RootDatabaseClass {
         } else {
             return assertNeverReplicaName(current);
         }
-        await globalSublevel.put(stringToNodeKeyString('version'), version);
+        await globalSublevel.put('version', version);
     }
 
     /**

--- a/backend/src/generators/incremental_graph/database/typed_database.js
+++ b/backend/src/generators/incremental_graph/database/typed_database.js
@@ -7,17 +7,20 @@
 
 /**
  * @template T
- * @typedef {import('./types').SimpleSublevel<T>} SimpleSublevel
+ * @template [K=import('./types').DatabaseKey]
+ * @typedef {import('./types').SimpleSublevel<T, K>} SimpleSublevel
  */
 
 /**
  * @template T
- * @typedef {import('./types').DatabasePutOperation<T>} DatabasePutOperation
+ * @template [K=import('./types').DatabaseKey]
+ * @typedef {{ type: 'put', sublevel: SimpleSublevel<T, K>, key: K, value: T }} DatabasePutOperation
  */
 
 /**
  * @template T
- * @typedef {import('./types').DatabaseDelOperation<T>} DatabaseDelOperation
+ * @template [K=import('./types').DatabaseKey]
+ * @typedef {{ type: 'del', sublevel: SimpleSublevel<T, K>, key: K }} DatabaseDelOperation
  */
 
 /**
@@ -28,34 +31,36 @@
  * Generic typed database interface.
  * All databases (values, freshness, inputs, revdeps) implement this interface.
  * @template TValue - The value type
+ * @template TKey - The key type
  * @typedef {object} GenericDatabase
- * @property {(key: DatabaseKey) => Promise<TValue | undefined>} get - Retrieve a value
- * @property {(key: DatabaseKey, value: TValue) => Promise<void>} put - Store a value
- * @property {(key: DatabaseKey, value: *) => Promise<void>} rawPut - Store a value with sync:false (for unification adapters where runtime type is guaranteed by schema invariant)
- * @property {(key: DatabaseKey) => Promise<void>} del - Delete a value
- * @property {(key: DatabaseKey) => Promise<void>} rawDel - Delete a value with sync:false (for unification adapters; mirrors rawPut)
- * @property {(key: DatabaseKey, value: TValue) => DatabasePutOperation<TValue>} putOp - Store a value operation
- * @property {(key: DatabaseKey, value: *) => DatabasePutOperation<TValue>} rawPutOp - Store a value operation accepting an untyped value (for unification adapters where runtime type is guaranteed by schema invariant)
- * @property {(key: DatabaseKey) => DatabaseDelOperation<TValue>} delOp - Delete a value operation
- * @property {() => AsyncIterable<DatabaseKey>} keys - Iterate over all keys
+ * @property {(key: TKey) => Promise<TValue | undefined>} get - Retrieve a value
+ * @property {(key: TKey, value: TValue) => Promise<void>} put - Store a value
+ * @property {(key: TKey, value: *) => Promise<void>} rawPut - Store a value with sync:false (for unification adapters where runtime type is guaranteed by schema invariant)
+ * @property {(key: TKey) => Promise<void>} del - Delete a value
+ * @property {(key: TKey) => Promise<void>} rawDel - Delete a value with sync:false (for unification adapters; mirrors rawPut)
+ * @property {(key: TKey, value: TValue) => DatabasePutOperation<TValue, TKey>} putOp - Store a value operation
+ * @property {(key: TKey, value: *) => DatabasePutOperation<TValue, TKey>} rawPutOp - Store a value operation accepting an untyped value (for unification adapters where runtime type is guaranteed by schema invariant)
+ * @property {(key: TKey) => DatabaseDelOperation<TValue, TKey>} delOp - Delete a value operation
+ * @property {() => AsyncIterable<TKey>} keys - Iterate over all keys
  * @property {() => Promise<void>} clear - Clear all entries
  */
 
 /**
  * Wrapper class that adapts a LevelDB sublevel to the GenericDatabase interface.
  * @template TValue
+ * @template TKey
  */
 class TypedDatabaseClass {
     /**
      * The underlying LevelDB sublevel instance.
      * @private
-     * @type {SimpleSublevel<TValue>}
+     * @type {SimpleSublevel<TValue, TKey>}
      */
     sublevel;
 
     /**
      * @constructor
-     * @param {SimpleSublevel<TValue>} sublevel - The LevelDB sublevel instance
+     * @param {SimpleSublevel<TValue, TKey>} sublevel - The LevelDB sublevel instance
      */
     constructor(sublevel) {
         this.sublevel = sublevel;
@@ -67,7 +72,7 @@ class TypedDatabaseClass {
      * Note: Level v10+ returns `undefined` for missing keys rather than throwing an error.
      * This is the expected behavior and we pass it through directly.
      *
-     * @param {import('./types').DatabaseKey} key - The key to retrieve
+     * @param {TKey} key - The key to retrieve
      * @returns {Promise<TValue | undefined>}
      */
     async get(key) {
@@ -76,7 +81,7 @@ class TypedDatabaseClass {
 
     /**
      * Store a value in the database.
-     * @param {DatabaseKey} key - The key to store
+     * @param {TKey} key - The key to store
      * @param {TValue} value - The value to store
      * @returns {Promise<void>}
      */
@@ -94,7 +99,7 @@ class TypedDatabaseClass {
      * sync:false means the OS may buffer the write before flushing to disk.
      * Callers must invoke rootDatabase._rawSync() once after all unification
      * writes are complete to ensure durability.
-     * @param {DatabaseKey} key - The key to store
+     * @param {TKey} key - The key to store
      * @param {*} value - The value to store (must be TValue at runtime)
      * @returns {Promise<void>}
      */
@@ -115,7 +120,7 @@ class TypedDatabaseClass {
      * Mirrors rawPut(): for use only in unification adapters.
      * Callers must invoke rootDatabase._rawSync() once after all unification
      * writes are complete to ensure durability.
-     * @param {DatabaseKey} key - The key to delete
+     * @param {TKey} key - The key to delete
      * @returns {Promise<void>}
      */
     async rawDel(key) {
@@ -127,7 +132,7 @@ class TypedDatabaseClass {
 
     /**
      * Delete a value from the database.
-     * @param {DatabaseKey} key - The key to delete
+     * @param {TKey} key - The key to delete
      * @returns {Promise<void>}
      */
     async del(key) {
@@ -136,9 +141,9 @@ class TypedDatabaseClass {
 
     /**
      * Create a put operation for batch processing.
-     * @param {DatabaseKey} key - The key to store
+     * @param {TKey} key - The key to store
      * @param {TValue} value - The value to store
-     * @returns {DatabasePutOperation<TValue>}
+     * @returns {DatabasePutOperation<TValue, TKey>}
      */
     putOp(key, value) {
         return { sublevel: this.sublevel, type: "put", key, value };
@@ -150,9 +155,9 @@ class TypedDatabaseClass {
      * schema and are therefore the correct runtime type despite being typed as
      * unknown at the call site.  Keeping this separate from putOp preserves
      * the typed boundary for normal callers.
-     * @param {DatabaseKey} key - The key to store
+     * @param {TKey} key - The key to store
      * @param {*} value - The value to store (must be TValue at runtime)
-     * @returns {DatabasePutOperation<TValue>}
+     * @returns {DatabasePutOperation<TValue, TKey>}
      */
     rawPutOp(key, value) {
         return { sublevel: this.sublevel, type: "put", key, value };
@@ -160,20 +165,20 @@ class TypedDatabaseClass {
 
     /**
      * Create a delete operation for batch processing.
-     * @param {DatabaseKey} key - The key to delete
-     * @returns {DatabaseDelOperation<TValue>}
+     * @param {TKey} key - The key to delete
+     * @returns {DatabaseDelOperation<TValue, TKey>}
      */
     delOp(key) {
-        /** @type {SimpleSublevel<TValue>} */
+        /** @type {SimpleSublevel<TValue, TKey>} */
         const thisSublevel = this.sublevel;
-        /** @type {SimpleSublevel<TValue>} */
+        /** @type {SimpleSublevel<TValue, TKey>} */
         const sublevel = thisSublevel;
         return { sublevel: sublevel, type: "del", key };
     }
 
     /**
      * Iterate over all keys in the database.
-     * @returns {AsyncIterable<DatabaseKey>}
+     * @returns {AsyncIterable<TKey>}
      */
     async *keys() {
         for await (const key of this.sublevel.keys()) {
@@ -193,8 +198,9 @@ class TypedDatabaseClass {
 /**
  * Factory function to create a TypedDatabase instance.
  * @template TValue
- * @param {SimpleSublevel<TValue>} sublevel - The LevelDB sublevel instance
- * @returns {GenericDatabase<TValue>}
+ * @template TKey
+ * @param {SimpleSublevel<TValue, TKey>} sublevel - The LevelDB sublevel instance
+ * @returns {GenericDatabase<TValue, TKey>}
  */
 function makeTypedDatabase(sublevel) {
     return new TypedDatabaseClass(sublevel);

--- a/backend/src/generators/incremental_graph/database/types.js
+++ b/backend/src/generators/incremental_graph/database/types.js
@@ -373,13 +373,13 @@ function versionToString(Version) {
 /**
  * A database put operation.
  * @template T
- * @typedef {{ type: 'put', sublevel: SimpleSublevel<T>, key: DatabaseKey, value: T }} DatabasePutOperation
+ * @typedef {{ type: 'put', sublevel: SimpleSublevel<T, DatabaseKey>, key: DatabaseKey, value: T }} DatabasePutOperation
  */
 
 /**
  * A database delete operation.
  * @template T
- * @typedef {{ type: 'del', sublevel: SimpleSublevel<T>, key: DatabaseKey }} DatabaseDelOperation
+ * @typedef {{ type: 'del', sublevel: SimpleSublevel<T, DatabaseKey>, key: DatabaseKey }} DatabaseDelOperation
  */
 
 /**
@@ -486,7 +486,8 @@ function schemaPatternToString(schemaPattern) {
 
 /**
  * @template T
- * @typedef {AbstractSublevel<AbstractSublevel<RootLevelType, SublevelFormat, DatabaseKey, DatabaseStoredValue>, SublevelFormat, DatabaseKey, T>} SimpleSublevel
+ * @template [K=NodeKeyString]
+ * @typedef {AbstractSublevel<AbstractSublevel<RootLevelType, SublevelFormat, DatabaseKey, DatabaseStoredValue>, SublevelFormat, K, T>} SimpleSublevel
  */
 
 module.exports = {

--- a/backend/src/generators/incremental_graph/database/unification/db_to_db.js
+++ b/backend/src/generators/incremental_graph/database/unification/db_to_db.js
@@ -39,24 +39,14 @@ const { stringToNodeKeyString } = require('../types');
  * source side of the DB→DB adapter.  Both GenericDatabase<T> and the
  * InMemorySchemaStorage sublevels satisfy this interface.
  *
- * @typedef {object} ReadableSublevel
- * @property {(key: NodeKeyString) => Promise<unknown>} get
- * @property {() => AsyncIterable<NodeKeyString>} keys
- */
-
-/**
- * Read-only structural type accepted as source by makeDbToDbAdapter.
- * Both SchemaStorage (via GenericDatabase<T>) and InMemorySchemaStorage
- * satisfy this interface without any casts.
- *
  * @typedef {object} ReadableSchemaStorage
- * @property {ReadableSublevel} values
- * @property {ReadableSublevel} freshness
- * @property {ReadableSublevel} global
- * @property {ReadableSublevel} inputs
- * @property {ReadableSublevel} revdeps
- * @property {ReadableSublevel} counters
- * @property {ReadableSublevel} timestamps
+ * @property {{ get: (key: NodeKeyString) => Promise<unknown>, keys: () => AsyncIterable<NodeKeyString> }} values
+ * @property {{ get: (key: NodeKeyString) => Promise<unknown>, keys: () => AsyncIterable<NodeKeyString> }} freshness
+ * @property {{ get: (key: string) => Promise<unknown>, keys: () => AsyncIterable<string> }} global
+ * @property {{ get: (key: NodeKeyString) => Promise<unknown>, keys: () => AsyncIterable<NodeKeyString> }} inputs
+ * @property {{ get: (key: NodeKeyString) => Promise<unknown>, keys: () => AsyncIterable<NodeKeyString> }} revdeps
+ * @property {{ get: (key: NodeKeyString) => Promise<unknown>, keys: () => AsyncIterable<NodeKeyString> }} counters
+ * @property {{ get: (key: NodeKeyString) => Promise<unknown>, keys: () => AsyncIterable<NodeKeyString> }} timestamps
  */
 
 /**
@@ -120,7 +110,7 @@ function parseCompositeKey(compositeKey) {
  *
  * @param {ReadableSchemaStorage} source
  * @param {string} sublevel
- * @returns {ReadableSublevel}
+ * @returns {ReadableSchemaStorage['values'] | ReadableSchemaStorage['freshness'] | ReadableSchemaStorage['global'] | ReadableSchemaStorage['inputs'] | ReadableSchemaStorage['revdeps'] | ReadableSchemaStorage['counters'] | ReadableSchemaStorage['timestamps']}
  */
 function getSourceSubDb(source, sublevel) {
     switch (sublevel) {
@@ -135,31 +125,11 @@ function getSourceSubDb(source, sublevel) {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Target accessor
-// ---------------------------------------------------------------------------
-
 /**
- * Returns the typed sublevel object from a SchemaStorage.
- * Used only for the target side where put/del ops require concrete types.
- *
- * @param {SchemaStorage} storage
  * @param {string} sublevel
- * @returns {AnySubDb}
+ * @param {string} nodeKey
+ * @returns {string | NodeKeyString}
  */
-function getTargetSubDb(storage, sublevel) {
-    switch (sublevel) {
-        case 'values': return storage.values;
-        case 'freshness': return storage.freshness;
-        case 'global': return storage.global;
-        case 'inputs': return storage.inputs;
-        case 'revdeps': return storage.revdeps;
-        case 'counters': return storage.counters;
-        case 'timestamps': return storage.timestamps;
-        default: throw new Error(`Unknown sublevel name: ${sublevel}`);
-    }
-}
-
 // ---------------------------------------------------------------------------
 // Key iteration
 // ---------------------------------------------------------------------------
@@ -214,12 +184,30 @@ function makeDbToDbAdapter(source, target, options = {}) {
 
         async readSource(compositeKey) {
             const { sublevel, nodeKey } = parseCompositeKey(compositeKey);
-            return await getSourceSubDb(source, sublevel).get(stringToNodeKeyString(nodeKey));
+            if (sublevel === 'global') return await source.global.get(nodeKey);
+            switch (sublevel) {
+                case 'values': return await source.values.get(stringToNodeKeyString(nodeKey));
+                case 'freshness': return await source.freshness.get(stringToNodeKeyString(nodeKey));
+                case 'inputs': return await source.inputs.get(stringToNodeKeyString(nodeKey));
+                case 'revdeps': return await source.revdeps.get(stringToNodeKeyString(nodeKey));
+                case 'counters': return await source.counters.get(stringToNodeKeyString(nodeKey));
+                case 'timestamps': return await source.timestamps.get(stringToNodeKeyString(nodeKey));
+                default: throw new Error(`Unknown sublevel name: ${sublevel}`);
+            }
         },
 
         async readTarget(compositeKey) {
             const { sublevel, nodeKey } = parseCompositeKey(compositeKey);
-            return await getTargetSubDb(target, sublevel).get(stringToNodeKeyString(nodeKey));
+            if (sublevel === 'global') return await target.global.get(nodeKey);
+            switch (sublevel) {
+                case 'values': return await target.values.get(stringToNodeKeyString(nodeKey));
+                case 'freshness': return await target.freshness.get(stringToNodeKeyString(nodeKey));
+                case 'inputs': return await target.inputs.get(stringToNodeKeyString(nodeKey));
+                case 'revdeps': return await target.revdeps.get(stringToNodeKeyString(nodeKey));
+                case 'counters': return await target.counters.get(stringToNodeKeyString(nodeKey));
+                case 'timestamps': return await target.timestamps.get(stringToNodeKeyString(nodeKey));
+                default: throw new Error(`Unknown sublevel name: ${sublevel}`);
+            }
         },
 
         equals(sv, tv) {
@@ -228,12 +216,36 @@ function makeDbToDbAdapter(source, target, options = {}) {
 
         async putTarget(compositeKey, value) {
             const { sublevel, nodeKey } = parseCompositeKey(compositeKey);
-            await getTargetSubDb(target, sublevel).rawPut(stringToNodeKeyString(nodeKey), value);
+            if (sublevel === 'global') {
+                await target.global.rawPut(nodeKey, value);
+                return;
+            }
+            switch (sublevel) {
+                case 'values': await target.values.rawPut(stringToNodeKeyString(nodeKey), value); return;
+                case 'freshness': await target.freshness.rawPut(stringToNodeKeyString(nodeKey), value); return;
+                case 'inputs': await target.inputs.rawPut(stringToNodeKeyString(nodeKey), value); return;
+                case 'revdeps': await target.revdeps.rawPut(stringToNodeKeyString(nodeKey), value); return;
+                case 'counters': await target.counters.rawPut(stringToNodeKeyString(nodeKey), value); return;
+                case 'timestamps': await target.timestamps.rawPut(stringToNodeKeyString(nodeKey), value); return;
+                default: throw new Error(`Unknown sublevel name: ${sublevel}`);
+            }
         },
 
         async deleteTarget(compositeKey) {
             const { sublevel, nodeKey } = parseCompositeKey(compositeKey);
-            await getTargetSubDb(target, sublevel).rawDel(stringToNodeKeyString(nodeKey));
+            if (sublevel === 'global') {
+                await target.global.rawDel(nodeKey);
+                return;
+            }
+            switch (sublevel) {
+                case 'values': await target.values.rawDel(stringToNodeKeyString(nodeKey)); return;
+                case 'freshness': await target.freshness.rawDel(stringToNodeKeyString(nodeKey)); return;
+                case 'inputs': await target.inputs.rawDel(stringToNodeKeyString(nodeKey)); return;
+                case 'revdeps': await target.revdeps.rawDel(stringToNodeKeyString(nodeKey)); return;
+                case 'counters': await target.counters.rawDel(stringToNodeKeyString(nodeKey)); return;
+                case 'timestamps': await target.timestamps.rawDel(stringToNodeKeyString(nodeKey)); return;
+                default: throw new Error(`Unknown sublevel name: ${sublevel}`);
+            }
         },
     };
 }

--- a/backend/src/generators/incremental_graph/graph_storage.js
+++ b/backend/src/generators/incremental_graph/graph_storage.js
@@ -106,7 +106,7 @@ function findInsertionIndex(sortedArray, node, compareFn) {
  * Creates a transactional database view for batch-consistent reads.
  * Implements read-your-writes semantics within a batch.
  * @template TValue
- * @param {import('./database/typed_database').GenericDatabase<TValue>} db - The underlying database
+ * @param {import('./database/typed_database').GenericDatabase<TValue, DatabaseKey>} db - The underlying database
  * @param {Array<DatabasePutOperation<TValue> | DatabaseDelOperation<TValue>>} operations - Array to append operations to
  * @param {Map<DatabaseKey, TValue>} pendingPuts - Overlay of pending put operations
  * @param {Set<DatabaseKey>} pendingDels - Set of pending delete operations

--- a/backend/src/generators/incremental_graph/migration_runner.js
+++ b/backend/src/generators/incremental_graph/migration_runner.js
@@ -275,9 +275,9 @@ function makeLazyMigrationSource(prevStorage, decisions, desiredRevdeps, newVers
         },
         global: {
             async *keys() {
-                yield stringToNodeKeyString('version');
+                yield 'version';
             },
-            async get(/** @type {NodeKeyString} */ _key) {
+            async get(/** @type {string} */ _key) {
                 return newVersion;
             },
         },


### PR DESCRIPTION
### Motivation
- The low-level DB typing conflated all keys with `NodeKeyString`, forcing meta/global keys (like `global/version`) through `stringToNodeKeyString('version')` instead of using plain `string`, which is incorrect for non-node sublevels.
- Keys must depend on the sublevel: node-addressed sublevels (`values`, `freshness`, `inputs`, `revdeps`, `counters`, `timestamps`) continue to use `NodeKeyString`, while `global` and other meta sublevels must use plain `string` keys for clarity and correctness.

### Description
- Made `SimpleSublevel` key-aware by adding a key-type parameter `K` and propagated that into `DatabasePutOperation` and `DatabaseDelOperation` so batch ops carry the correct key type (`backend/src/generators/incremental_graph/database/types.js`).
- Made the typed DB wrapper generic over both value and key types (`GenericDatabase<TValue, TKey>`) and updated `TypedDatabaseClass`/`makeTypedDatabase` to accept the key type so `global` can be `string` keyed while node sublevels remain `NodeKeyString` keyed (`backend/src/generators/incremental_graph/database/typed_database.js`).
- Updated the root/schema storage typing so the `global` sublevel is explicitly string-keyed and replaced `stringToNodeKeyString('version')` uses with direct `'version'` gets/puts in schema init, `getGlobalVersion`, and `setGlobalVersion` (`backend/src/generators/incremental_graph/database/root_database.js`).
- Adjusted the migration lazy source to expose `global` keys as plain strings (`'version'`) and changed the `get` signature accordingly to align with the new contract (`backend/src/generators/incremental_graph/migration_runner.js`).
- Refactored DB→DB unification to treat `global` keys as plain strings while preserving `NodeKeyString` handling for node-addressed sublevels (read/put/delete now branch on sublevel and perform the correct key handling) (`backend/src/generators/incremental_graph/database/unification/db_to_db.js`).
- Updated hostname staging storage typing so its `global` sublevel is typed as string-keyed at the abstract-level boundary and updated `graph_storage` annotations to the two-parameter `GenericDatabase` form for consistency (`backend/src/generators/incremental_graph/database/hostname_storage.js`, `backend/src/generators/incremental_graph/graph_storage.js`).

### Testing
- Ran the repository static analysis with `npm run static-analysis` (which runs `tsc` and `eslint`) and iterated on type fixes until the command completed successfully; the static analysis step now passes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06590099d4832eb0a6b06344a1627e)