### PR TITLE
Restore reusable sublevel abstractions and reduce duplication in DB→DB unifier

### DIFF
--- a/backend/src/generators/incremental_graph/database/hostname_storage.js
+++ b/backend/src/generators/incremental_graph/database/hostname_storage.js
@@ -60,6 +60,7 @@ function validateHostname(hostname) {
 
 /** @typedef {import('./types').RootLevelType} RootLevelType */
 /** @typedef {import('./types').SchemaSublevelType} SchemaSublevelType */
+/** @typedef {import('./types').GlobalSublevelType} GlobalSublevelType */
 /** @typedef {import('./types').Version} Version */
 /** @typedef {import('./root_database').SchemaStorage} SchemaStorage */
 /** @typedef {import('./types').DatabaseBatchOperation} DatabaseBatchOperation */
@@ -100,7 +101,7 @@ function buildBareSchemaStorage(namespaceSublevel) {
     const countersSublevel = namespaceSublevel.sublevel('counters', { valueEncoding: 'json' });
     /** @type {SimpleSublevel<TimestampRecord>} */
     const timestampsSublevel = namespaceSublevel.sublevel('timestamps', { valueEncoding: 'json' });
-    /** @type {import('abstract-level').AbstractSublevel<SchemaSublevelType, import('./types').SublevelFormat, string, Version>} */
+    /** @type {GlobalSublevelType} */
     const globalSublevel = namespaceSublevel.sublevel('global', { valueEncoding: 'json' });
 
     /** @type {(operations: DatabaseBatchOperation[]) => Promise<void>} */
@@ -123,6 +124,18 @@ function buildBareSchemaStorage(namespaceSublevel) {
 }
 
 /**
+ * @param {RootLevelType} db
+ * @param {string} hostname
+ * @returns {SchemaSublevelType}
+ */
+function getHostnameNamespaceSublevel(db, hostname) {
+    validateHostname(hostname);
+    /** @type {SchemaSublevelType} */
+    const hostnameSublevel = db.sublevel(`_h_${hostname}`, { valueEncoding: 'json' });
+    return hostnameSublevel;
+}
+
+/**
  * Returns a bare SchemaStorage for a hostname staging namespace.
  * The storage reads/writes under `_h_<hostname>` and does NOT enforce any
  * local version check.
@@ -133,9 +146,7 @@ function buildBareSchemaStorage(namespaceSublevel) {
  * @throws {InvalidHostnameError} If the hostname is invalid.
  */
 function hostnameSchemaStorage(db, hostname) {
-    validateHostname(hostname);
-    /** @type {SchemaSublevelType} */
-    const hostnameSub = db.sublevel(`_h_${hostname}`, { valueEncoding: 'json' });
+    const hostnameSub = getHostnameNamespaceSublevel(db, hostname);
     return buildBareSchemaStorage(hostnameSub);
 }
 
@@ -148,10 +159,7 @@ function hostnameSchemaStorage(db, hostname) {
  * @throws {InvalidHostnameError} If the hostname is invalid.
  */
 async function clearHostnameStorage(db, hostname) {
-    validateHostname(hostname);
-    /** @type {SchemaSublevelType} */
-    const hostnameSub = db.sublevel(`_h_${hostname}`, { valueEncoding: 'json' });
-    await hostnameSub.clear();
+    await getHostnameNamespaceSublevel(db, hostname).clear();
 }
 
 /**

--- a/backend/src/generators/incremental_graph/database/root_database.js
+++ b/backend/src/generators/incremental_graph/database/root_database.js
@@ -26,6 +26,7 @@ const {
 
 /** @typedef {import('./types').RootLevelType} RootLevelType */
 /** @typedef {import('./types').SchemaSublevelType} SchemaSublevelType */
+/** @typedef {import('./types').GlobalSublevelType} GlobalSublevelType */
 /** @typedef {import('./types').SublevelFormat} SublevelFormat */
 /** @typedef {import('./types').ComputedValue} ComputedValue */
 /** @typedef {import('./types').Freshness} Freshness */
@@ -46,13 +47,6 @@ const {
  * @typedef {import('abstract-level').AbstractLevel<SublevelFormat, string, DatabaseStoredValue>} AnyLevelType
  */
 
-/**
- * Sublevel for storing replica-level global state (e.g., version).
- * @typedef {import('abstract-level').AbstractSublevel<SchemaSublevelType, SublevelFormat, string, Version>} GlobalSublevelType
- */
-
-/**
- */
 /**
  * The valid replica names.
  * @typedef {'x' | 'y'} ReplicaName

--- a/backend/src/generators/incremental_graph/database/types.js
+++ b/backend/src/generators/incremental_graph/database/types.js
@@ -485,6 +485,10 @@ function schemaPatternToString(schemaPattern) {
  */
 
 /**
+ * @typedef {AbstractSublevel<SchemaSublevelType, SublevelFormat, string, Version>} GlobalSublevelType
+ */
+
+/**
  * @template T
  * @template [K=NodeKeyString]
  * @typedef {AbstractSublevel<AbstractSublevel<RootLevelType, SublevelFormat, DatabaseKey, DatabaseStoredValue>, SublevelFormat, K, T>} SimpleSublevel

--- a/backend/src/generators/incremental_graph/database/unification/db_to_db.js
+++ b/backend/src/generators/incremental_graph/database/unification/db_to_db.js
@@ -39,25 +39,24 @@ const { stringToNodeKeyString } = require('../types');
  * source side of the DB→DB adapter.  Both GenericDatabase<T> and the
  * InMemorySchemaStorage sublevels satisfy this interface.
  *
- * @typedef {object} ReadableSublevel
- * @property {(key: string | NodeKeyString) => Promise<unknown>} get
- * @property {() => AsyncIterable<string | NodeKeyString>} keys
- *
- * @typedef {object} ReadableSchemaStorage
- * @property {ReadableSublevel} values
- * @property {ReadableSublevel} freshness
- * @property {ReadableSublevel} global
- * @property {ReadableSublevel} inputs
- * @property {ReadableSublevel} revdeps
- * @property {ReadableSublevel} counters
- * @property {ReadableSublevel} timestamps
+ * @typedef {object} ReadableNodeSublevel
+ * @property {(key: NodeKeyString) => Promise<unknown>} get
+ * @property {() => AsyncIterable<NodeKeyString>} keys
  */
 
 /**
- * Union of all concrete typed sublevels in a SchemaStorage.
- * Used for the target side only (where put/del ops must be typed).
+ * @typedef {object} ReadableGlobalSublevel
+ * @property {(key: string) => Promise<unknown>} get
+ * @property {() => AsyncIterable<string>} keys
  *
- * @typedef {import('../root_database').ValuesDatabase | import('../root_database').FreshnessDatabase | import('../root_database').GlobalVersionDatabase | import('../root_database').InputsDatabase | import('../root_database').RevdepsDatabase | import('../root_database').CountersDatabase | import('../root_database').TimestampsDatabase} AnySubDb
+ * @typedef {object} ReadableSchemaStorage
+ * @property {ReadableNodeSublevel} values
+ * @property {ReadableNodeSublevel} freshness
+ * @property {ReadableGlobalSublevel} global
+ * @property {ReadableNodeSublevel} inputs
+ * @property {ReadableNodeSublevel} revdeps
+ * @property {ReadableNodeSublevel} counters
+ * @property {ReadableNodeSublevel} timestamps
  */
 
 /**
@@ -129,38 +128,6 @@ function getSourceSubDb(source, sublevel) {
     }
 }
 
-/**
- * Returns the target GenericDatabase for the given sublevel name.
- *
- * @param {SchemaStorage} target
- * @param {string} sublevel
- * @returns {AnySubDb}
- */
-function getTargetSubDb(target, sublevel) {
-    switch (sublevel) {
-        case 'values': return target.values;
-        case 'freshness': return target.freshness;
-        case 'global': return target.global;
-        case 'inputs': return target.inputs;
-        case 'revdeps': return target.revdeps;
-        case 'counters': return target.counters;
-        case 'timestamps': return target.timestamps;
-        default: throw new Error(`Unknown sublevel name: ${sublevel}`);
-    }
-}
-
-/**
- * @param {string} sublevel
- * @param {string} nodeKey
- * @returns {string | NodeKeyString}
- */
-function toDbKey(sublevel, nodeKey) {
-    if (sublevel === 'global') {
-        return nodeKey;
-    }
-    return stringToNodeKeyString(nodeKey);
-}
-
 // ---------------------------------------------------------------------------
 // Key iteration
 // ---------------------------------------------------------------------------
@@ -215,12 +182,30 @@ function makeDbToDbAdapter(source, target, options = {}) {
 
         async readSource(compositeKey) {
             const { sublevel, nodeKey } = parseCompositeKey(compositeKey);
-            return await getSourceSubDb(source, sublevel).get(toDbKey(sublevel, nodeKey));
+            if (sublevel === 'global') return await source.global.get(nodeKey);
+            switch (sublevel) {
+                case 'values': return await source.values.get(stringToNodeKeyString(nodeKey));
+                case 'freshness': return await source.freshness.get(stringToNodeKeyString(nodeKey));
+                case 'inputs': return await source.inputs.get(stringToNodeKeyString(nodeKey));
+                case 'revdeps': return await source.revdeps.get(stringToNodeKeyString(nodeKey));
+                case 'counters': return await source.counters.get(stringToNodeKeyString(nodeKey));
+                case 'timestamps': return await source.timestamps.get(stringToNodeKeyString(nodeKey));
+                default: throw new Error(`Unknown sublevel name: ${sublevel}`);
+            }
         },
 
         async readTarget(compositeKey) {
             const { sublevel, nodeKey } = parseCompositeKey(compositeKey);
-            return await getTargetSubDb(target, sublevel).get(toDbKey(sublevel, nodeKey));
+            if (sublevel === 'global') return await target.global.get(nodeKey);
+            switch (sublevel) {
+                case 'values': return await target.values.get(stringToNodeKeyString(nodeKey));
+                case 'freshness': return await target.freshness.get(stringToNodeKeyString(nodeKey));
+                case 'inputs': return await target.inputs.get(stringToNodeKeyString(nodeKey));
+                case 'revdeps': return await target.revdeps.get(stringToNodeKeyString(nodeKey));
+                case 'counters': return await target.counters.get(stringToNodeKeyString(nodeKey));
+                case 'timestamps': return await target.timestamps.get(stringToNodeKeyString(nodeKey));
+                default: throw new Error(`Unknown sublevel name: ${sublevel}`);
+            }
         },
 
         equals(sv, tv) {
@@ -229,12 +214,36 @@ function makeDbToDbAdapter(source, target, options = {}) {
 
         async putTarget(compositeKey, value) {
             const { sublevel, nodeKey } = parseCompositeKey(compositeKey);
-            await getTargetSubDb(target, sublevel).rawPut(toDbKey(sublevel, nodeKey), value);
+            if (sublevel === 'global') {
+                await target.global.rawPut(nodeKey, value);
+                return;
+            }
+            switch (sublevel) {
+                case 'values': await target.values.rawPut(stringToNodeKeyString(nodeKey), value); return;
+                case 'freshness': await target.freshness.rawPut(stringToNodeKeyString(nodeKey), value); return;
+                case 'inputs': await target.inputs.rawPut(stringToNodeKeyString(nodeKey), value); return;
+                case 'revdeps': await target.revdeps.rawPut(stringToNodeKeyString(nodeKey), value); return;
+                case 'counters': await target.counters.rawPut(stringToNodeKeyString(nodeKey), value); return;
+                case 'timestamps': await target.timestamps.rawPut(stringToNodeKeyString(nodeKey), value); return;
+                default: throw new Error(`Unknown sublevel name: ${sublevel}`);
+            }
         },
 
         async deleteTarget(compositeKey) {
             const { sublevel, nodeKey } = parseCompositeKey(compositeKey);
-            await getTargetSubDb(target, sublevel).rawDel(toDbKey(sublevel, nodeKey));
+            if (sublevel === 'global') {
+                await target.global.rawDel(nodeKey);
+                return;
+            }
+            switch (sublevel) {
+                case 'values': await target.values.rawDel(stringToNodeKeyString(nodeKey)); return;
+                case 'freshness': await target.freshness.rawDel(stringToNodeKeyString(nodeKey)); return;
+                case 'inputs': await target.inputs.rawDel(stringToNodeKeyString(nodeKey)); return;
+                case 'revdeps': await target.revdeps.rawDel(stringToNodeKeyString(nodeKey)); return;
+                case 'counters': await target.counters.rawDel(stringToNodeKeyString(nodeKey)); return;
+                case 'timestamps': await target.timestamps.rawDel(stringToNodeKeyString(nodeKey)); return;
+                default: throw new Error(`Unknown sublevel name: ${sublevel}`);
+            }
         },
     };
 }

--- a/backend/src/generators/incremental_graph/database/unification/db_to_db.js
+++ b/backend/src/generators/incremental_graph/database/unification/db_to_db.js
@@ -39,14 +39,18 @@ const { stringToNodeKeyString } = require('../types');
  * source side of the DB→DB adapter.  Both GenericDatabase<T> and the
  * InMemorySchemaStorage sublevels satisfy this interface.
  *
+ * @typedef {object} ReadableSublevel
+ * @property {(key: string | NodeKeyString) => Promise<unknown>} get
+ * @property {() => AsyncIterable<string | NodeKeyString>} keys
+ *
  * @typedef {object} ReadableSchemaStorage
- * @property {{ get: (key: NodeKeyString) => Promise<unknown>, keys: () => AsyncIterable<NodeKeyString> }} values
- * @property {{ get: (key: NodeKeyString) => Promise<unknown>, keys: () => AsyncIterable<NodeKeyString> }} freshness
- * @property {{ get: (key: string) => Promise<unknown>, keys: () => AsyncIterable<string> }} global
- * @property {{ get: (key: NodeKeyString) => Promise<unknown>, keys: () => AsyncIterable<NodeKeyString> }} inputs
- * @property {{ get: (key: NodeKeyString) => Promise<unknown>, keys: () => AsyncIterable<NodeKeyString> }} revdeps
- * @property {{ get: (key: NodeKeyString) => Promise<unknown>, keys: () => AsyncIterable<NodeKeyString> }} counters
- * @property {{ get: (key: NodeKeyString) => Promise<unknown>, keys: () => AsyncIterable<NodeKeyString> }} timestamps
+ * @property {ReadableSublevel} values
+ * @property {ReadableSublevel} freshness
+ * @property {ReadableSublevel} global
+ * @property {ReadableSublevel} inputs
+ * @property {ReadableSublevel} revdeps
+ * @property {ReadableSublevel} counters
+ * @property {ReadableSublevel} timestamps
  */
 
 /**
@@ -126,10 +130,37 @@ function getSourceSubDb(source, sublevel) {
 }
 
 /**
+ * Returns the target GenericDatabase for the given sublevel name.
+ *
+ * @param {SchemaStorage} target
+ * @param {string} sublevel
+ * @returns {AnySubDb}
+ */
+function getTargetSubDb(target, sublevel) {
+    switch (sublevel) {
+        case 'values': return target.values;
+        case 'freshness': return target.freshness;
+        case 'global': return target.global;
+        case 'inputs': return target.inputs;
+        case 'revdeps': return target.revdeps;
+        case 'counters': return target.counters;
+        case 'timestamps': return target.timestamps;
+        default: throw new Error(`Unknown sublevel name: ${sublevel}`);
+    }
+}
+
+/**
  * @param {string} sublevel
  * @param {string} nodeKey
  * @returns {string | NodeKeyString}
  */
+function toDbKey(sublevel, nodeKey) {
+    if (sublevel === 'global') {
+        return nodeKey;
+    }
+    return stringToNodeKeyString(nodeKey);
+}
+
 // ---------------------------------------------------------------------------
 // Key iteration
 // ---------------------------------------------------------------------------
@@ -184,30 +215,12 @@ function makeDbToDbAdapter(source, target, options = {}) {
 
         async readSource(compositeKey) {
             const { sublevel, nodeKey } = parseCompositeKey(compositeKey);
-            if (sublevel === 'global') return await source.global.get(nodeKey);
-            switch (sublevel) {
-                case 'values': return await source.values.get(stringToNodeKeyString(nodeKey));
-                case 'freshness': return await source.freshness.get(stringToNodeKeyString(nodeKey));
-                case 'inputs': return await source.inputs.get(stringToNodeKeyString(nodeKey));
-                case 'revdeps': return await source.revdeps.get(stringToNodeKeyString(nodeKey));
-                case 'counters': return await source.counters.get(stringToNodeKeyString(nodeKey));
-                case 'timestamps': return await source.timestamps.get(stringToNodeKeyString(nodeKey));
-                default: throw new Error(`Unknown sublevel name: ${sublevel}`);
-            }
+            return await getSourceSubDb(source, sublevel).get(toDbKey(sublevel, nodeKey));
         },
 
         async readTarget(compositeKey) {
             const { sublevel, nodeKey } = parseCompositeKey(compositeKey);
-            if (sublevel === 'global') return await target.global.get(nodeKey);
-            switch (sublevel) {
-                case 'values': return await target.values.get(stringToNodeKeyString(nodeKey));
-                case 'freshness': return await target.freshness.get(stringToNodeKeyString(nodeKey));
-                case 'inputs': return await target.inputs.get(stringToNodeKeyString(nodeKey));
-                case 'revdeps': return await target.revdeps.get(stringToNodeKeyString(nodeKey));
-                case 'counters': return await target.counters.get(stringToNodeKeyString(nodeKey));
-                case 'timestamps': return await target.timestamps.get(stringToNodeKeyString(nodeKey));
-                default: throw new Error(`Unknown sublevel name: ${sublevel}`);
-            }
+            return await getTargetSubDb(target, sublevel).get(toDbKey(sublevel, nodeKey));
         },
 
         equals(sv, tv) {
@@ -216,36 +229,12 @@ function makeDbToDbAdapter(source, target, options = {}) {
 
         async putTarget(compositeKey, value) {
             const { sublevel, nodeKey } = parseCompositeKey(compositeKey);
-            if (sublevel === 'global') {
-                await target.global.rawPut(nodeKey, value);
-                return;
-            }
-            switch (sublevel) {
-                case 'values': await target.values.rawPut(stringToNodeKeyString(nodeKey), value); return;
-                case 'freshness': await target.freshness.rawPut(stringToNodeKeyString(nodeKey), value); return;
-                case 'inputs': await target.inputs.rawPut(stringToNodeKeyString(nodeKey), value); return;
-                case 'revdeps': await target.revdeps.rawPut(stringToNodeKeyString(nodeKey), value); return;
-                case 'counters': await target.counters.rawPut(stringToNodeKeyString(nodeKey), value); return;
-                case 'timestamps': await target.timestamps.rawPut(stringToNodeKeyString(nodeKey), value); return;
-                default: throw new Error(`Unknown sublevel name: ${sublevel}`);
-            }
+            await getTargetSubDb(target, sublevel).rawPut(toDbKey(sublevel, nodeKey), value);
         },
 
         async deleteTarget(compositeKey) {
             const { sublevel, nodeKey } = parseCompositeKey(compositeKey);
-            if (sublevel === 'global') {
-                await target.global.rawDel(nodeKey);
-                return;
-            }
-            switch (sublevel) {
-                case 'values': await target.values.rawDel(stringToNodeKeyString(nodeKey)); return;
-                case 'freshness': await target.freshness.rawDel(stringToNodeKeyString(nodeKey)); return;
-                case 'inputs': await target.inputs.rawDel(stringToNodeKeyString(nodeKey)); return;
-                case 'revdeps': await target.revdeps.rawDel(stringToNodeKeyString(nodeKey)); return;
-                case 'counters': await target.counters.rawDel(stringToNodeKeyString(nodeKey)); return;
-                case 'timestamps': await target.timestamps.rawDel(stringToNodeKeyString(nodeKey)); return;
-                default: throw new Error(`Unknown sublevel name: ${sublevel}`);
-            }
+            await getTargetSubDb(target, sublevel).rawDel(toDbKey(sublevel, nodeKey));
         },
     };
 }


### PR DESCRIPTION
### Motivation
- Previous refactor removed useful shared definitions and duplicated sublevel dispatch logic across read/write paths, making maintenance harder and removing the `ReadableSublevel` abstraction that documented the minimal sublevel interface. 
- The intent of this change is to restore those reusable definitions and centralize key conversion and sublevel dispatch so behavior is unchanged but duplication is eliminated.

### Description
- Reintroduced a `ReadableSublevel` typedef and used it inside `ReadableSchemaStorage` instead of repeating inline sublevel shapes. 
- Added `getTargetSubDb(target, sublevel)` to centralize target-side sublevel dispatch and removed repeated switch statements. 
- Added `toDbKey(sublevel, nodeKey)` to centralize conversion of composite key fragments to either plain string (`global`) or `NodeKeyString`. 
- Simplified `readSource`, `readTarget`, `putTarget`, and `deleteTarget` to use `getSourceSubDb`, `getTargetSubDb`, and `toDbKey`, reducing duplication while preserving semantics.

### Testing
- Ran `npm install` successfully. 
- Ran `npx jest backend/tests/migration_runner.test.js` and all tests passed (`46 passed`). 
- Ran the full test suite with `npm test`, which exhibited existing Jest timeouts in `backend/tests/interface.test.js` unrelated to these refactors. 
- Ran `npm run build` successfully for the frontend bundle.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a065c55cd60832ea8f2d48299e910a6)