### PR TITLE
Expand populated incremental-database fixture and add smoke tests

### DIFF
--- a/backend/tests/interface.test.js
+++ b/backend/tests/interface.test.js
@@ -2,6 +2,8 @@
  * Tests for generators/interface module.
  */
 
+jest.setTimeout(15000);
+
 const path = require("path");
 const {
     makeInterface,
@@ -497,7 +499,7 @@ describe("generators/interface", () => {
                 expect.objectContaining({ hostname: 'test-host' }),
                 'Bootstrap: hostname branch found; using reset-to-hostname sync path'
             );
-            await expect(iface.getAllEvents()).resolves.toHaveLength(3);
+            await expect(iface.getAllEvents()).resolves.toHaveLength(24);
             await expect(iface.getConfig()).resolves.toMatchObject({
                 help: expect.stringContaining("Event logging help text"),
                 shortcuts: expect.arrayContaining([

--- a/backend/tests/mock-incremental-database-remote-populated/rendered/r/values/all_events
+++ b/backend/tests/mock-incremental-database-remote-populated/rendered/r/values/all_events
@@ -2,38 +2,290 @@
   "type": "all_events",
   "events": [
     {
-      "id": "ajqw7mgcbxrjwcu3",
-      "date": "2025-06-28T16:31:37+0000",
-      "original": "mood [level happy]",
-      "input": "mood [level happy]",
+      "id": "fx-anchor-latest",
+      "date": "2025-04-20T22:10:00+0000",
+      "original": "Shipped recap and backlog tidy #focus #project-x",
+      "input": "Shipped recap and backlog tidy #focus #project-x",
       "creator": {
         "name": "Volodyslav",
         "uuid": "81c3188c-d2cc-4879-a237-cdd0f1121346",
-        "version": "v0.1.0-674-g8b127ea",
+        "version": "0.0.0-dev",
         "hostname": "fixturehost"
       }
     },
     {
-      "id": "r49r56mbh2hssujf",
-      "date": "2025-06-28T16:33:19+0000",
-      "original": "exercise [type cardio] walking",
-      "input": "exercise [type cardio] walking",
+      "id": "fx-anchor-earliest",
+      "date": "2025-01-02T06:45:00+0000",
+      "original": "Early start note before sunrise #focus",
+      "input": "Early start note before sunrise #focus",
       "creator": {
         "name": "Volodyslav",
         "uuid": "81c3188c-d2cc-4879-a237-cdd0f1121346",
-        "version": "v0.1.0-674-g8b127ea",
+        "version": "0.0.0-dev",
         "hostname": "fixturehost"
       }
     },
     {
-      "id": "xovxev9i1b8j4kqm",
-      "date": "2025-06-28T16:33:30+0000",
-      "original": "work [type development] programming",
-      "input": "work [type development] programming",
+      "id": "evtalphaaa",
+      "date": "2025-01-15T08:20:00+0000",
+      "original": "Breakfast journaling no tags just oatmeal and tea.",
+      "input": "Breakfast journaling no tags just oatmeal and tea.",
       "creator": {
         "name": "Volodyslav",
         "uuid": "81c3188c-d2cc-4879-a237-cdd0f1121346",
-        "version": "v0.1.0-674-g8b127ea",
+        "version": "0.0.0-dev",
+        "hostname": "fixturehost"
+      }
+    },
+    {
+      "id": "evtalphabb",
+      "date": "2025-03-28T12:00:00+0000",
+      "original": "Lunch walk felt good #health",
+      "input": "Lunch walk felt good #health",
+      "creator": {
+        "name": "Volodyslav",
+        "uuid": "81c3188c-d2cc-4879-a237-cdd0f1121346",
+        "version": "0.0.0-dev",
+        "hostname": "fixturehost"
+      }
+    },
+    {
+      "id": "fx-anchor-focus-a",
+      "date": "2025-02-03T09:15:00+0000",
+      "original": "Deep work sprint #focus #project-x",
+      "input": "Deep work sprint #focus #project-x",
+      "creator": {
+        "name": "Volodyslav",
+        "uuid": "81c3188c-d2cc-4879-a237-cdd0f1121346",
+        "version": "0.0.0-dev",
+        "hostname": "fixturehost"
+      }
+    },
+    {
+      "id": "evtalphacc",
+      "date": "2025-02-03T11:45:00+0000",
+      "original": "Follow-up implementation review #project-x",
+      "input": "Follow-up implementation review #project-x",
+      "creator": {
+        "name": "Volodyslav",
+        "uuid": "81c3188c-d2cc-4879-a237-cdd0f1121346",
+        "version": "0.0.0-dev",
+        "hostname": "fixturehost"
+      }
+    },
+    {
+      "id": "evtalphadd",
+      "date": "2025-02-10T07:00:00+0000",
+      "original": "Morning planning board refresh #focus",
+      "input": "Morning planning board refresh #focus",
+      "creator": {
+        "name": "Volodyslav",
+        "uuid": "81c3188c-d2cc-4879-a237-cdd0f1121346",
+        "version": "0.0.0-dev",
+        "hostname": "fixturehost"
+      }
+    },
+    {
+      "id": "fx-anchor-focus-b",
+      "date": "2025-02-10T14:40:00+0000",
+      "original": "Afternoon checkpoint, closed two tasks #focus",
+      "input": "Afternoon checkpoint, closed two tasks #focus",
+      "creator": {
+        "name": "Volodyslav",
+        "uuid": "81c3188c-d2cc-4879-a237-cdd0f1121346",
+        "version": "0.0.0-dev",
+        "hostname": "fixturehost"
+      }
+    },
+    {
+      "id": "evtalphaee",
+      "date": "2025-02-10T18:05:00+0000",
+      "original": "Evening stretch and hydration #health",
+      "input": "Evening stretch and hydration #health",
+      "creator": {
+        "name": "Volodyslav",
+        "uuid": "81c3188c-d2cc-4879-a237-cdd0f1121346",
+        "version": "0.0.0-dev",
+        "hostname": "fixturehost"
+      }
+    },
+    {
+      "id": "fx-anchor-health-a",
+      "date": "2025-03-01T07:05:00+0000",
+      "original": "Jog around the park before rain #health",
+      "input": "Jog around the park before rain #health",
+      "creator": {
+        "name": "Volodyslav",
+        "uuid": "81c3188c-d2cc-4879-a237-cdd0f1121346",
+        "version": "0.0.0-dev",
+        "hostname": "fixturehost"
+      }
+    },
+    {
+      "id": "fx-anchor-no-tags",
+      "date": "2025-03-05T19:30:00+0000",
+      "original": "Read two chapters and sketched architecture ideas.",
+      "input": "Read two chapters and sketched architecture ideas.",
+      "creator": {
+        "name": "Volodyslav",
+        "uuid": "81c3188c-d2cc-4879-a237-cdd0f1121346",
+        "version": "0.0.0-dev",
+        "hostname": "fixturehost"
+      }
+    },
+    {
+      "id": "evtalphaff",
+      "date": "2025-01-25T21:10:00+0000",
+      "original": "Debug diary: traced issue, added notes! #project-x",
+      "input": "Debug diary: traced issue, added notes! #project-x",
+      "creator": {
+        "name": "Volodyslav",
+        "uuid": "81c3188c-d2cc-4879-a237-cdd0f1121346",
+        "version": "0.0.0-dev",
+        "hostname": "fixturehost"
+      }
+    },
+    {
+      "id": "evtalphagg",
+      "date": "2025-03-05T07:55:00+0000",
+      "original": "Stacked habits today #focus #health",
+      "input": "Stacked habits today #focus #health",
+      "creator": {
+        "name": "Volodyslav",
+        "uuid": "81c3188c-d2cc-4879-a237-cdd0f1121346",
+        "version": "0.0.0-dev",
+        "hostname": "fixturehost"
+      }
+    },
+    {
+      "id": "evtalphahh",
+      "date": "2025-03-12T10:10:00+0000",
+      "original": "Team sync, punctuation test: wow, steady progress; yes. #focus",
+      "input": "Team sync, punctuation test: wow, steady progress; yes. #focus",
+      "creator": {
+        "name": "Volodyslav",
+        "uuid": "81c3188c-d2cc-4879-a237-cdd0f1121346",
+        "version": "0.0.0-dev",
+        "hostname": "fixturehost"
+      }
+    },
+    {
+      "id": "evtalphaii",
+      "date": "2025-03-12T22:45:00+0000",
+      "original": "Late tea and writing, no hashtag this time.",
+      "input": "Late tea and writing, no hashtag this time.",
+      "creator": {
+        "name": "Volodyslav",
+        "uuid": "81c3188c-d2cc-4879-a237-cdd0f1121346",
+        "version": "0.0.0-dev",
+        "hostname": "fixturehost"
+      }
+    },
+    {
+      "id": "evtalphajj",
+      "date": "2025-04-01T09:00:00+0000",
+      "original": "Quarter reset checklist #focus #project-x",
+      "input": "Quarter reset checklist #focus #project-x",
+      "creator": {
+        "name": "Volodyslav",
+        "uuid": "81c3188c-d2cc-4879-a237-cdd0f1121346",
+        "version": "0.0.0-dev",
+        "hostname": "fixturehost"
+      }
+    },
+    {
+      "id": "evtalphakk",
+      "date": "2025-04-01T09:30:00+0000",
+      "original": "Second note same day different minute #health",
+      "input": "Second note same day different minute #health",
+      "creator": {
+        "name": "Volodyslav",
+        "uuid": "81c3188c-d2cc-4879-a237-cdd0f1121346",
+        "version": "0.0.0-dev",
+        "hostname": "fixturehost"
+      }
+    },
+    {
+      "id": "evtalphall",
+      "date": "2025-04-02T16:15:00+0000",
+      "original": "Weight session complete #health",
+      "input": "Weight session complete #health",
+      "creator": {
+        "name": "Volodyslav",
+        "uuid": "81c3188c-d2cc-4879-a237-cdd0f1121346",
+        "version": "0.0.0-dev",
+        "hostname": "fixturehost"
+      }
+    },
+    {
+      "id": "evtalphamm",
+      "date": "2025-04-10T06:25:00+0000",
+      "original": "Quiet morning brain dump without tags.",
+      "input": "Quiet morning brain dump without tags.",
+      "creator": {
+        "name": "Volodyslav",
+        "uuid": "81c3188c-d2cc-4879-a237-cdd0f1121346",
+        "version": "0.0.0-dev",
+        "hostname": "fixturehost"
+      }
+    },
+    {
+      "id": "evtalphann",
+      "date": "2025-04-11T13:00:00+0000",
+      "original": "Pairing session solved parser edge #project-x #focus",
+      "input": "Pairing session solved parser edge #project-x #focus",
+      "creator": {
+        "name": "Volodyslav",
+        "uuid": "81c3188c-d2cc-4879-a237-cdd0f1121346",
+        "version": "0.0.0-dev",
+        "hostname": "fixturehost"
+      }
+    },
+    {
+      "id": "evtalphaoo",
+      "date": "2025-02-20T20:20:00+0000",
+      "original": "Watched a talk; keyword repeat project but no tag.",
+      "input": "Watched a talk; keyword repeat project but no tag.",
+      "creator": {
+        "name": "Volodyslav",
+        "uuid": "81c3188c-d2cc-4879-a237-cdd0f1121346",
+        "version": "0.0.0-dev",
+        "hostname": "fixturehost"
+      }
+    },
+    {
+      "id": "evtalphapp",
+      "date": "2025-03-18T15:35:00+0000",
+      "original": "Meal prep and hydration audit #health",
+      "input": "Meal prep and hydration audit #health",
+      "creator": {
+        "name": "Volodyslav",
+        "uuid": "81c3188c-d2cc-4879-a237-cdd0f1121346",
+        "version": "0.0.0-dev",
+        "hostname": "fixturehost"
+      }
+    },
+    {
+      "id": "evtalphaqq",
+      "date": "2025-01-30T17:05:00+0000",
+      "original": "Context weaving across weeks #focus",
+      "input": "Context weaving across weeks #focus",
+      "creator": {
+        "name": "Volodyslav",
+        "uuid": "81c3188c-d2cc-4879-a237-cdd0f1121346",
+        "version": "0.0.0-dev",
+        "hostname": "fixturehost"
+      }
+    },
+    {
+      "id": "evtalpharr",
+      "date": "2025-04-18T11:11:00+0000",
+      "original": "Final pre-release smoke pass #focus",
+      "input": "Final pre-release smoke pass #focus",
+      "creator": {
+        "name": "Volodyslav",
+        "uuid": "81c3188c-d2cc-4879-a237-cdd0f1121346",
+        "version": "0.0.0-dev",
         "hostname": "fixturehost"
       }
     }

--- a/backend/tests/mock-incremental-database-remote-populated/rendered/r/values/config
+++ b/backend/tests/mock-incremental-database-remote-populated/rendered/r/values/config
@@ -32,6 +32,26 @@
         "gym",
         "exercise [type strength] gym workout",
         "Gym workout shortcut"
+      ],
+      [
+        "focusmode",
+        "work [tag focus] #focus",
+        "Focus-mode shortcut"
+      ],
+      [
+        "healthcheck",
+        "health [tag health] #health",
+        "Health check shortcut"
+      ],
+      [
+        "shipx",
+        "work [project x] #project-x",
+        "Project X shortcut"
+      ],
+      [
+        "nightnote",
+        "journal [when night] freeform note",
+        "Night note shortcut"
       ]
     ]
   }

--- a/backend/tests/mock-incremental-database-remote-populated/rendered/r/values/events_count
+++ b/backend/tests/mock-incremental-database-remote-populated/rendered/r/values/events_count
@@ -1,4 +1,4 @@
 {
   "type": "events_count",
-  "count": 3
+  "count": 24
 }

--- a/backend/tests/populated_incremental_database_remote_smoke.test.js
+++ b/backend/tests/populated_incremental_database_remote_smoke.test.js
@@ -1,0 +1,174 @@
+const path = require("path");
+const { fromISOString, isDateTime } = require("../src/datetime");
+const { SORTED_EVENTS_CACHE_SIZE } = require("../src/generators/interface/constants");
+const { LIVE_DATABASE_WORKING_PATH } = require("../src/generators/incremental_graph");
+const { stubPopulatedIncrementalDatabaseRemote } = require("./stub_incremental_database_remote");
+const { getMockedRootCapabilities } = require("./spies");
+const {
+    stubLogger,
+    stubEnvironment,
+    stubDatetime,
+    ensureLiveDatabaseDirectory,
+} = require("./stubs");
+
+const ANCHOR_IDS = {
+    earliest: "fx-anchor-earliest",
+    focusA: "fx-anchor-focus-a",
+    focusB: "fx-anchor-focus-b",
+    healthA: "fx-anchor-health-a",
+    noTags: "fx-anchor-no-tags",
+    latest: "fx-anchor-latest",
+};
+
+async function getTestCapabilities() {
+    const capabilities = getMockedRootCapabilities();
+    stubEnvironment(capabilities);
+    stubLogger(capabilities);
+    stubDatetime(capabilities);
+    ensureLiveDatabaseDirectory(capabilities);
+    await stubPopulatedIncrementalDatabaseRemote(capabilities);
+    const liveDbPath = path.join(
+        capabilities.environment.workingDirectory(),
+        LIVE_DATABASE_WORKING_PATH
+    );
+    await capabilities.deleter.deleteDirectory(liveDbPath);
+    return capabilities;
+}
+
+async function collectAll(iter) {
+    const results = [];
+    for await (const item of iter) {
+        results.push(item);
+    }
+    return results;
+}
+
+function assertAscending(events) {
+    for (let i = 1; i < events.length; i += 1) {
+        expect(events[i - 1].date.compare(events[i].date) <= 0).toBe(true);
+    }
+}
+
+function assertDescending(events) {
+    for (let i = 1; i < events.length; i += 1) {
+        expect(events[i - 1].date.compare(events[i].date) >= 0).toBe(true);
+    }
+}
+
+describe("populated incremental-database remote smoke", () => {
+    test("bootstraps from populated fixture", async () => {
+        const capabilities = await getTestCapabilities();
+        const iface = capabilities.interface;
+        await iface.ensureInitialized();
+
+        expect(iface._incrementalGraph).toBeTruthy();
+        await expect(iface.synchronizeDatabase()).resolves.toBeUndefined();
+        expect(iface._incrementalGraph).toBeTruthy();
+    });
+
+    test("getAllEvents returns realistic fixture dataset", async () => {
+        const capabilities = await getTestCapabilities();
+        const iface = capabilities.interface;
+        await iface.ensureInitialized();
+
+        const events = await iface.getAllEvents();
+        expect(events).toHaveLength(24);
+        for (const anchorId of Object.values(ANCHOR_IDS)) {
+            expect(events.some((e) => e.id.identifier === anchorId)).toBe(true);
+        }
+        expect(events.some((e) => e.input.includes("#project-x"))).toBe(true);
+        expect(events.some((e) => e.input.includes("no tags"))).toBe(true);
+        expect(events.every((e) => isDateTime(e.date))).toBe(true);
+    });
+
+    test("getConfig and getEvent work for existing/missing ids", async () => {
+        const capabilities = await getTestCapabilities();
+        const iface = capabilities.interface;
+        await iface.ensureInitialized();
+
+        const config = await iface.getConfig();
+        expect(config.help).toBe("Event logging help text");
+        expect(config.shortcuts.some(([k]) => k === "gym")).toBe(true);
+        expect(config.shortcuts.some(([k]) => k === "shipx")).toBe(true);
+
+        const focusA = await iface.getEvent(ANCHOR_IDS.focusA);
+        expect(focusA).toBeTruthy();
+        expect(focusA.id.identifier).toBe(ANCHOR_IDS.focusA);
+        expect(focusA.input).toContain("#focus");
+        expect(focusA.date.toISOString()).toBe("2025-02-03T09:15:00.000Z");
+
+        await expect(iface.getEvent("missing-event-id")).resolves.toBe(null);
+    });
+
+    test("events_count, sorted pulls, caches, updates, context and synchronize all behave", async () => {
+        const capabilities = await getTestCapabilities();
+        const iface = capabilities.interface;
+        await iface.ensureInitialized();
+
+        const allEvents = await iface.getAllEvents();
+        const count = await iface.getEventsCount();
+        expect(count).toBe(allEvents.length);
+
+        const countEntry = await iface._incrementalGraph.pull("events_count");
+        expect(countEntry.type).toBe("events_count");
+        expect(countEntry.count).toBe(24);
+
+        const desc = await collectAll(iface.getSortedEvents("dateDescending"));
+        const asc = await collectAll(iface.getSortedEvents("dateAscending"));
+        assertDescending(desc);
+        assertAscending(asc);
+        expect(desc.map((e) => e.id.identifier)).toEqual(
+            [...asc].reverse().map((e) => e.id.identifier)
+        );
+
+        const descNode = await iface._incrementalGraph.pull("sorted_events_descending");
+        const ascNode = await iface._incrementalGraph.pull("sorted_events_ascending");
+        expect(descNode.type).toBe("sorted_events_descending");
+        expect(ascNode.type).toBe("sorted_events_ascending");
+        expect(descNode.events.map((e) => e.id)).toEqual(
+            [...ascNode.events].reverse().map((e) => e.id)
+        );
+
+        const lastEntries = await iface._incrementalGraph.pull("last_entries", [SORTED_EVENTS_CACHE_SIZE]);
+        const firstEntries = await iface._incrementalGraph.pull("first_entries", [SORTED_EVENTS_CACHE_SIZE]);
+        expect(lastEntries.events).toHaveLength(24);
+        expect(firstEntries.events).toHaveLength(24);
+        expect(lastEntries.events.map((e) => e.id)).toEqual(desc.map((e) => e.id.identifier));
+        expect(firstEntries.events.map((e) => e.id)).toEqual(asc.map((e) => e.id.identifier));
+
+        const newEvents = [
+            {
+                id: { identifier: "fx-smoke-new-1" },
+                date: fromISOString("2025-04-21T08:00:00.000Z"),
+                original: "Smoke inserted newest #focus",
+                input: "Smoke inserted newest #focus",
+                creator: { name: "test", uuid: "00000000-0000-0000-0000-000000000001", version: "0.0.0-dev", hostname: "test-host" },
+            },
+            {
+                id: { identifier: "fx-smoke-new-2" },
+                date: fromISOString("2025-01-01T08:00:00.000Z"),
+                original: "Smoke inserted oldest",
+                input: "Smoke inserted oldest",
+                creator: { name: "test", uuid: "00000000-0000-0000-0000-000000000001", version: "0.0.0-dev", hostname: "test-host" },
+            },
+        ];
+
+        await iface.update([...allEvents, ...newEvents]);
+        expect(await iface.getEventsCount()).toBe(26);
+        expect(await iface.getEvent(ANCHOR_IDS.focusA)).toBeTruthy();
+        expect(await iface.getEvent("fx-smoke-new-1")).toBeTruthy();
+
+        const updatedDesc = await collectAll(iface.getSortedEvents("dateDescending"));
+        expect(updatedDesc[0].id.identifier).toBe("fx-smoke-new-1");
+
+        const focusEvent = await iface.getEvent(ANCHOR_IDS.focusA);
+        const focusContextEvents = await iface.getEventBasicContext(focusEvent);
+        expect(focusContextEvents.length > 0).toBe(true);
+        expect(focusContextEvents.some((e) => e.id.identifier === ANCHOR_IDS.noTags)).toBe(false);
+
+        await iface.synchronizeDatabase();
+        expect(await iface.getEventsCount()).toBe(26);
+        expect((await iface.getConfig()).help).toBe("Event logging help text");
+        expect(await iface.getEvent("fx-smoke-new-1")).toBeTruthy();
+    });
+});


### PR DESCRIPTION
### Motivation
- The existing populated incremental-database fixture contained only 3 events which was too small to exercise realistic sorting, cache and context behavior. 
- Add a deterministic, reviewer-friendly dataset (~24 events) with stable anchor IDs to enable reliable smoke coverage of graph nodes and iterators. 
- Provide a smoke-suite that proves key nodes are computable from the rendered snapshot rather than pre-materialized.

### Description
- Replaced and expanded populated fixture files under `backend/tests/mock-incremental-database-remote-populated/rendered/r/values/`: updated `all_events` (24 deterministic events with pinned `creator.version = "0.0.0-dev"` and stable `fx-anchor-*` IDs), `events_count` (set to `24`), and extended `config` shortcuts. 
- Added a new smoke test file `backend/tests/populated_incremental_database_remote_smoke.test.js` which bootstraps from the populated remote and validates `getAllEvents()`, `getConfig()`, `getEvent()`, `getEventsCount()`, `getSortedEvents()` (both orders), `sorted_events_*` node pulls, `first_entries`/`last_entries` cache behavior (using `SORTED_EVENTS_CACHE_SIZE`), update-on-top flows, basic context sampling and `synchronizeDatabase()` persistence. 
- Kept the fixture scope limited to pre-materialized nodes (`all_events`, `config`, `events_count`) so other nodes (`event(e)`, `sorted_events_*`, cache nodes) are verified as computed by the smoke tests. 
- Adjusted test harness expectations in `backend/tests/interface.test.js` to account for the larger populated fixture and increased the test timeout to reduce flakiness when bootstrapping the richer fixture.

### Testing
- Ran `npx jest backend/tests/populated_incremental_database_remote_smoke.test.js`, which passed. 
- Ran targeted bootstrap assertions via `npx jest backend/tests/interface.test.js -t "bootstrap path selection"`, which passed after updating the expected count and timeout. 
- Ran static analysis via `npm run static-analysis`, which passed. 
- Ran frontend build via `npm run build`, which passed. 
- Running the entire test suite (`npm test`) was attempted; some long-running/time-sensitive tests in the broader `interface` test file required timeout adjustments and targeted fixes and caused transient failures during iteration, so the PR focuses on the smoke coverage and fixture changes with targeted test runs passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0683ab0b04832e99c8ea739e53b07e)