### PR TITLE
docs: make legacy NodeIdentifier migration deterministic per NodeKey

### DIFF
--- a/docs/plan1.md
+++ b/docs/plan1.md
@@ -99,7 +99,10 @@ Replace (not preserve) the current `NodeKey`-addressed migration callback surfac
 - [ ] Remove both lookup entries and all identifier-keyed state for migration `delete`
 
 Then, write a single migration that will migrate the database from `NodeKey`-based storage to `NodeIdentifier`-based one.
-For this one-time legacy `NodeKey` -> `NodeIdentifier` migration, identifiers must be deterministic from the old `NodeKey` (still conform to `[a-z]*` regex of `basicString(length=9)`). To achieve this, set a fixed `seed` for the random generator, and then from that seed, generate all the `basicString(length=9)` values.
+For this one-time legacy `NodeKey` -> `NodeIdentifier` migration, identifiers must be deterministic from the old `NodeKey` (still conform to `[a-z]*` regex of `basicString(length=9)`), **and must not depend on traversal order**.
+- [ ] Do **not** use a single global fixed-seed generator consumed in iteration order; migration traversal order can change (for example, by key enumeration or topology tie-break differences), which would remap stable nodes to different identifiers across runs.
+- [ ] Instead, derive each legacy node’s candidate identifier from that node’s own `NodeKey` in an order-independent way (for example: key-derived deterministic PRNG seed or hash-to-identifier mapping), then resolve rare collisions with a deterministic per-key retry sequence.
+- [ ] Add a regression test that runs the legacy migration from the same source data under two different node-iteration orders and asserts the resulting `identifiers_keys_map` is identical.
 This requires changing the existing migration API for all future migrations so the migration surface is consistently `NodeIdentifier`-based; do not keep a mixed `NodeKey`/`NodeIdentifier` migration mode, even temporarily.
 
 ## 5. HTTP inspection API


### PR DESCRIPTION
### Motivation
- The original plan suggested assigning legacy identifiers by consuming a single fixed-seed RNG in traversal order, which contradicts the stated requirement that identifiers be deterministic from `NodeKey` because traversal/enumeration order can vary across runs and implementations. 
- The repository’s migration and key-enumeration code is traversal-driven (for example `migration_runner.js` and topo-sort tie-breakers), so relying on iteration order for id assignment is fragile and likely to produce inconsistent mappings.

### Description
- Updated `docs/plan1.md` migration section to forbid using a global fixed-seed generator consumed in iteration order and to require order-independent per-key deterministic id derivation (for example key-derived hash or per-key PRNG seed) together with deterministic collision resolution. 
- Added an explicit requirement to add a regression test that runs the legacy `NodeKey -> NodeIdentifier` migration under at least two different node-iteration orders and asserts the resulting `identifiers_keys_map` is identical. 
- Kept all other plan text and scope unchanged; this is a narrow, behavioral correction to the legacy migration guidance so implementers cannot inadvertently introduce order-dependent identifier assignments.

### Testing
- I validated the documentation change with `git diff -- docs/plan1.md` which shows the intended modifications. 
- I verified repository state with `git status --short` after committing the change. 
- No automated runtime/unit tests were executed because this change is documentation-only; implementers should add the described regression test as part of the feature implementation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06b926e700832ea38f5e4bf591b9c5)