### PR TITLE
docs: require NodeIdentifier-only IncrementalGraph methods

### DIFF
--- a/docs/plan1.md
+++ b/docs/plan1.md
@@ -61,6 +61,11 @@ then run concrete-node operations by identifier.
 
 - [ ] Refactor `graph_storage.js` so graph-state sublevels are keyed by `NodeIdentifier`, not `NodeKeyString`
 - [ ] Refactor `incremental_graph/class.js` so that all of `IncrementalGraph` methods accept (and return) `NodeIdentifier`, not `NodeKeyString`. The `NodeKeyString` must not even be imported into that module.
+- [ ] Remove the `(head, args)` concrete-node addressing model from `IncrementalGraph` entirely.
+  - [ ] `IncrementalGraph` concrete-node methods must accept a single `NodeIdentifier` argument (or `NodeIdentifier[]` for collections), never `(head, args)`.
+  - [ ] This includes all pull variants, invalidate variants, delete variants, concrete-node read/write helpers, dependency/revdep helpers, and any internal helper that currently reconstructs a `NodeKey` from `(head, args)`.
+  - [ ] Any method that currently returns `(head, args)` for concrete nodes must return `NodeIdentifier` (or objects keyed by `nodeIdentifier`) instead.
+  - [ ] The only `NodeKey`-typed methods on `IncrementalGraph` are the translation bridge methods `nodeKeyToId(nodeKey)` and `nodeIdToKey(id)`.
 - [ ] Add two methods to `IncrementalGraph` public interface:
   - [ ] `nodeKeyToId`
   - [ ] `nodeIdToKey`

--- a/docs/specs/keys-design.md
+++ b/docs/specs/keys-design.md
@@ -46,6 +46,12 @@ After that conversion, concrete-node operations run by id (for example
 `deleteById(id)`).
 
 No mixed model is allowed where some concrete-node operations remain `NodeKey`-addressed.
+No mixed model is allowed where some concrete-node operations remain `(head, args)`-addressed.
+
+`(head, args)` is semantic construction data for `NodeKey`, not a concrete-node
+address. Outside schema/head APIs and the explicit translation bridge, `(head, args)`
+must not be used as an addressing input, output, or internal transport shape for
+concrete-node logic.
 
 ### Schema/head APIs
 
@@ -237,7 +243,13 @@ Accordingly:
 
 ## API invariants
 
+- every concrete-node `IncrementalGraph` method uses `NodeIdentifier` arguments/returns
 - concrete-node read/write/invalidate/delete/pull/inspection operations use `NodeIdentifier`
+- this includes all pull variants and invalidate variants, with no exceptions
+- `(head, args)` concrete-node method signatures are forbidden
+- the only `NodeKey`-typed concrete-node bridge methods are:
+  - `nodeKeyToId(nodeKey)`
+  - `nodeIdToKey(id)`
 - schema/head family operations may remain schema/head-based
 - HTTP concrete-node routes are identifier-based
 - HTTP schema routes may remain schema/head-based


### PR DESCRIPTION
### Motivation

- Eliminate ambiguity and mixed addressing in the graph layer by making `NodeIdentifier` the single concrete-node address for `IncrementalGraph` methods. 
- Prevent accidental reintroduction of the legacy `(head, args)` concrete-node model that leaks `NodeKey` semantics into persistence, migration, rendering, and HTTP inspection. 
- Make the translation boundary explicit so callers must use `nodeKeyToId`/`nodeIdToKey` when starting from a `NodeKey`, avoiding implicit conversions scattered through the codebase. 

### Description

- `docs/plan1.md` was updated to explicitly require removing the `(head, args)` concrete-node addressing model from `IncrementalGraph` and to require that every concrete-node method accept/return a single `NodeIdentifier` (or `NodeIdentifier[]`), including all pull/invalidate/delete variants and internal helpers, while reserving only `nodeKeyToId` and `nodeIdToKey` as `NodeKey`-typed bridge methods. 
- `docs/specs/keys-design.md` was updated to forbid any mixed concrete-node addressing with `(head, args)`, to clarify that `(head, args)` is construction data for `NodeKey` and not a concrete-node address, and to strengthen the API invariants so every concrete-node `IncrementalGraph` method is `NodeIdentifier`-based with no exceptions. 
- The changes clarify expectations for related surfaces that must be migrated (migration callbacks, HTTP inspection routes/payloads, render/scan filesystem paths, and storage/bijection handling) so implementers do not accidentally retain `NodeKey`-addressed code paths. 

### Testing

- No automated tests were executed for this documentation-only change. 
- Recommend running `npm test`, `npm run static-analysis`, and `npm run build` after implementing the code changes described in `docs/plan1.md` to validate behavior and preserve invariants.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06babecd08832ea00de1cad73ec107)