### PR TITLE
Clarify NodeKey/NodeIdentifier boundary in plan and keys design spec

### DIFF
--- a/docs/plan1.md
+++ b/docs/plan1.md
@@ -54,22 +54,21 @@ The semantic `NodeKey` should remain recoverable through explicit lookup tables.
 
 ## 3. Storage boundary and lifecycle behavior
 
-Make `NodeIdentifier` the normal concrete-node address for IncrementalGraph operations.
-`NodeKey` remains semantic identity and the explicit lookup input to `nodeKeyToId(nodeKey)`.
-If a caller starts with a `NodeKey`, it must resolve `id = nodeKeyToId(nodeKey)` first and
-then run concrete-node operations by identifier.
+`IncrementalGraph` is the conversion boundary.
 
+- Public graph-facing APIs remain semantic-key based (`NodeKey` and existing `head + args` forms).
+- At the public method boundary (`pull`, `invalidate`, `unsafePull`, `unsafeInvalidate`, `getValue`, `getFreshness`, timestamp/inspection helpers), convert immediately to `NodeIdentifier`.
+- After this conversion point, all internals (storage, recompute, invalidation propagation, migration/sync/render/scan interactions) must use `NodeIdentifier` only.
+
+- [ ] Keep public `IncrementalGraph` concrete-node API signatures `NodeKey`/`head+args` based (`pull`, `invalidate`, `unsafePull`, `unsafeInvalidate`, `getValue`, `getFreshness`, timestamp helpers, inspection helpers)
+- [ ] Refactor `incremental_graph/class.js` internals so conversion from `NodeKey`/`head+args` to `NodeIdentifier` happens immediately at method entry before storage/internal calls
+  - [ ] Add focused tests that assert public methods still accept `head + args` and do not require callers to resolve ids first
+  - [ ] Add focused tests that verify internal calls below the boundary are `NodeIdentifier`-only (no `NodeKeyString` passed into storage/migration/sync helpers)
+- [ ] Keep `nodeKeyToId` / `nodeIdToKey` as lower-level translation helpers (storage/internal boundary), not public `IncrementalGraph` methods
+  - [ ] Place them in storage/database-facing helper modules used by `IncrementalGraph` internals and migration/sync/render paths
+  - [ ] Add tests that guard against re-introducing `graph.nodeKeyToId(...)` / `graph.nodeIdToKey(...)` on the public interface
 - [ ] Refactor `graph_storage.js` so graph-state sublevels are keyed by `NodeIdentifier`, not `NodeKeyString`
-- [ ] Refactor `incremental_graph/class.js` so that all of `IncrementalGraph` methods accept (and return) `NodeIdentifier`, not `NodeKeyString`. The `NodeKeyString` must not even be imported into that module.
-- [ ] Remove the `(head, args)` concrete-node addressing model from `IncrementalGraph` entirely.
-  - [ ] `IncrementalGraph` concrete-node methods must accept a single `NodeIdentifier` argument (or `NodeIdentifier[]` for collections), never `(head, args)`.
-  - [ ] This includes all pull variants, invalidate variants, delete variants, concrete-node read/write helpers, dependency/revdep helpers, and any internal helper that currently reconstructs a `NodeKey` from `(head, args)`.
-  - [ ] Any method that currently returns `(head, args)` for concrete nodes must return `NodeIdentifier` (or objects keyed by `nodeIdentifier`) instead.
-  - [ ] The only `NodeKey`-typed methods on `IncrementalGraph` are the translation bridge methods `nodeKeyToId(nodeKey)` and `nodeIdToKey(id)`.
-- [ ] Add two methods to `IncrementalGraph` public interface:
-  - [ ] `nodeKeyToId`
-  - [ ] `nodeIdToKey`
-- [ ] Make all internal logic work on `NodeIdentifier` instead of `NodeKey`. Including, but not limited to:
+- [ ] Make all internal logic below the boundary use `NodeIdentifier` instead of `NodeKey`. Including, but not limited to:
   - [ ] Update `inputs` and `revdeps` persistence so all stored references are `NodeIdentifier[]`
     - [ ] When rewriting `inputs`, preserve original input order so `inputs[i]` still corresponds to `inputCounters[i]`; only translate each element from `NodeKeyString` to `NodeIdentifier` without reordering.
   - [ ] Preserve deterministic revdeps ordering by sorting `NodeIdentifier` values in ascending lexicographic order (do not consult `NodeKey` for ordering)
@@ -84,8 +83,7 @@ then run concrete-node operations by identifier.
   - [ ] Ensure merged-input-map construction, topo ordering, and revdeps rebuild run only after the above validation succeeds.
 - [ ] Update invalidation and recompute paths to reuse existing identifiers and never allocate duplicates
 - [ ] Update deletion paths so deleting a node removes both lookup entries and all identifier-keyed state
-- [ ] Old key-addressed concrete-node APIs must be removed once identifier-based paths exist. Remove key-path transforms, key-based storage helpers, and key-based rendering helpers. Outside schema/head APIs and the explicit lookup bridge (`nodeKeyToId` / `nodeIdToKey`), concrete-node operations must not be `NodeKey`-addressed.
-
+- [ ] Remove legacy key-based concrete-node storage internals after boundary conversion is in place. Outside public API entrypoints and semantic-schema helpers, concrete-node operations must not be `NodeKey`-addressed.
 ## 4. Migration behavior
 
 Replace (not preserve) the current `NodeKey`-addressed migration callback surface with a fully `NodeIdentifier`-addressed one, while keeping identifier stability where required by the design.
@@ -112,25 +110,18 @@ This requires changing the existing migration API for all future migrations so t
 
 ## 5. HTTP inspection API
 
-Refactor the internal HTTP inspection surface so concrete-node addressing matches the
-identifier-addressed storage model directly.
+Keep the HTTP graph API compatible with the existing public graph model.
+Concrete-node routes stay `head + args` addressed, while handler internals convert to
+`NodeIdentifier` at the same `IncrementalGraph` boundary.
 
-- [ ] Change the HTTP inspection API so concrete-node operations address nodes by `NodeIdentifier`, not by `head/args`
-- [ ] Update the HTTP graph API spec, route shapes, handlers, and tests to the identifier-based concrete-node model
-  - [ ] Replace concrete-node `head/args` routes (`/graph/nodes/:head`, `/graph/nodes/:head/*` and the matching POST/DELETE handlers) with identifier-addressed concrete-node routes, and remove all URL-arg decoding logic tied to concrete-node addressing.
-    - Current handlers rely on wildcard path parsing (`req.params[0]`) plus `getArgsFromRequest()` in `backend/src/routes/graph_helpers.js` to recover `ConstValue[]` from URL segments (including encoded `/` and `~`-prefixed non-strings). If this helper path is left in place after route migration, identifier endpoints can accidentally continue treating identifiers as split arg vectors or apply JSON-ish decoding to IDs.
-    - Define explicit concrete-node routes that take one opaque identifier segment (for example `GET/POST/DELETE /graph/nodes/id/:nodeIdentifier`) and ensure handlers call identifier-based interface methods directly rather than reconstructing `(head, args)` from the URL.
-    - Keep schema endpoints head-based (`/graph/schemas`, `/graph/schemas/:head`) and do not route them through identifier parsing.
-    - Update route registration order/comments in `backend/src/routes/graph.js`: wildcard-first ordering is currently required only for `:head/*`; once identifier routes are used, preserve only the ordering constraints that still apply.
-    - Replace route tests that currently assert head/args parsing behavior (including encoded slash and `~` decoding cases) with identifier-focused tests that assert identifiers are passed through as opaque strings and never decoded as `ConstValue` arguments.
-  - [ ] Update list/read response payloads so concrete-node records returned by HTTP inspection are identifier-addressed, not `(head,args)`-addressed.
-    - Current `GET /graph/nodes` and `GET /graph/nodes/:head` handlers in `backend/src/routes/graph.js` enumerate materialized nodes from `interface.listMaterializedNodes()` and emit `{ id, head, args, freshness, ... }` objects. After route migration, this payload shape leaves clients unable to call identifier-addressed pull/delete/invalidate endpoints without recomputing keys.
-    - Introduce interface/inspection methods that can enumerate concrete nodes by `NodeIdentifier` (with freshness/value/timestamps), and have HTTP handlers read from those methods directly instead of re-keying from `(head,args)`.
-    - Keep any schema-oriented responses head-based, but require concrete-node response objects (lists and single-node reads) to carry `nodeIdentifier` as the addressing field used by follow-up concrete-node operations.
-    - Update `backend/tests/graph_routes.test.js` assertions to reject legacy concrete-node payloads that omit `nodeIdentifier` and to verify round-trip workflow (`list` → `GET/POST/DELETE by id`) without any `head/args` URL construction.
-    - Add at least one regression test for encoded-looking identifiers to prove response-to-route flow treats identifiers as opaque and never applies argument-decoding semantics.
-- [ ] Keep the schema-oriented HTTP endpoints aligned with the public graph model where they are still head-based rather than concrete-node based
-
+- [ ] Keep HTTP concrete-node routes `head/args` based (`/graph/nodes/:head`, `/graph/nodes/:head/*`, and matching POST/DELETE flows)
+- [ ] Do **not** introduce identifier-addressed public concrete-node routes such as `/graph/nodes/id/:nodeIdentifier`
+- [ ] Keep request parsing behavior in `backend/src/routes/graph.js` and `graph_helpers.js` aligned with current head/args semantics
+- [ ] Add regression tests that protect against accidental identifier leakage into HTTP API:
+  - [ ] round-trip workflows remain `list/read/pull/invalidate` via `head + args`
+  - [ ] responses do not require caller-visible `NodeIdentifier` for follow-up operations
+  - [ ] encoded arg parsing behavior remains intact where currently supported
+- [ ] Add integration tests that prove HTTP handlers can stay head/args-facing while graph internals execute identifier-native storage paths after boundary conversion
 ## 6. Filesystem snapshot simplification
 
 Simplify snapshot rendering and scanning around direct identifier paths, with readable
@@ -164,4 +155,4 @@ Update the documentation and focused tests so the new identifier-addressed model
 fully specified and regression-protected.
 
 - [ ] Update docs and tests that currently assert raw `NodeKeyString` storage in `inputs`, `revdeps`, rendering, migration, and unification
-- [ ] Add focused tests for identifier allocation, lookup bijection, stable id reuse, migration preservation, identifier-based HTTP inspection, and snapshot round-tripping
+- [ ] Add focused tests for identifier allocation, lookup bijection, stable id reuse, migration preservation, head+args HTTP API boundary protections, identifier-native internals validation, and snapshot round-tripping

--- a/docs/specs/keys-design.md
+++ b/docs/specs/keys-design.md
@@ -9,7 +9,7 @@ This model separates three concerns:
 
 - `NodeKey` is the semantic identity of a concrete node instance
 - `NodeIdentifier` is the persisted storage identity of a materialized node
-- filesystem snapshots and the HTTP inspection API operate directly on stored identifiers
+- filesystem snapshots and internal storage operate directly on stored identifiers
 
 This document is the **intended target design specification** for IncrementalGraph
 node addressing. It describes the model as it is meant to be.
@@ -24,34 +24,29 @@ node addressing. It describes the model as it is meant to be.
 
 ## Boundary
 
-Concrete-node operations are `NodeIdentifier`-addressed.
+Public concrete-node operations remain `NodeKey`-addressed (`head + args` / `NodeKey`).
 
-`NodeKey` remains important, but only as semantic identity and as the explicit lookup
-input to:
+`IncrementalGraph` is the conversion boundary:
 
-- `nodeKeyToId(nodeKey)`
-- `nodeIdToKey(id)`
+- Public callers and HTTP routes provide semantic keys (`head + args` / `NodeKey`).
+- At public method entry, `IncrementalGraph` resolves to `NodeIdentifier` immediately.
+- All logic below that boundary (storage, recompute, invalidation propagation, migration, sync, render, scan) is identifier-native.
+
+`nodeKeyToId(nodeKey)` and `nodeIdToKey(id)` are internal/lower-level translation helpers,
+not public `IncrementalGraph` methods and not HTTP API operations.
 
 ### Required workflow
 
-If a caller has only a `NodeKey` and needs to operate on a concrete materialized node,
-it must first resolve the identifier:
+Upstream/public workflow stays semantic:
 
 ```js
-const id = await nodeKeyToId(nodeKey);
+await graph.pull(head, args);
+await graph.invalidate(head, args);
 ```
 
-After that conversion, concrete-node operations run by id (for example
-`getValueById(id)`, `getFreshnessById(id)`, `invalidateById(id)`, `pullById(id)`,
-`deleteById(id)`).
+Internal workflow converts once at the boundary, then stays identifier-native.
 
-No mixed model is allowed where some concrete-node operations remain `NodeKey`-addressed.
-No mixed model is allowed where some concrete-node operations remain `(head, args)`-addressed.
-
-`(head, args)` is semantic construction data for `NodeKey`, not a concrete-node
-address. Outside schema/head APIs and the explicit translation bridge, `(head, args)`
-must not be used as an addressing input, output, or internal transport shape for
-concrete-node logic.
+No mixed model is allowed where storage-layer concrete-node operations remain `NodeKey`-addressed after boundary conversion.
 
 ### Schema/head APIs
 
@@ -70,11 +65,12 @@ There is no mixed-mode migration API: `NodeKey`-addressed migration payloads are
 
 ### HTTP inspection API
 
-The HTTP inspection API is not a user-facing API. It is an internal development and
-inspection surface.
+HTTP concrete-node routes remain `head + args` based to preserve existing API behavior.
 
-Every HTTP operation that addresses a concrete node uses `NodeIdentifier`.
-Schema/head inspection endpoints may remain schema/head-oriented.
+- Route addressing remains semantic (`head + args`).
+- Handlers call the public graph API in semantic form.
+- Identifier conversion happens inside `IncrementalGraph` at the same boundary as non-HTTP callers.
+- `NodeIdentifier` is not exposed as required request-addressing for public graph routes.
 
 ## NodeIdentifier requirements
 
@@ -115,7 +111,6 @@ This applies to:
 - values inside `revdeps`
 - all migration callback payloads and migration-produced state
 - filesystem-rendered snapshots
-- HTTP API addressing of concrete nodes
 
 ### Graph-state sublevels
 
@@ -148,6 +143,21 @@ These functions operate on the `/${current_replica}/global/identifiers_keys_map`
 Here `${current_replica}` is the replica name of the current database instance, for example `x` or `y`.
 
 `NodeKeyString` may remain persisted only in this lookup table at `/${current_replica}/global/identifiers_keys_map`.
+
+The map is the materialized-node identity table, with a strict invariant:
+
+1. contains every materialized node;
+2. contains only materialized nodes.
+
+Lifecycle rules:
+
+- `NodeIdentifier` allocation happens when a node becomes materialized (not on arbitrary key mention/lookups).
+- `nodeKeyToId(nodeKey)` is an internal lookup helper and must not allocate for non-materialized nodes.
+- if `nodeKeyToId(nodeKey)` is called for a non-materialized node, it returns missing (or equivalent lookup-miss error/value).
+- the materialization write path is responsible for atomically inserting both graph-state records and id↔key entry.
+- node deletion/de-materialization path is responsible for atomically removing both graph-state records and id↔key entry.
+- `inputs`/`revdeps` may reference only materialized-node identifiers; they must never require lookup entries for non-materialized nodes.
+- migration/render/scan/sync validation must fail fast if any graph-state id lacks a key entry, or if any key entry exists without materialized graph-state presence.
 
 ## Allocation and stability
 
@@ -243,18 +253,14 @@ Accordingly:
 
 ## API invariants
 
-- every concrete-node `IncrementalGraph` method uses `NodeIdentifier` arguments/returns
-- concrete-node read/write/invalidate/delete/pull/inspection operations use `NodeIdentifier`
-- this includes all pull variants and invalidate variants, with no exceptions
-- `(head, args)` concrete-node method signatures are forbidden
-- the only `NodeKey`-typed concrete-node bridge methods are:
-  - `nodeKeyToId(nodeKey)`
-  - `nodeIdToKey(id)`
-- schema/head family operations may remain schema/head-based
-- HTTP concrete-node routes are identifier-based
-- HTTP schema routes may remain schema/head-based
-- migration APIs are identifier-based
-- no mixed migration callback surface is allowed
+- public `IncrementalGraph` methods remain semantic (`NodeKey` / `head + args`)
+- `pull`, `invalidate`, `unsafePull`, `unsafeInvalidate`, `getValue`, `getFreshness`, and timestamp/inspection helpers are all semantic at the public boundary
+- `IncrementalGraph` converts to `NodeIdentifier` immediately at method entry
+- concrete-node read/write/recompute/invalidate/delete/inspection/storage operations below that boundary use `NodeIdentifier`
+- `nodeKeyToId(nodeKey)` and `nodeIdToKey(id)` are internal translation helpers, not public graph-interface methods
+- HTTP concrete-node routes remain semantic (`head + args`)
+- migration APIs are identifier-based internally
+- no mixed model below the boundary is allowed
 
 ## Invariants
 


### PR DESCRIPTION
### Motivation

- The existing plan promoted leaking `NodeIdentifier` into public APIs and HTTP routes, which contradicts the intended semantic/addressing separation. 
- The change restores `IncrementalGraph` as the explicit conversion boundary so the public API and HTTP routes remain `NodeKey`/`head + args` while internals and storage are identifier-native. 
- The identifier↔key lookup table needed a clearer, simpler invariant and lifecycle description to avoid accidental allocations or stale mappings.

### Description

- Updated `docs/plan1.md` to keep public `IncrementalGraph` methods and HTTP concrete-node routes `NodeKey`/`head+args`-based and to require immediate conversion to `NodeIdentifier` at the `IncrementalGraph` method entry, with tasks/tests to guard against identifier leakage. 
- Reworked the HTTP inspection section in `docs/plan1.md` to preserve existing `head/args` routes and added regression/test tasks that ensure handlers continue to accept semantic keys while internals operate on identifiers. 
- Updated `docs/specs/keys-design.md` to state explicitly that `NodeKey` is public semantic identity, `NodeIdentifier` is internal persisted identity, `IncrementalGraph` is the conversion boundary, and `nodeKeyToId`/`nodeIdToKey` are internal helpers; also added the strict materialized-node map invariant and lifecycle rules. 
- Kept lower-level identifier-storage goals (identifier-native storage, migration, render/scan, sync) intact while removing claims that `nodeKeyToId` should be a public `IncrementalGraph` interface; committed edits to both documents.

### Testing

- Performed a repository audit (search and file reads) to validate the edits against current code paths and confirm `IncrementalGraph` and HTTP code remain head/args-facing; these inspection commands completed successfully. 
- No automated unit/integration test suite was executed in this edit; before landing code changes that implement the plan run `npm test`, `npm run static-analysis`, and `npm run build` to verify the repo. 
- Recommended focused automated checks to run after implementation: `npx jest` for `backend/tests/` (especially graph routes, incremental graph, database render/synchronize/gitstore, migration, revdeps-ordering, and sync/merge tests) and the bijection/allocation tests described in the plan to validate the lookup-map invariant and boundary conversion behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a078f29c4f0832e91386b501e0114b0)