### PR TITLE
docs: pin listMaterializedNodes semantic boundary in plan1

### DIFF
--- a/docs/plan1.md
+++ b/docs/plan1.md
@@ -61,6 +61,10 @@ The semantic `NodeKey` should remain recoverable through explicit lookup tables.
 - After this conversion point, all internals (storage, recompute, invalidation propagation, migration/sync/render/scan interactions) must use `NodeIdentifier` only.
 
 - [ ] Keep public `IncrementalGraph` concrete-node API signatures `NodeKey`/`head+args` based (`pull`, `invalidate`, `unsafePull`, `unsafeInvalidate`, `getValue`, `getFreshness`, timestamp helpers, inspection helpers)
+- [ ] Keep `listMaterializedNodes()` as a semantic API returning `[head, args]`, even after storage keys become `NodeIdentifier`
+  - [ ] Update `inspection.js` + `graph_storage.js` boundary so materialization listing reads identifier-keyed materialized records, translates each id through `nodeIdToKey`, then deserializes to existing `[head, args]` route-facing output.
+  - [ ] Treat missing/invalid bijection entries during this translation as hard errors (fail-fast), not as silently skipped nodes; otherwise `/graph/nodes` can hide durable corruption.
+  - [ ] Add a regression test for `/graph/nodes` and `listMaterializedNodes()` proving no caller-visible `NodeIdentifier` leakage and stable pre-migration response shape.
 - [ ] Refactor `incremental_graph/class.js` internals so conversion from `NodeKey`/`head+args` to `NodeIdentifier` happens immediately at method entry before storage/internal calls
   - [ ] Add focused tests that assert public methods still accept `head + args` and do not require callers to resolve ids first
   - [ ] Add focused tests that verify internal calls below the boundary are `NodeIdentifier`-only (no `NodeKeyString` passed into storage/migration/sync helpers)


### PR DESCRIPTION
### Motivation
- The current inspection path (`internalListMaterializedNodes`) reads `storage.listMaterializedNodes()` and immediately calls `deserializeNodeKey(...)`, so a migration to identifier-keyed storage would either leak `NodeIdentifier` values to `/graph/nodes` or silently drop materialized entries unless the plan explicitly preserves the semantic boundary and translation behavior (see `backend/src/generators/incremental_graph/inspection.js`).

### Description
- Updated `docs/plan1.md` to explicitly require that `listMaterializedNodes()` remain a semantic API returning `[head, args]`, to mandate translating identifier-keyed records via the bijection at the `inspection.js` / `graph_storage.js` boundary, to treat missing/invalid bijection entries as hard errors, and to add a regression test requirement preventing `NodeIdentifier` leakage into `/graph/nodes`.

### Testing
- No automated unit/integration tests were executed as part of this documentation-only change; only repository inspections (`rg`, `sed`) and a local diff check were performed to validate the edit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0798f62360832e94e91e644ff5ee9a)