### PR TITLE
docs: align plan1 public API boundary with identifier design

### DIFF
--- a/docs/plan1.md
+++ b/docs/plan1.md
@@ -64,6 +64,10 @@ The semantic `NodeKey` should remain recoverable through explicit lookup tables.
 - [ ] Refactor `incremental_graph/class.js` internals so conversion from `NodeKey`/`head+args` to `NodeIdentifier` happens immediately at method entry before storage/internal calls
   - [ ] Add focused tests that assert public methods still accept `head + args` and do not require callers to resolve ids first
   - [ ] Add focused tests that verify internal calls below the boundary are `NodeIdentifier`-only (no `NodeKeyString` passed into storage/migration/sync helpers)
+- [ ] Remove the remaining `NodeKeyString`-addressed graph methods from the public class surface in `incremental_graph/class.js` (`pullByNodeKeyStringWithStatus`, `pullByNodeKeyStringWithStatusDuringPull`)
+  - [ ] Keep equivalent functionality as internal-only helpers for recompute/pull internals (for example in `pull.js`) so recursion does not re-open a semantic/public boundary.
+  - [ ] Update `recompute.js` capability typing to depend on identifier-native/internal helper calls instead of public `NodeKeyString` class methods.
+  - [ ] Add a regression test that public graph-facing routes and interface flows still work, while no public `NodeKeyString`-addressed concrete-node entrypoints remain exposed on the graph object.
 - [ ] Keep `nodeKeyToId` / `nodeIdToKey` as lower-level translation helpers (storage/internal boundary), not public `IncrementalGraph` methods
   - [ ] Place them in storage/database-facing helper modules used by `IncrementalGraph` internals and migration/sync/render paths
   - [ ] Add tests that guard against re-introducing `graph.nodeKeyToId(...)` / `graph.nodeIdToKey(...)` on the public interface


### PR DESCRIPTION
### Motivation
- The design in `docs/specs/keys-design.md` mandates that public concrete-node operations remain semantic (`head + args`) and that identifier conversion occurs at the `IncrementalGraph` boundary.  
- The current codebase still exposes `pullByNodeKeyStringWithStatus` and `pullByNodeKeyStringWithStatusDuringPull` on the public `IncrementalGraph` class, which contradicts the intended boundary and risks misleading implementers to keep a key-string public surface. 

### Description
- Edited `docs/plan1.md` to add an explicit task to remove the `NodeKeyString`-addressed public methods `pullByNodeKeyStringWithStatus` and `pullByNodeKeyStringWithStatusDuringPull` from `incremental_graph/class.js`.  
- Added instructions to preserve equivalent behavior as internal-only helpers (e.g., in `pull.js`) and to update `recompute.js` capability typing to depend on identifier-native/internal helpers rather than public `NodeKeyString` methods.  
- Added a concrete regression-test requirement to assert public graph-facing routes and interface flows continue to work while no `NodeKeyString`-addressed concrete-node entrypoints are exposed on the graph object.  

### Testing
- No automated test suite was run because this is a documentation-only change.  
- Performed repository validation steps: ran `git diff -- docs/plan1.md`, `git status --short`, and committed the updated `docs/plan1.md`, and inspected references via `rg`/`sed` to confirm the targeted methods are present in code and that the plan now explicitly addresses them.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0798f7d588832ea70ccf01c26f446d)