### PR TITLE
docs: require identifier-native internal pull helpers in plan1

### DIFF
--- a/docs/plan1.md
+++ b/docs/plan1.md
@@ -69,7 +69,7 @@ The semantic `NodeKey` should remain recoverable through explicit lookup tables.
   - [ ] Add focused tests that assert public methods still accept `head + args` and do not require callers to resolve ids first
   - [ ] Add focused tests that verify internal calls below the boundary are `NodeIdentifier`-only (no `NodeKeyString` passed into storage/migration/sync helpers)
 - [ ] Remove the remaining `NodeKeyString`-addressed graph methods from the public class surface in `incremental_graph/class.js` (`pullByNodeKeyStringWithStatus`, `pullByNodeKeyStringWithStatusDuringPull`)
-  - [ ] Keep equivalent functionality as internal-only helpers for recompute/pull internals (for example in `pull.js`) so recursion does not re-open a semantic/public boundary.
+  - [ ] Replace them with **NodeIdentifier-addressed** internal helpers for recompute/pull recursion (for example in `pull.js`); do not keep `NodeKeyString`-addressed recursion helpers after boundary conversion, or internal pull paths will silently violate the identifier-native invariant.
   - [ ] Update `recompute.js` capability typing to depend on identifier-native/internal helper calls instead of public `NodeKeyString` class methods.
   - [ ] Add a regression test that public graph-facing routes and interface flows still work, while no public `NodeKeyString`-addressed concrete-node entrypoints remain exposed on the graph object.
 - [ ] Keep `nodeKeyToId` / `nodeIdToKey` as lower-level translation helpers (storage/internal boundary), not public `IncrementalGraph` methods


### PR DESCRIPTION
### Motivation
- Close a concrete contradiction in `docs/plan1.md` where the plan removed public `NodeKeyString` pull entrypoints but still allowed equivalent internal `NodeKeyString` recursion helpers, which would permit a mixed-mode implementation that violates the design invariant that logic below the `IncrementalGraph` boundary must be identifier-native.

### Description
- Replace a single bullet in `docs/plan1.md` (storage-boundary / internal pull recursion) to explicitly require replacing removed public `NodeKeyString` methods with NodeIdentifier-addressed internal helpers (e.g., in `pull.js`), rather than keeping `NodeKeyString`-addressed recursion helpers; the change is in `docs/plan1.md` only.

### Testing
- Verified the edit with `git diff -- docs/plan1.md` to confirm the intended replacement; attempted `npm run -s markdownlint docs/plan1.md` but the lint command failed in this environment (tool not available); no runtime tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07a3837140832e9e637bfa495b9d46)