### PR TITLE
docs(plan1): pin filesystem unification adapters to identifier-keyed paths

### DIFF
--- a/docs/plan1.md
+++ b/docs/plan1.md
@@ -141,6 +141,9 @@ lookup tables carrying the `NodeKey ↔ NodeIdentifier` relationship.
 - [ ] Delete any code whose job is converting concrete node keys to filesystem paths or back
 - [ ] Simplify `database/encoding.js`, render helpers, scan helpers, and unification helpers around the direct identifier-path snapshot format
   - [ ] In `database/encoding.js`, remove the NodeKey JSON path contract for data sublevels: `keyToRelativePath()` and `relativePathToKey()` must treat `values|freshness|inputs|revdeps|counters|timestamps` keys as single identifier segments (`.../<id>`), not `head/arg...` expansions.
+  - [ ] Update both filesystem unification adapters (`database/unification/db_to_fs.js` and `database/unification/fs_to_db.js`) to rely on the new identifier-segment contract for graph-state sublevels.
+    - [ ] `db_to_fs` must render identifier-keyed graph-state records directly (no `head/args` decomposition) when computing destination file paths.
+    - [ ] `fs_to_db` must decode those same paths back to raw keys without attempting NodeKey reconstruction, so sync import/export remains a true round-trip for identifier-addressed state.
   - [ ] Remove `serializeNodeKey` / `deserializeNodeKey` usage from graph-state path encoding/decoding; after this change those conversions are only allowed for reading/writing `/${current_replica}/global/identifiers_keys_map`, not for graph-state files.
   - [ ] Update `backend/tests/database_render.test.js` cases that currently enforce “expected NodeKey JSON” for data sublevels; those assertions become wrong once keys are opaque identifiers and will otherwise force accidental reintroduction of NodeKey-based path decoding.
   - [ ] Add a render/scan regression test that seeds raw keys like `!x!!values!nodeid1` + `!x!!inputs!nodeid1`, verifies rendered files are `rendered/x/values/nodeid1` / `rendered/x/inputs/nodeid1`, and round-trips back without any `head`/`args` directories.


### PR DESCRIPTION
### Motivation
- The plan required changing `database/encoding.js` to use identifier-paths but did not explicitly call out the two filesystem unification adapters that perform export/import path translation, which can lead to a partial migration where sync round-trips still assume `NodeKey`-style paths and cause drift or corruption.

### Description
- Modify `docs/plan1.md` to explicitly require updating both unification adapters (`backend/src/generators/incremental_graph/database/unification/db_to_fs.js` and `backend/src/generators/incremental_graph/database/unification/fs_to_db.js`) and to state concrete semantics: `db_to_fs` must render identifier-keyed graph-state records directly and `fs_to_db` must decode those paths back to raw keys without reconstructing `NodeKey` values; this change is documentation-only and is contained in `docs/plan1.md`.

### Testing
- Ran a formatting check with `npx prettier --check docs/plan1.md`, which reported style warnings; no runtime/unit tests were run because this is a documentation-only update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07cc770128832e9aab12d0a4611daa)