### PR TITLE
docs: clarify identifier-native graph_storage comments

### DIFF
--- a/backend/src/generators/incremental_graph/graph_storage.js
+++ b/backend/src/generators/incremental_graph/graph_storage.js
@@ -1,7 +1,7 @@
 /* eslint volodyslav/max-lines-per-file: "off" */
 /**
  * Identifier-native graph storage.
- * This module is the low-level persistence layer below the semantic graph API.
+ * This module is the low-level persistence layer below IncrementalGraph runtime logic.
  */
 
 const {
@@ -77,7 +77,7 @@ const {
 /**
  * Convert a nominal identifier to the underlying database key used by typed sublevels.
  * @param {NodeIdentifier} nodeIdentifier
- * @returns {import('./database/types').NodeKeyString}
+ * @returns {string}
  */
 function toDatabaseKey(nodeIdentifier) {
     return nodeIdentifierToDatabaseKey(nodeIdentifier);


### PR DESCRIPTION
### Motivation
- Remove leftover NodeKey/semantic-key wording so the storage-layer docs unambiguously describe an identifier-native persistence contract.

### Description
- Update `backend/src/generators/incremental_graph/graph_storage.js` module comment and change the `toDatabaseKey` JSDoc return type from `import('./database/types').NodeKeyString` to `string`.

### Testing
- Ran `npx eslint backend/src/generators/incremental_graph/graph_storage.js` and `npx jest backend/tests/graph_storage_revdeps_ordering.test.js backend/tests/incremental_graph_persistence.test.js --runInBand`, and both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0808d03270832eb8752eceb4e86059)