### PR TITLE
Fix graph-storage database key typing for identifier-native writes

### DIFF
--- a/backend/src/generators/incremental_graph/graph_storage.js
+++ b/backend/src/generators/incremental_graph/graph_storage.js
@@ -77,7 +77,7 @@ const {
 /**
  * Convert a nominal identifier to the underlying database key used by typed sublevels.
  * @param {NodeIdentifier} nodeIdentifier
- * @returns {string}
+ * @returns {import('./database/types').NodeKeyString}
  */
 function toDatabaseKey(nodeIdentifier) {
     return nodeIdentifierToDatabaseKey(nodeIdentifier);


### PR DESCRIPTION
### Motivation
- The NodeIdentifier migration work in `docs/plan1.md` caused `tsc` errors where identifier-native helpers were inferred as returning plain `string`; the JSDoc for the graph-storage helper needed to reflect the typed sublevel key contract so TypeScript accepts identifier-keyed operations.

### Description
- Update the JSDoc return type of `toDatabaseKey` in `backend/src/generators/incremental_graph/graph_storage.js` from `string` to `import('./database/types').NodeKeyString` so identifier-native code produces the expected typed database key for typed sublevels.

### Testing
- Ran `npm install` to install dependencies successfully.
- Ran the full test suite with `npm test` and all tests passed (`240` test suites, `2582` tests).
- Ran static analysis with `npm run static-analysis` (`tsc` + `eslint`) and it completed successfully.
- Built the frontend with `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08b27fbfa0832eb3368d1de04cee52)