### PR TITLE
Add regression coverage for IncrementalGraph public API boundary

### DIFF
--- a/backend/tests/incremental_graph.test.js
+++ b/backend/tests/incremental_graph.test.js
@@ -50,6 +50,18 @@ describe("generators/incremental_graph", () => {
 
             await db.close();
         });
+
+        test("does not expose identifier lookup helpers on public graph interface", async () => {
+            const capabilities = getTestCapabilities();
+            const db = await getRootDatabase(capabilities);
+            const graph = makeIncrementalGraph(capabilities, db, []);
+
+            expect(graph.nodeKeyToId).toBeUndefined();
+            expect(graph.nodeIdToKey).toBeUndefined();
+
+            await db.close();
+        });
+
     });
 
     describe("pull()", () => {


### PR DESCRIPTION
### Motivation
- Ensure the `IncrementalGraph` public surface does not expose internal identifier translation helpers so the storage `NodeIdentifier` ↔ `NodeKey` bijection remains internal as described in `docs/plan1.md`.

### Description
- Add a regression test in `backend/tests/incremental_graph.test.js` that asserts `graph.nodeKeyToId` and `graph.nodeIdToKey` are not present on the public `IncrementalGraph` instance.

### Testing
- Ran `npx jest backend/tests/incremental_graph.test.js --runInBand`, and the test passed (29 tests in the suite).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08b14b97bc832e8c873a64918a3081)