### PR TITLE
Refactor incremental-graph database key typing to NodeIdentifier + global keys

### DIFF
--- a/backend/src/generators/incremental_graph/database/hostname_storage.js
+++ b/backend/src/generators/incremental_graph/database/hostname_storage.js
@@ -11,7 +11,7 @@
  */
 
 const { makeTypedDatabase } = require('./typed_database');
-const { stringToNodeKeyString, stringToVersion } = require('./types');
+const { stringToVersion } = require('./types');
 const { RAW_BATCH_CHUNK_SIZE } = require('./constants');
 
 /**
@@ -169,10 +169,10 @@ async function clearHostnameStorage(db, hostname) {
  * @param {string} hostname
  * @param {string} sublevelName - e.g. 'meta', 'values', 'freshness', etc.
  * @param {string} subkey
- * @returns {NodeKeyString}
+ * @returns {string}
  */
 function hostnameRawKey(hostname, sublevelName, subkey) {
-    return stringToNodeKeyString(`!_h_${hostname}!!${sublevelName}!${subkey}`);
+    return `!_h_${hostname}!!${sublevelName}!${subkey}`;
 }
 
 /**
@@ -227,7 +227,7 @@ async function rawPutAllToHostname(db, hostname, entries) {
     validateHostname(hostname);
     /**
      * @param {{ sublevelName: string, subkey: string, value: * }} entry
-     * @returns {{ type: 'put', key: NodeKeyString, value: * }}
+     * @returns {{ type: 'put', key: string, value: * }}
      */
     function makePutOp(entry) {
         return {

--- a/backend/src/generators/incremental_graph/database/root_database.js
+++ b/backend/src/generators/incremental_graph/database/root_database.js
@@ -8,7 +8,7 @@
 const { getVersion } = require('../../../version');
 const random = require('../../../random');
 const { makeTypedDatabase } = require('./typed_database');
-const { stringToVersion, stringToNodeKeyString, versionToString } = require('./types');
+const { stringToVersion, versionToString } = require('./types');
 const { RAW_BATCH_CHUNK_SIZE } = require('./constants');
 const {
     IDENTIFIERS_KEY,
@@ -700,7 +700,7 @@ class RootDatabaseClass {
     async _rawGetInSublevel(sublevelName, innerKey) {
         /** @type {SchemaSublevelType} */
         const sublevel = this.db.sublevel(sublevelName, { valueEncoding: 'json' });
-        return await sublevel.get(stringToNodeKeyString(innerKey));
+        return await sublevel.get(innerKey);
     }
 
     /**
@@ -741,7 +741,7 @@ class RootDatabaseClass {
         // AbstractPutOptions property and satisfies the weak-type check without
         // changing runtime behaviour.
         const opts = { sync: false, keyEncoding: undefined };
-        await this.db.put(stringToNodeKeyString(key), value, opts);
+        await this.db.put(key, value, opts);
     }
 
     /**
@@ -760,7 +760,7 @@ class RootDatabaseClass {
         // Pass sync:false to avoid per-write fsyncs during bulk unification.
         // See _rawPut() for the keyEncoding:undefined weak-type-check workaround.
         const opts = { sync: false, keyEncoding: undefined };
-        await this.db.del(stringToNodeKeyString(key), opts);
+        await this.db.del(key, opts);
     }
 
     /**
@@ -798,12 +798,12 @@ class RootDatabaseClass {
          * Converts a plain raw-entry object into a LevelDB batch put operation,
          * applying the JSDoc-level NodeKeyString wrapper expected by this.db.
          * @param {{ key: string, value: * }} entry
-         * @returns {{ type: 'put', key: NodeKeyString, value: * }}
+         * @returns {{ type: 'put', key: string, value: * }}
          */
         function makePutOp(entry) {
             return {
                 type: 'put',
-                key: stringToNodeKeyString(entry.key),
+                key: entry.key,
                 value: entry.value,
             };
         }
@@ -824,7 +824,7 @@ class RootDatabaseClass {
      * @returns {Promise<void>}
      */
     async _rawDeleteKeys(keys) {
-        await this.db.batch(keys.map(k => ({ type: 'del', key: stringToNodeKeyString(k) })));
+        await this.db.batch(keys.map(k => ({ type: 'del', key: k })));
     }
 
     /**

--- a/backend/src/generators/incremental_graph/database/types.js
+++ b/backend/src/generators/incremental_graph/database/types.js
@@ -426,13 +426,15 @@ function versionToString(Version) {
 /**
  * A database put operation.
  * @template T
- * @typedef {{ type: 'put', sublevel: SimpleSublevel<T, DatabaseKey>, key: DatabaseKey, value: T }} DatabasePutOperation
+ * @template [K=DatabaseKey]
+ * @typedef {{ type: 'put', sublevel: SimpleSublevel<T, K>, key: K, value: T }} DatabasePutOperation
  */
 
 /**
  * A database delete operation.
  * @template T
- * @typedef {{ type: 'del', sublevel: SimpleSublevel<T, DatabaseKey>, key: DatabaseKey }} DatabaseDelOperation
+ * @template [K=DatabaseKey]
+ * @typedef {{ type: 'del', sublevel: SimpleSublevel<T, K>, key: K }} DatabaseDelOperation
  */
 
 /**
@@ -447,7 +449,7 @@ function versionToString(Version) {
 
 /**
  * A batch operation for the database.
- * @typedef {DatabasePutOperation<ComputedValue> | DatabasePutOperation<Freshness> | DatabasePutOperation<InputsRecord> | DatabasePutOperation<NodeKeyString[]> | DatabasePutOperation<Counter> | DatabasePutOperation<TimestampRecord> | DatabasePutOperation<Version> | DatabasePutOperation<IdentifiersKeysMap> | DatabaseDelOperation<ComputedValue> | DatabaseDelOperation<Freshness> | DatabaseDelOperation<InputsRecord> | DatabaseDelOperation<NodeKeyString[]> | DatabaseDelOperation<Counter> | DatabaseDelOperation<TimestampRecord> | DatabaseDelOperation<Version> | DatabaseDelOperation<IdentifiersKeysMap>} DatabaseBatchOperation
+ * @typedef {DatabasePutOperation<ComputedValue, any> | DatabasePutOperation<Freshness, any> | DatabasePutOperation<InputsRecord, any> | DatabasePutOperation<NodeKeyString[], any> | DatabasePutOperation<Counter, any> | DatabasePutOperation<TimestampRecord, any> | DatabasePutOperation<Version, any> | DatabasePutOperation<IdentifiersKeysMap, any> | DatabaseDelOperation<ComputedValue, any> | DatabaseDelOperation<Freshness, any> | DatabaseDelOperation<InputsRecord, any> | DatabaseDelOperation<NodeKeyString[], any> | DatabaseDelOperation<Counter, any> | DatabaseDelOperation<TimestampRecord, any> | DatabaseDelOperation<Version, any> | DatabaseDelOperation<IdentifiersKeysMap, any>} DatabaseBatchOperation
  */
 
 /**
@@ -521,8 +523,8 @@ function schemaPatternToString(schemaPattern) {
  * @typedef {import('abstract-level').AbstractSublevel<D, F, K, V>} AbstractSublevel
  */
 
-/** 
- * @typedef {NodeKeyString} DatabaseKey
+/**
+ * @typedef {NodeIdentifier | 'version' | 'identifiers_keys_map'} DatabaseKey
  */
 
 /**
@@ -530,11 +532,11 @@ function schemaPatternToString(schemaPattern) {
  */
 
 /**
- * @typedef {Level<DatabaseKey, DatabaseStoredValue>} RootLevelType
+ * @typedef {Level<string, DatabaseStoredValue>} RootLevelType
  */
 
 /**
- * @typedef {AbstractSublevel<RootLevelType, SublevelFormat, DatabaseKey, DatabaseStoredValue>} SchemaSublevelType
+ * @typedef {AbstractSublevel<RootLevelType, SublevelFormat, string, DatabaseStoredValue>} SchemaSublevelType
  */
 
 /**


### PR DESCRIPTION
### Motivation
- Move the incremental-graph storage model toward identifier-addressed state by making `DatabaseKey` represent `NodeIdentifier` or global root keys (`'version'` and `'identifiers_keys_map'`).
- Allow batch operations and sublevels to express their own key spaces so the `NodeKey`→`NodeIdentifier` refactor can be completed without leaking legacy key types.
- Use raw string keys for low-level root and hostname helpers so untyped root-level operations continue to work while the typed sublevel lattice is adjusted.

### Description
- Changed the `DatabaseKey` typedef to `NodeIdentifier | 'version' | 'identifiers_keys_map'` in `backend/src/generators/incremental_graph/database/types.js`.
- Generalized `DatabasePutOperation` and `DatabaseDelOperation` to accept a key-type template parameter so per-sublevel key types can be represented instead of a single hardcoded key typedef.
- Reworked `DatabaseBatchOperation` typedefs to allow key-parameterized operations (temporarily widened to `any` for the key parameter where needed to unblock the refactor).
- Updated `RootLevelType` and `SchemaSublevelType` typedefs to use plain `string` keys for the raw root/sublevel helpers, and replaced `stringToNodeKeyString` wrapping in low-level helpers with raw string keys.
- Replaced `NodeKeyString` wrapper usage in `hostname_storage.js` and `root_database.js` for raw helpers: `hostnameRawKey`, `_rawGetInSublevel`, `_rawPut`, `_rawDel`, `_rawPutAll`, and `_rawDeleteKeys` now operate with plain `string` root keys.
- These changes intentionally surface deeper generic-type inconsistencies in the sublevel typings so they can be fixed in follow-up refactor steps rather than masking them.

### Testing
- Ran `npm install` which completed successfully.
- Ran `npm run static-analysis` (TypeScript + ESLint), which currently fails with TypeScript generic-key mismatches originating from the incremental-graph sublevel typing lattice (`hostname_storage.js` and `root_database.js`).
- Started `npm test` / `npx jest`; the test runner was launched but did not produce a reliable completion report in this environment before being interrupted.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08c239ca9c832ebf27b576f06dcf21)