### PR TITLE
Refactor database key typing to identifier-native `DatabaseKey` and key-generic DB ops

### DIFF
--- a/backend/src/generators/incremental_graph/database/types.js
+++ b/backend/src/generators/incremental_graph/database/types.js
@@ -426,13 +426,15 @@ function versionToString(Version) {
 /**
  * A database put operation.
  * @template T
- * @typedef {{ type: 'put', sublevel: SimpleSublevel<T, DatabaseKey>, key: DatabaseKey, value: T }} DatabasePutOperation
+ * @template [K=DatabaseKey]
+ * @typedef {{ type: 'put', sublevel: SimpleSublevel<T, K>, key: K, value: T }} DatabasePutOperation
  */
 
 /**
  * A database delete operation.
  * @template T
- * @typedef {{ type: 'del', sublevel: SimpleSublevel<T, DatabaseKey>, key: DatabaseKey }} DatabaseDelOperation
+ * @template [K=DatabaseKey]
+ * @typedef {{ type: 'del', sublevel: SimpleSublevel<T, K>, key: K }} DatabaseDelOperation
  */
 
 /**
@@ -522,7 +524,7 @@ function schemaPatternToString(schemaPattern) {
  */
 
 /** 
- * @typedef {NodeKeyString} DatabaseKey
+ * @typedef {NodeIdentifier | 'version' | 'identifiers_keys_map'} DatabaseKey
  */
 
 /**
@@ -530,11 +532,11 @@ function schemaPatternToString(schemaPattern) {
  */
 
 /**
- * @typedef {Level<DatabaseKey, DatabaseStoredValue>} RootLevelType
+ * @typedef {Level<NodeKeyString, DatabaseStoredValue>} RootLevelType
  */
 
 /**
- * @typedef {AbstractSublevel<RootLevelType, SublevelFormat, DatabaseKey, DatabaseStoredValue>} SchemaSublevelType
+ * @typedef {AbstractSublevel<RootLevelType, SublevelFormat, NodeKeyString, DatabaseStoredValue>} SchemaSublevelType
  */
 
 /**
@@ -544,7 +546,7 @@ function schemaPatternToString(schemaPattern) {
 /**
  * @template T
  * @template [K=NodeKeyString]
- * @typedef {AbstractSublevel<AbstractSublevel<RootLevelType, SublevelFormat, DatabaseKey, DatabaseStoredValue>, SublevelFormat, K, T>} SimpleSublevel
+ * @typedef {AbstractSublevel<AbstractSublevel<RootLevelType, SublevelFormat, NodeKeyString, DatabaseStoredValue>, SublevelFormat, K, T>} SimpleSublevel
  */
 
 module.exports = {


### PR DESCRIPTION
### Motivation
- Align database typing with a model where higher-level database keys are identifier-native rather than raw key strings, and reserve a small set of special keys for metadata like `version` and `identifiers_keys_map`.
- Enable progressing a larger refactor that needs database operation types to carry precise key-type information through batch operations.

### Description
- Rewrote the `DatabaseKey` typedef in `backend/src/generators/incremental_graph/database/types.js` to be `NodeIdentifier | 'version' | 'identifiers_keys_map'` instead of `NodeKeyString`.
- Generalized database operation typedefs by making `DatabasePutOperation` and `DatabaseDelOperation` key-parameterized with `@template [K=DatabaseKey]` so callers can pass specific key types through batch operations.
- Adjusted root/sublevel typedef plumbing to keep the physical root level keyed by `NodeKeyString` while using `NodeKeyString`/`DatabaseKey` distinctions in `RootLevelType`, `SchemaSublevelType`, and `SimpleSublevel` to reflect the new semantics at different layers.
- All edits are contained to `backend/src/generators/incremental_graph/database/types.js` and the typedefs it exposes to the graph storage code.

### Testing
- Ran `npm install` successfully and dependencies installed without blocking errors.
- Ran the full test suite with `npm test` and all tests passed (`240` test suites, `2582` tests reported as passed).
- Ran static analysis with `npm run static-analysis` which runs `tsc && eslint`, and this step failed with TypeScript errors (many `TS2345` generic/key-compatibility errors) originating in `backend/src/generators/incremental_graph/database/hostname_storage.js`, `backend/src/generators/incremental_graph/database/root_database.js`, and `backend/src/generators/incremental_graph/database/sync_merge.js`, indicating remaining work is required to reconcile `NodeKeyStringClass` vs `DatabaseKey` generics across batch operation unions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08c2351674832eb66eae349cd74998)