### PR TITLE
Refactor DB typing: DatabaseKey → NodeIdentifier | 'version' | 'identifiers_keys_map' and remove NodeKeyString from DB types

### DIFF
--- a/backend/src/generators/incremental_graph/database/hostname_storage.js
+++ b/backend/src/generators/incremental_graph/database/hostname_storage.js
@@ -11,7 +11,8 @@
  */
 
 const { makeTypedDatabase } = require('./typed_database');
-const { stringToNodeKeyString, stringToVersion } = require('./types');
+const { stringToVersion } = require('./types');
+const { stringToNodeKeyString } = require('./node_key');
 const { RAW_BATCH_CHUNK_SIZE } = require('./constants');
 
 /**
@@ -67,7 +68,7 @@ function validateHostname(hostname) {
 /** @typedef {import('./types').ComputedValue} ComputedValue */
 /** @typedef {import('./types').Freshness} Freshness */
 /** @typedef {import('./types').InputsRecord} InputsRecord */
-/** @typedef {import('./types').NodeKeyString} NodeKeyString */
+/** @typedef {import('./node_key').NodeKeyString} NodeKeyString */
 /** @typedef {import('./types').Counter} Counter */
 /** @typedef {import('./types').TimestampRecord} TimestampRecord */
 

--- a/backend/src/generators/incremental_graph/database/identifier_lookup.js
+++ b/backend/src/generators/incremental_graph/database/identifier_lookup.js
@@ -7,10 +7,10 @@ const {
 } = require("./node_identifier");
 const {
     nodeKeyStringToString,
-} = require("./types");
+} = require("./node_key");
 
 /** @typedef {import("./node_identifier").NodeIdentifier} NodeIdentifier */
-/** @typedef {import("./types").NodeKeyString} NodeKeyString */
+/** @typedef {import("./node_key").NodeKeyString} NodeKeyString */
 
 /**
  * Global metadata key that stores the sorted `NodeIdentifier -> NodeKey` bijection.

--- a/backend/src/generators/incremental_graph/database/index.js
+++ b/backend/src/generators/incremental_graph/database/index.js
@@ -3,7 +3,8 @@
  * Provides a LevelDB key-value store for storing generated values and event log mirrors.
  */
 
-const { schemaPatternToString, stringToSchemaPattern, stringToNodeKeyString, nodeNameToString, stringToNodeName, nodeKeyStringToString, versionToString, stringToVersion } = require('./types');
+const { schemaPatternToString, stringToSchemaPattern, nodeNameToString, stringToNodeName, versionToString, stringToVersion } = require('./types');
+const { stringToNodeKeyString, nodeKeyStringToString } = require('./node_key');
 const { makeRootDatabase, isRootDatabase, isInvalidReplicaPointerError, isSwitchReplicaError, isSchemaBatchVersionError } = require('./root_database');
 const { makeTypedDatabase, isTypedDatabase } = require('./typed_database');
 const {

--- a/backend/src/generators/incremental_graph/database/node_identifier.js
+++ b/backend/src/generators/incremental_graph/database/node_identifier.js
@@ -1,5 +1,5 @@
 const random = require("../../../random");
-const { nodeKeyStringToString, stringToNodeKeyString } = require("./types");
+const { nodeKeyStringToString, stringToNodeKeyString } = require("./node_key");
 
 /**
  * Persisted node identifiers are exactly 9 lowercase ASCII letters.
@@ -105,7 +105,7 @@ function nodeIdentifierToString(identifier) {
  * Convert an identifier to the branded database-key type used by typed sublevels.
  * This hides the NodeKeyString storage-brand detail from identifier-native callers.
  * @param {NodeIdentifier} identifier
- * @returns {import('./types').NodeKeyString}
+ * @returns {import('./node_key').NodeKeyString}
  */
 function nodeIdentifierToDatabaseKey(identifier) {
     return stringToNodeKeyString(nodeIdentifierToString(identifier));
@@ -113,7 +113,7 @@ function nodeIdentifierToDatabaseKey(identifier) {
 
 /**
  * Convert a typed database key that is known to hold an identifier back into a NodeIdentifier.
- * @param {import('./types').NodeKeyString} key
+ * @param {import('./node_key').NodeKeyString} key
  * @returns {NodeIdentifier}
  */
 function databaseKeyToNodeIdentifier(key) {

--- a/backend/src/generators/incremental_graph/database/node_key.js
+++ b/backend/src/generators/incremental_graph/database/node_key.js
@@ -16,14 +16,32 @@
 
 const { makeArityMismatchError } = require("../errors");
 const {
-    stringToNodeKeyString,
     nodeNameToString,
     stringToNodeName,
-    nodeKeyStringToString,
 } = require("./types");
 
+
+/**
+ * @typedef {string} NodeKeyString
+ */
+
+/**
+ * @param {string} nodeKeyStr
+ * @returns {NodeKeyString}
+ */
+function stringToNodeKeyString(nodeKeyStr) {
+    return nodeKeyStr;
+}
+
+/**
+ * @param {NodeKeyString} nodeKeyString
+ * @returns {string}
+ */
+function nodeKeyStringToString(nodeKeyString) {
+    return nodeKeyString;
+}
+
 /** @typedef {import('../types').ConstValue} ConstValue */
-/** @typedef {import('../types').NodeKeyString} NodeKeyString */
 /** @typedef {import('../types').NodeName} NodeName */
 /** @typedef {import('../types').SchemaPattern} SchemaPattern */
 

--- a/backend/src/generators/incremental_graph/database/root_database.js
+++ b/backend/src/generators/incremental_graph/database/root_database.js
@@ -8,7 +8,8 @@
 const { getVersion } = require('../../../version');
 const random = require('../../../random');
 const { makeTypedDatabase } = require('./typed_database');
-const { stringToVersion, stringToNodeKeyString, versionToString } = require('./types');
+const { stringToVersion, versionToString } = require('./types');
+const { stringToNodeKeyString } = require('./node_key');
 const { RAW_BATCH_CHUNK_SIZE } = require('./constants');
 const {
     IDENTIFIERS_KEY,
@@ -47,7 +48,7 @@ const {
 /** @typedef {import('./types').DatabaseBatchOperation} DatabaseBatchOperation */
 /** @typedef {import('./types').DatabaseKey} DatabaseKey */
 /** @typedef {import('./types').DatabaseStoredValue} DatabaseStoredValue */
-/** @typedef {import('./types').NodeKeyString} NodeKeyString */
+/** @typedef {import('./node_key').NodeKeyString} NodeKeyString */
 /** @typedef {import('./node_identifier').NodeIdentifier} NodeIdentifier */
 /** @typedef {import('./types').Version} Version */
 /** @typedef {import('./identifier_lookup').IdentifierLookup} IdentifierLookup */

--- a/backend/src/generators/incremental_graph/database/sync_merge.js
+++ b/backend/src/generators/incremental_graph/database/sync_merge.js
@@ -45,7 +45,8 @@
  */
 
 const { topologicalSortFromMap, isTopologicalSortCycleError } = require('./topo_sort');
-const { stringToNodeKeyString, versionToString } = require('./types');
+const { versionToString } = require('./types');
+const { stringToNodeKeyString } = require('./node_key');
 const { compareNodeKeyStringByNodeKey } = require('./node_key');
 const { RAW_BATCH_CHUNK_SIZE } = require('./constants');
 const { makeDbToDbAdapter, unifyStores } = require('./unification');
@@ -53,7 +54,7 @@ const { makeDbToDbAdapter, unifyStores } = require('./unification');
 /** @typedef {import('./root_database').RootDatabase} RootDatabase */
 /** @typedef {import('./root_database').SchemaStorage} SchemaStorage */
 /** @typedef {import('./root_database').ReplicaName} ReplicaName */
-/** @typedef {import('./types').NodeKeyString} NodeKeyString */
+/** @typedef {import('./node_key').NodeKeyString} NodeKeyString */
 /** @typedef {import('./types').Version} Version */
 /** @typedef {import('./types').DatabaseBatchOperation} DatabaseBatchOperation */
 

--- a/backend/src/generators/incremental_graph/database/topo_sort.js
+++ b/backend/src/generators/incremental_graph/database/topo_sort.js
@@ -13,9 +13,9 @@
  */
 
 const { compareNodeKeyStringByNodeKey } = require('./node_key');
-const { stringToNodeKeyString } = require('./types');
+const { stringToNodeKeyString } = require('./node_key');
 
-/** @typedef {import('./types').NodeKeyString} NodeKeyString */
+/** @typedef {import('./node_key').NodeKeyString} NodeKeyString */
 /** @typedef {import('./root_database').SchemaStorage} SchemaStorage */
 const CYCLE_MESSAGE_SAMPLE_LIMIT = 20;
 

--- a/backend/src/generators/incremental_graph/database/types.js
+++ b/backend/src/generators/incremental_graph/database/types.js
@@ -10,53 +10,6 @@
 /** @typedef {import('../../../environment').Environment} Environment */
 /** @typedef {import('../../../subprocess/command').Command} Command */
 
-class NodeKeyStringClass {
-    /**
-     * @private
-     * @type {undefined}
-     */
-    __brand;
-    constructor() {
-        if (this.__brand !== undefined) {
-            throw new Error("NodeKeyString cannot be instantiated");
-        }
-    }
-}
-
-/**
- * @param {string} _value
- * @returns {_value is NodeKeyString}
- */
-function castToNodeKeyString(_value) {
-    return true;
-}
-
-/**
- * @param {string} nodeKeyStr
- * @returns {NodeKeyString}
- */
-function stringToNodeKeyString(nodeKeyStr) {
-    if (castToNodeKeyString(nodeKeyStr)) {
-        return nodeKeyStr;
-    }
-    throw new Error("Invalid node key string");
-}
-
-/**
- * @param {NodeKeyString} nodeKeyString
- * @returns {string}
- */
-function nodeKeyStringToString(nodeKeyString) {
-    if (typeof nodeKeyString === "string") {
-        return nodeKeyString;
-    }
-    throw new Error("Invalid node key string type");
-}
-
-/**
- * A serialized node key string for storage.
- * @typedef {NodeKeyStringClass} NodeKeyString
- */
 
 class NodeIdentifierClass {
     /**
@@ -416,11 +369,11 @@ function versionToString(Version) {
  */
 
 /**
- * @typedef {Array<[NodeIdentifier, NodeKeyString]>} IdentifiersKeysMap
+ * @typedef {Array<[NodeIdentifier, string]>} IdentifiersKeysMap
  */
 
 /**
- * @typedef {ComputedValue | Freshness | InputsRecord | NodeKeyString[] | Counter | TimestampRecord | Version | IdentifiersKeysMap} DatabaseStoredValue
+ * @typedef {ComputedValue | Freshness | InputsRecord | NodeIdentifier[] | Counter | TimestampRecord | Version | IdentifiersKeysMap} DatabaseStoredValue
  */
 
 /**
@@ -447,7 +400,7 @@ function versionToString(Version) {
 
 /**
  * A batch operation for the database.
- * @typedef {DatabasePutOperation<ComputedValue> | DatabasePutOperation<Freshness> | DatabasePutOperation<InputsRecord> | DatabasePutOperation<NodeKeyString[]> | DatabasePutOperation<Counter> | DatabasePutOperation<TimestampRecord> | DatabasePutOperation<Version> | DatabasePutOperation<IdentifiersKeysMap> | DatabaseDelOperation<ComputedValue> | DatabaseDelOperation<Freshness> | DatabaseDelOperation<InputsRecord> | DatabaseDelOperation<NodeKeyString[]> | DatabaseDelOperation<Counter> | DatabaseDelOperation<TimestampRecord> | DatabaseDelOperation<Version> | DatabaseDelOperation<IdentifiersKeysMap>} DatabaseBatchOperation
+ * @typedef {DatabasePutOperation<ComputedValue> | DatabasePutOperation<Freshness> | DatabasePutOperation<InputsRecord> | DatabasePutOperation<NodeIdentifier[]> | DatabasePutOperation<Counter> | DatabasePutOperation<TimestampRecord> | DatabasePutOperation<Version> | DatabasePutOperation<IdentifiersKeysMap> | DatabaseDelOperation<ComputedValue> | DatabaseDelOperation<Freshness> | DatabaseDelOperation<InputsRecord> | DatabaseDelOperation<NodeIdentifier[]> | DatabaseDelOperation<Counter> | DatabaseDelOperation<TimestampRecord> | DatabaseDelOperation<Version> | DatabaseDelOperation<IdentifiersKeysMap>} DatabaseBatchOperation
  */
 
 /**
@@ -522,7 +475,7 @@ function schemaPatternToString(schemaPattern) {
  */
 
 /** 
- * @typedef {NodeKeyString} DatabaseKey
+ * @typedef {NodeIdentifier | 'version' | 'identifiers_keys_map'} DatabaseKey
  */
 
 /**
@@ -530,7 +483,7 @@ function schemaPatternToString(schemaPattern) {
  */
 
 /**
- * @typedef {Level<DatabaseKey, DatabaseStoredValue>} RootLevelType
+ * @typedef {Level<string, DatabaseStoredValue>} RootLevelType
  */
 
 /**
@@ -543,7 +496,7 @@ function schemaPatternToString(schemaPattern) {
 
 /**
  * @template T
- * @template [K=NodeKeyString]
+ * @template [K=NodeIdentifier]
  * @typedef {AbstractSublevel<AbstractSublevel<RootLevelType, SublevelFormat, DatabaseKey, DatabaseStoredValue>, SublevelFormat, K, T>} SimpleSublevel
  */
 
@@ -557,9 +510,6 @@ module.exports = {
     nodeNameToString,
     stringToNodeName,
     NodeNameClass,
-    nodeKeyStringToString,
-    stringToNodeKeyString,
-    NodeKeyStringClass,
     schemaPatternToString,
     stringToSchemaPattern,
     SchemaPatternClass,

--- a/backend/src/generators/incremental_graph/database/unification/db_to_db.js
+++ b/backend/src/generators/incremental_graph/database/unification/db_to_db.js
@@ -30,9 +30,9 @@
 
 /** @typedef {import('../root_database').SchemaStorage} SchemaStorage */
 /** @typedef {import('./core').UnificationAdapter} UnificationAdapter */
-/** @typedef {import('../types').NodeKeyString} NodeKeyString */
+/** @typedef {import('../node_key').NodeKeyString} NodeKeyString */
 
-const { stringToNodeKeyString } = require('../types');
+const { stringToNodeKeyString } = require('../node_key');
 
 /**
  * Read-only view of a single sublevel — the minimum interface required by the

--- a/backend/src/generators/incremental_graph/errors.js
+++ b/backend/src/generators/incremental_graph/errors.js
@@ -1,7 +1,7 @@
 
 /** @typedef {import('./database/types').NodeName} NodeName */
 /** @typedef {import('./database/types').SchemaPattern} SchemaPattern */
-/** @typedef {import('./database/types').NodeKeyString} NodeKeyString */
+/** @typedef {import('./database/node_key').NodeKeyString} NodeKeyString */
 
 /**
  * Base error class for database operations.

--- a/backend/src/generators/incremental_graph/graph_storage.js
+++ b/backend/src/generators/incremental_graph/graph_storage.js
@@ -77,7 +77,7 @@ const {
 /**
  * Convert a nominal identifier to the underlying database key used by typed sublevels.
  * @param {NodeIdentifier} nodeIdentifier
- * @returns {import('./database/types').NodeKeyString}
+ * @returns {import('./database/node_key').NodeKeyString}
  */
 function toDatabaseKey(nodeIdentifier) {
     return nodeIdentifierToDatabaseKey(nodeIdentifier);

--- a/backend/src/generators/incremental_graph/identifier_resolver.js
+++ b/backend/src/generators/incremental_graph/identifier_resolver.js
@@ -19,7 +19,7 @@ const {
 
 /** @typedef {import('./database/root_database').RootDatabase} RootDatabase */
 /** @typedef {import('./database/root_database').GlobalVersionDatabase} GlobalVersionDatabase */
-/** @typedef {import('./database/types').NodeKeyString} NodeKeyString */
+/** @typedef {import('./database/node_key').NodeKeyString} NodeKeyString */
 /** @typedef {import('./database/node_identifier').NodeIdentifier} NodeIdentifier */
 /** @typedef {import('./graph_storage').BatchBuilder} BatchBuilder */
 /** @typedef {import('./database/identifier_lookup').IdentifierLookup} IdentifierLookup */

--- a/backend/src/generators/incremental_graph/migration_errors.js
+++ b/backend/src/generators/incremental_graph/migration_errors.js
@@ -2,7 +2,7 @@
  * Error classes for MigrationStorage operations.
  */
 
-/** @typedef {import('./database/types').NodeKeyString} NodeKeyString */
+/** @typedef {import('./database/node_key').NodeKeyString} NodeKeyString */
 
 /**
  * Thrown when two different decisions are assigned to the same node.

--- a/backend/src/generators/incremental_graph/migration_runner.js
+++ b/backend/src/generators/incremental_graph/migration_runner.js
@@ -31,7 +31,7 @@ const { unifyStores, makeDbToDbAdapter } = require("./database");
 
 /** @typedef {import('./database/root_database').RootDatabase} RootDatabase */
 /** @typedef {import('./database/root_database').SchemaStorage} SchemaStorage */
-/** @typedef {import('./database/types').NodeKeyString} NodeKeyString */
+/** @typedef {import('./database/node_key').NodeKeyString} NodeKeyString */
 /** @typedef {import('./database/types').ComputedValue} ComputedValue */
 /** @typedef {import('./database/types').Counter} Counter */
 /** @typedef {import('./database/types').Freshness} Freshness */

--- a/backend/src/generators/incremental_graph/migration_storage.js
+++ b/backend/src/generators/incremental_graph/migration_storage.js
@@ -19,7 +19,7 @@ const {
 } = require("./migration_errors");
 
 /** @typedef {import('./database/types').ComputedValue} ComputedValue */
-/** @typedef {import('./database/types').NodeKeyString} NodeKeyString */
+/** @typedef {import('./database/node_key').NodeKeyString} NodeKeyString */
 /** @typedef {import('./types').CompiledNode} CompiledNode */
 /** @typedef {import('./types').NodeName} NodeName */
 

--- a/backend/src/generators/incremental_graph/types.js
+++ b/backend/src/generators/incremental_graph/types.js
@@ -44,7 +44,7 @@
 
 /**
  * A serialized node key string for storage.
- * @typedef {import('./database/types').NodeKeyString} NodeKeyString
+ * @typedef {import('./database/node_key').NodeKeyString} NodeKeyString
  */
 
 /**


### PR DESCRIPTION
### Motivation
- Ensure database sublevels are indexed only by stable persisted identifiers, not by semantic node keys, by making `DatabaseKey` model `NodeIdentifier | 'version' | 'identifiers_keys_map'`.
- Remove `NodeKeyString` from the core database typing so no sublevel is statically declared to be keyed by a node key string.
- Keep node-key helpers and representations as a separate concern (in `node_key.js`) so node-key serialization/utility functions remain available without anchoring database typings to them.

### Description
- Updated `backend/src/generators/incremental_graph/database/types.js` to set `DatabaseKey` to `NodeIdentifier | 'version' | 'identifiers_keys_map'`, replaced revdeps stored-type to `NodeIdentifier[]`, and adjusted `IdentifiersKeysMap` to use plain `string` for the node key mapping values.
- Removed the `NodeKeyString` nominal/exported helpers from `database/types.js` and stopped exporting them from that module.
- Introduced (and/or extended) `backend/src/generators/incremental_graph/database/node_key.js` to own the `NodeKeyString` typedef and `stringToNodeKeyString` / `nodeKeyStringToString` helpers, and migrated all node-key-specific helpers to import from `node_key` instead of `types`.
- Rewired many modules to import node-key helpers from `node_key` (e.g., `identifier_lookup.js`, `node_identifier.js`, `root_database.js`, `db_to_db.js`, `sync_merge.js`, `topo_sort.js`, `migration_*` modules, etc.) and updated JSDoc typedef references where appropriate.

### Testing
- Ran `npm install` successfully.
- Ran targeted test suite `npx jest backend/tests/incremental_graph.test.js --runInBand`, which passed (`28 passed`).
- Ran the full test suite with `npm test`; it currently fails in migration/unification flows (errors originating from remaining db/unification wiring and TypeScript-level key/generic mismatches in some modules). These failures are reproducible in the CI-local run.
- Ran `npm run static-analysis` (TypeScript + ESLint); TypeScript reports remaining generic/key-type mismatches (notably around `GenericDatabase<..., NodeIdentifier>` vs. expected string-keyed APIs) and these checks currently fail.

Notes: This is a large refactor that isolates node-key handling from core DB typing; the repository-wide type-level and unification/migration wiring still needs follow-up changes to make the full test suite and static analysis pass. No `any` annotations were introduced in the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08c9ef2900832ebf2601ef52930eb8)