### PR TITLE
Migrate DB typing to NodeIdentifier keys (remove NodeKeyString from DB sublevels)

### DIFF
--- a/backend/src/generators/incremental_graph/database/hostname_storage.js
+++ b/backend/src/generators/incremental_graph/database/hostname_storage.js
@@ -73,7 +73,8 @@ function validateHostname(hostname) {
 
 /**
  * @template T
- * @typedef {import('./types').SimpleSublevel<T>} SimpleSublevel
+ * @template [K=DatabaseKey]
+ * @typedef {import('./types').SimpleSublevel<T, K>} SimpleSublevel
  */
 
 /**
@@ -89,17 +90,17 @@ function validateHostname(hostname) {
  * @returns {SchemaStorage}
  */
 function buildBareSchemaStorage(namespaceSublevel) {
-    /** @type {SimpleSublevel<ComputedValue>} */
+    /** @type {SimpleSublevel<ComputedValue, NodeIdentifier>} */
     const valuesSublevel = namespaceSublevel.sublevel('values', { valueEncoding: 'json' });
-    /** @type {SimpleSublevel<Freshness>} */
+    /** @type {SimpleSublevel<Freshness, NodeIdentifier>} */
     const freshnessSublevel = namespaceSublevel.sublevel('freshness', { valueEncoding: 'json' });
-    /** @type {SimpleSublevel<InputsRecord>} */
+    /** @type {SimpleSublevel<InputsRecord, NodeIdentifier>} */
     const inputsSublevel = namespaceSublevel.sublevel('inputs', { valueEncoding: 'json' });
-    /** @type {SimpleSublevel<NodeIdentifier[]>} */
+    /** @type {SimpleSublevel<NodeIdentifier[], NodeIdentifier>} */
     const revdepsSublevel = namespaceSublevel.sublevel('revdeps', { valueEncoding: 'json' });
-    /** @type {SimpleSublevel<Counter>} */
+    /** @type {SimpleSublevel<Counter, NodeIdentifier>} */
     const countersSublevel = namespaceSublevel.sublevel('counters', { valueEncoding: 'json' });
-    /** @type {SimpleSublevel<TimestampRecord>} */
+    /** @type {SimpleSublevel<TimestampRecord, NodeIdentifier>} */
     const timestampsSublevel = namespaceSublevel.sublevel('timestamps', { valueEncoding: 'json' });
     /** @type {GlobalSublevelType} */
     const globalSublevel = namespaceSublevel.sublevel('global', { valueEncoding: 'json' });

--- a/backend/src/generators/incremental_graph/database/hostname_storage.js
+++ b/backend/src/generators/incremental_graph/database/hostname_storage.js
@@ -11,7 +11,7 @@
  */
 
 const { makeTypedDatabase } = require('./typed_database');
-const { stringToVersion } = require('./types');
+const { stringToNodeIdentifier, stringToVersion } = require('./types');
 const { RAW_BATCH_CHUNK_SIZE } = require('./constants');
 
 /**
@@ -67,7 +67,8 @@ function validateHostname(hostname) {
 /** @typedef {import('./types').ComputedValue} ComputedValue */
 /** @typedef {import('./types').Freshness} Freshness */
 /** @typedef {import('./types').InputsRecord} InputsRecord */
-/** @typedef {import('./node_identifier').NodeIdentifier} NodeIdentifier */
+/** @typedef {import('./types').NodeIdentifier} NodeIdentifier */
+/** @typedef {import('./types').DatabaseKey} DatabaseKey */
 /** @typedef {import('./types').Counter} Counter */
 /** @typedef {import('./types').TimestampRecord} TimestampRecord */
 
@@ -170,10 +171,10 @@ async function clearHostnameStorage(db, hostname) {
  * @param {string} hostname
  * @param {string} sublevelName - e.g. 'meta', 'values', 'freshness', etc.
  * @param {string} subkey
- * @returns {string}
+ * @returns {DatabaseKey}
  */
 function hostnameRawKey(hostname, sublevelName, subkey) {
-    return `!_h_${hostname}!!${sublevelName}!${subkey}`;
+    return stringToNodeIdentifier(`!_h_${hostname}!!${sublevelName}!${subkey}`);
 }
 
 /**
@@ -228,7 +229,7 @@ async function rawPutAllToHostname(db, hostname, entries) {
     validateHostname(hostname);
     /**
      * @param {{ sublevelName: string, subkey: string, value: * }} entry
-     * @returns {{ type: 'put', key: NodeKeyString, value: * }}
+     * @returns {{ type: 'put', key: DatabaseKey, value: * }}
      */
     function makePutOp(entry) {
         return {

--- a/backend/src/generators/incremental_graph/database/hostname_storage.js
+++ b/backend/src/generators/incremental_graph/database/hostname_storage.js
@@ -11,7 +11,7 @@
  */
 
 const { makeTypedDatabase } = require('./typed_database');
-const { stringToNodeKeyString, stringToVersion } = require('./types');
+const { stringToVersion } = require('./types');
 const { RAW_BATCH_CHUNK_SIZE } = require('./constants');
 
 /**
@@ -67,7 +67,7 @@ function validateHostname(hostname) {
 /** @typedef {import('./types').ComputedValue} ComputedValue */
 /** @typedef {import('./types').Freshness} Freshness */
 /** @typedef {import('./types').InputsRecord} InputsRecord */
-/** @typedef {import('./types').NodeKeyString} NodeKeyString */
+/** @typedef {import('./node_identifier').NodeIdentifier} NodeIdentifier */
 /** @typedef {import('./types').Counter} Counter */
 /** @typedef {import('./types').TimestampRecord} TimestampRecord */
 
@@ -95,7 +95,7 @@ function buildBareSchemaStorage(namespaceSublevel) {
     const freshnessSublevel = namespaceSublevel.sublevel('freshness', { valueEncoding: 'json' });
     /** @type {SimpleSublevel<InputsRecord>} */
     const inputsSublevel = namespaceSublevel.sublevel('inputs', { valueEncoding: 'json' });
-    /** @type {SimpleSublevel<NodeKeyString[]>} */
+    /** @type {SimpleSublevel<NodeIdentifier[]>} */
     const revdepsSublevel = namespaceSublevel.sublevel('revdeps', { valueEncoding: 'json' });
     /** @type {SimpleSublevel<Counter>} */
     const countersSublevel = namespaceSublevel.sublevel('counters', { valueEncoding: 'json' });
@@ -169,10 +169,10 @@ async function clearHostnameStorage(db, hostname) {
  * @param {string} hostname
  * @param {string} sublevelName - e.g. 'meta', 'values', 'freshness', etc.
  * @param {string} subkey
- * @returns {NodeKeyString}
+ * @returns {string}
  */
 function hostnameRawKey(hostname, sublevelName, subkey) {
-    return stringToNodeKeyString(`!_h_${hostname}!!${sublevelName}!${subkey}`);
+    return `!_h_${hostname}!!${sublevelName}!${subkey}`;
 }
 
 /**

--- a/backend/src/generators/incremental_graph/database/root_database.js
+++ b/backend/src/generators/incremental_graph/database/root_database.js
@@ -48,7 +48,7 @@ const {
 /** @typedef {import('./types').DatabaseKey} DatabaseKey */
 /** @typedef {import('./types').DatabaseStoredValue} DatabaseStoredValue */
 /** @typedef {import('./types').NodeKeyString} NodeKeyString */
-/** @typedef {import('./node_identifier').NodeIdentifier} NodeIdentifier */
+/** @typedef {import('./types').NodeIdentifier} NodeIdentifier */
 /** @typedef {import('./types').Version} Version */
 /** @typedef {import('./identifier_lookup').IdentifierLookup} IdentifierLookup */
 

--- a/backend/src/generators/incremental_graph/database/root_database.js
+++ b/backend/src/generators/incremental_graph/database/root_database.js
@@ -87,14 +87,14 @@ function assertNeverReplicaName(name) {
  * Database for storing node output values.
  * Key: persisted node identifier (e.g., "nodecachex")
  * Value: the computed value (object with type field)
- * @typedef {GenericDatabase<ComputedValue, NodeKeyString>} ValuesDatabase
+ * @typedef {GenericDatabase<ComputedValue, NodeIdentifier>} ValuesDatabase
  */
 
 /**
  * Database for storing node freshness state.
  * Key: persisted node identifier (e.g., "nodecachex")
  * Value: freshness state ('up-to-date' | 'potentially-outdated')
- * @typedef {GenericDatabase<Freshness, NodeKeyString>} FreshnessDatabase
+ * @typedef {GenericDatabase<Freshness, NodeIdentifier>} FreshnessDatabase
  */
 
 /**
@@ -108,28 +108,28 @@ function assertNeverReplicaName(name) {
  * Database for storing node input dependencies.
  * Key: persisted node identifier
  * Value: inputs record with identifier-addressed dependencies
- * @typedef {GenericDatabase<InputsRecord, NodeKeyString>} InputsDatabase
+ * @typedef {GenericDatabase<InputsRecord, NodeIdentifier>} InputsDatabase
  */
 
 /**
  * Database for reverse dependency index.
  * Key: persisted input identifier
  * Value: array of dependent identifiers sorted lexicographically by identifier
- * @typedef {GenericDatabase<NodeKeyString[], NodeKeyString>} RevdepsDatabase
+ * @typedef {GenericDatabase<NodeIdentifier[], NodeIdentifier>} RevdepsDatabase
  */
 
 /**
  * Database for storing node counters.
  * Key: persisted node identifier
  * Value: counter (monotonic integer tracking value changes)
- * @typedef {GenericDatabase<Counter, NodeKeyString>} CountersDatabase
+ * @typedef {GenericDatabase<Counter, NodeIdentifier>} CountersDatabase
  */
 
 /**
  * Database for storing node timestamps (creation and modification times).
  * Key: persisted node identifier
  * Value: timestamp record with createdAt and modifiedAt ISO strings
- * @typedef {GenericDatabase<TimestampRecord, NodeKeyString>} TimestampsDatabase
+ * @typedef {GenericDatabase<TimestampRecord, NodeIdentifier>} TimestampsDatabase
  */
 
 /**
@@ -194,7 +194,7 @@ function buildSchemaStorage(namespaceSublevel, globalSublevel, version) {
     const freshnessSublevel = namespaceSublevel.sublevel('freshness', { valueEncoding: 'json' });
     /** @type {SimpleSublevel<InputsRecord>} */
     const inputsSublevel = namespaceSublevel.sublevel('inputs', { valueEncoding: 'json' });
-    /** @type {SimpleSublevel<NodeKeyString[]>} */
+    /** @type {SimpleSublevel<NodeIdentifier[]>} */
     const revdepsSublevel = namespaceSublevel.sublevel('revdeps', { valueEncoding: 'json' });
     /** @type {SimpleSublevel<Counter>} */
     const countersSublevel = namespaceSublevel.sublevel('counters', { valueEncoding: 'json' });

--- a/backend/src/generators/incremental_graph/database/root_database.js
+++ b/backend/src/generators/incremental_graph/database/root_database.js
@@ -8,7 +8,7 @@
 const { getVersion } = require('../../../version');
 const random = require('../../../random');
 const { makeTypedDatabase } = require('./typed_database');
-const { stringToVersion, stringToNodeKeyString, versionToString } = require('./types');
+const { stringToVersion, stringToNodeIdentifier, versionToString } = require('./types');
 const { RAW_BATCH_CHUNK_SIZE } = require('./constants');
 const {
     IDENTIFIERS_KEY,
@@ -701,7 +701,7 @@ class RootDatabaseClass {
     async _rawGetInSublevel(sublevelName, innerKey) {
         /** @type {SchemaSublevelType} */
         const sublevel = this.db.sublevel(sublevelName, { valueEncoding: 'json' });
-        return await sublevel.get(stringToNodeKeyString(innerKey));
+        return await sublevel.get(stringToNodeIdentifier(innerKey));
     }
 
     /**
@@ -742,7 +742,7 @@ class RootDatabaseClass {
         // AbstractPutOptions property and satisfies the weak-type check without
         // changing runtime behaviour.
         const opts = { sync: false, keyEncoding: undefined };
-        await this.db.put(stringToNodeKeyString(key), value, opts);
+        await this.db.put(stringToNodeIdentifier(key), value, opts);
     }
 
     /**
@@ -761,7 +761,7 @@ class RootDatabaseClass {
         // Pass sync:false to avoid per-write fsyncs during bulk unification.
         // See _rawPut() for the keyEncoding:undefined weak-type-check workaround.
         const opts = { sync: false, keyEncoding: undefined };
-        await this.db.del(stringToNodeKeyString(key), opts);
+        await this.db.del(stringToNodeIdentifier(key), opts);
     }
 
     /**
@@ -799,12 +799,12 @@ class RootDatabaseClass {
          * Converts a plain raw-entry object into a LevelDB batch put operation,
          * applying the JSDoc-level NodeKeyString wrapper expected by this.db.
          * @param {{ key: string, value: * }} entry
-         * @returns {{ type: 'put', key: NodeKeyString, value: * }}
+         * @returns {{ type: 'put', key: DatabaseKey, value: * }}
          */
         function makePutOp(entry) {
             return {
                 type: 'put',
-                key: stringToNodeKeyString(entry.key),
+                key: stringToNodeIdentifier(entry.key),
                 value: entry.value,
             };
         }
@@ -825,7 +825,7 @@ class RootDatabaseClass {
      * @returns {Promise<void>}
      */
     async _rawDeleteKeys(keys) {
-        await this.db.batch(keys.map(k => ({ type: 'del', key: stringToNodeKeyString(k) })));
+        await this.db.batch(keys.map(k => ({ type: 'del', key: stringToNodeIdentifier(k) })));
     }
 
     /**

--- a/backend/src/generators/incremental_graph/database/root_database.js
+++ b/backend/src/generators/incremental_graph/database/root_database.js
@@ -170,7 +170,8 @@ async function loadIdentifierLookupFromGlobal(globalSublevel) {
 
 /**
  * @template T
- * @typedef {import('./types').SimpleSublevel<T>} SimpleSublevel
+ * @template [K=DatabaseKey]
+ * @typedef {import('./types').SimpleSublevel<T, K>} SimpleSublevel
  */
 
 /**
@@ -188,17 +189,17 @@ async function loadIdentifierLookupFromGlobal(globalSublevel) {
  * @returns {SchemaStorage}
  */
 function buildSchemaStorage(namespaceSublevel, globalSublevel, version) {
-    /** @type {SimpleSublevel<ComputedValue>} */
+    /** @type {SimpleSublevel<ComputedValue, NodeIdentifier>} */
     const valuesSublevel = namespaceSublevel.sublevel('values', { valueEncoding: 'json' });
-    /** @type {SimpleSublevel<Freshness>} */
+    /** @type {SimpleSublevel<Freshness, NodeIdentifier>} */
     const freshnessSublevel = namespaceSublevel.sublevel('freshness', { valueEncoding: 'json' });
-    /** @type {SimpleSublevel<InputsRecord>} */
+    /** @type {SimpleSublevel<InputsRecord, NodeIdentifier>} */
     const inputsSublevel = namespaceSublevel.sublevel('inputs', { valueEncoding: 'json' });
-    /** @type {SimpleSublevel<NodeIdentifier[]>} */
+    /** @type {SimpleSublevel<NodeIdentifier[], NodeIdentifier>} */
     const revdepsSublevel = namespaceSublevel.sublevel('revdeps', { valueEncoding: 'json' });
-    /** @type {SimpleSublevel<Counter>} */
+    /** @type {SimpleSublevel<Counter, NodeIdentifier>} */
     const countersSublevel = namespaceSublevel.sublevel('counters', { valueEncoding: 'json' });
-    /** @type {SimpleSublevel<TimestampRecord>} */
+    /** @type {SimpleSublevel<TimestampRecord, NodeIdentifier>} */
     const timestampsSublevel = namespaceSublevel.sublevel('timestamps', { valueEncoding: 'json' });
 
     // True once this closure's first batch() verifies/writes global/version.

--- a/backend/src/generators/incremental_graph/database/types.js
+++ b/backend/src/generators/incremental_graph/database/types.js
@@ -420,7 +420,7 @@ function versionToString(Version) {
  */
 
 /**
- * @typedef {ComputedValue | Freshness | InputsRecord | NodeKeyString[] | Counter | TimestampRecord | Version | IdentifiersKeysMap} DatabaseStoredValue
+ * @typedef {ComputedValue | Freshness | InputsRecord | NodeIdentifier[] | Counter | TimestampRecord | Version | IdentifiersKeysMap} DatabaseStoredValue
  */
 
 /**
@@ -447,7 +447,7 @@ function versionToString(Version) {
 
 /**
  * A batch operation for the database.
- * @typedef {DatabasePutOperation<ComputedValue> | DatabasePutOperation<Freshness> | DatabasePutOperation<InputsRecord> | DatabasePutOperation<NodeKeyString[]> | DatabasePutOperation<Counter> | DatabasePutOperation<TimestampRecord> | DatabasePutOperation<Version> | DatabasePutOperation<IdentifiersKeysMap> | DatabaseDelOperation<ComputedValue> | DatabaseDelOperation<Freshness> | DatabaseDelOperation<InputsRecord> | DatabaseDelOperation<NodeKeyString[]> | DatabaseDelOperation<Counter> | DatabaseDelOperation<TimestampRecord> | DatabaseDelOperation<Version> | DatabaseDelOperation<IdentifiersKeysMap>} DatabaseBatchOperation
+ * @typedef {DatabasePutOperation<ComputedValue> | DatabasePutOperation<Freshness> | DatabasePutOperation<InputsRecord> | DatabasePutOperation<NodeIdentifier[]> | DatabasePutOperation<Counter> | DatabasePutOperation<TimestampRecord> | DatabasePutOperation<Version> | DatabasePutOperation<IdentifiersKeysMap> | DatabaseDelOperation<ComputedValue> | DatabaseDelOperation<Freshness> | DatabaseDelOperation<InputsRecord> | DatabaseDelOperation<NodeIdentifier[]> | DatabaseDelOperation<Counter> | DatabaseDelOperation<TimestampRecord> | DatabaseDelOperation<Version> | DatabaseDelOperation<IdentifiersKeysMap>} DatabaseBatchOperation
  */
 
 /**
@@ -522,7 +522,7 @@ function schemaPatternToString(schemaPattern) {
  */
 
 /** 
- * @typedef {NodeKeyString} DatabaseKey
+ * @typedef {NodeIdentifier | 'version' | 'identifiers_keys_map'} DatabaseKey
  */
 
 /**
@@ -543,7 +543,7 @@ function schemaPatternToString(schemaPattern) {
 
 /**
  * @template T
- * @template [K=NodeKeyString]
+ * @template [K=DatabaseKey]
  * @typedef {AbstractSublevel<AbstractSublevel<RootLevelType, SublevelFormat, DatabaseKey, DatabaseStoredValue>, SublevelFormat, K, T>} SimpleSublevel
  */
 

--- a/backend/src/generators/incremental_graph/graph_storage.js
+++ b/backend/src/generators/incremental_graph/graph_storage.js
@@ -24,7 +24,7 @@ const {
 /** @typedef {import('./database/types').Counter} Counter */
 /** @typedef {import('./database/types').TimestampRecord} TimestampRecord */
 /** @typedef {import('./database/types').InputsRecord} InputsRecord */
-/** @typedef {import('./database/node_identifier').NodeIdentifier} NodeIdentifier */
+/** @typedef {import('./database/types').NodeIdentifier} NodeIdentifier */
 
 /**
  * @template TValue

--- a/backend/src/generators/incremental_graph/graph_storage.js
+++ b/backend/src/generators/incremental_graph/graph_storage.js
@@ -5,10 +5,9 @@
  */
 
 const {
-    nodeIdentifierToDatabaseKey,
     nodeIdentifierToString,
-} = require('./database');
-const { stringToNodeIdentifier } = require('./database/types');
+    stringToNodeIdentifier,
+} = require('./database/types');
 
 /** @typedef {import('./database/root_database').RootDatabase} RootDatabase */
 /** @typedef {import('./database/root_database').SchemaStorage} SchemaStorage */
@@ -76,10 +75,10 @@ const { stringToNodeIdentifier } = require('./database/types');
 /**
  * Convert a nominal identifier to the underlying database key used by typed sublevels.
  * @param {NodeIdentifier} nodeIdentifier
- * @returns {import('./database/types').NodeKeyString}
+ * @returns {NodeIdentifier}
  */
 function toDatabaseKey(nodeIdentifier) {
-    return nodeIdentifierToDatabaseKey(nodeIdentifier);
+    return nodeIdentifier;
 }
 
 /**

--- a/backend/src/generators/incremental_graph/graph_storage.js
+++ b/backend/src/generators/incremental_graph/graph_storage.js
@@ -5,11 +5,10 @@
  */
 
 const {
-    databaseKeyToNodeIdentifier,
-    nodeIdentifierFromString,
     nodeIdentifierToDatabaseKey,
     nodeIdentifierToString,
 } = require('./database');
+const { stringToNodeIdentifier } = require('./database/types');
 
 /** @typedef {import('./database/root_database').RootDatabase} RootDatabase */
 /** @typedef {import('./database/root_database').SchemaStorage} SchemaStorage */
@@ -268,7 +267,7 @@ function makeBatchBuilder(schemaStorage) {
                     if (stored === undefined) {
                         return undefined;
                     }
-                    return stored.map(databaseKeyToNodeIdentifier);
+                    return stored;
                 },
             },
             counters: {
@@ -421,7 +420,7 @@ function makeGraphStorage(rootDatabase) {
         if (record === undefined) {
             return null;
         }
-        return record.inputs.map((input) => nodeIdentifierFromString(input));
+        return record.inputs.map((input) => stringToNodeIdentifier(input));
     }
 
     /**
@@ -430,7 +429,7 @@ function makeGraphStorage(rootDatabase) {
     async function listMaterializedNodes() {
         const nodes = [];
         for await (const key of schemaStorage.inputs.keys()) {
-            nodes.push(databaseKeyToNodeIdentifier(key));
+            nodes.push(key);
         }
         return nodes;
     }
@@ -440,42 +439,42 @@ function makeGraphStorage(rootDatabase) {
             async get(key) { return await schemaStorage.values.get(toDatabaseKey(key)); },
             async put(key, value) { await schemaStorage.values.put(toDatabaseKey(key), value); },
             async del(key) { await schemaStorage.values.del(toDatabaseKey(key)); },
-            async *keys() { for await (const key of schemaStorage.values.keys()) { yield databaseKeyToNodeIdentifier(key); } },
+            async *keys() { for await (const key of schemaStorage.values.keys()) { yield key; } },
         }),
         freshness: makeIdentifierDatabase({
             async get(key) { return await schemaStorage.freshness.get(toDatabaseKey(key)); },
             async put(key, value) { await schemaStorage.freshness.put(toDatabaseKey(key), value); },
             async del(key) { await schemaStorage.freshness.del(toDatabaseKey(key)); },
-            async *keys() { for await (const key of schemaStorage.freshness.keys()) { yield databaseKeyToNodeIdentifier(key); } },
+            async *keys() { for await (const key of schemaStorage.freshness.keys()) { yield key; } },
         }),
         inputs: makeIdentifierDatabase({
             async get(key) { return await schemaStorage.inputs.get(toDatabaseKey(key)); },
             async put(key, value) { await schemaStorage.inputs.put(toDatabaseKey(key), value); },
             async del(key) { await schemaStorage.inputs.del(toDatabaseKey(key)); },
-            async *keys() { for await (const key of schemaStorage.inputs.keys()) { yield databaseKeyToNodeIdentifier(key); } },
+            async *keys() { for await (const key of schemaStorage.inputs.keys()) { yield key; } },
         }),
         revdeps: makeIdentifierDatabase({
             async get(key) {
                 const stored = await schemaStorage.revdeps.get(toDatabaseKey(key));
-                return stored === undefined ? undefined : stored.map(databaseKeyToNodeIdentifier);
+                return stored;
             },
             async put(key, value) {
                 await schemaStorage.revdeps.put(toDatabaseKey(key), value.map(toDatabaseKey));
             },
             async del(key) { await schemaStorage.revdeps.del(toDatabaseKey(key)); },
-            async *keys() { for await (const key of schemaStorage.revdeps.keys()) { yield databaseKeyToNodeIdentifier(key); } },
+            async *keys() { for await (const key of schemaStorage.revdeps.keys()) { yield key; } },
         }),
         counters: makeIdentifierDatabase({
             async get(key) { return await schemaStorage.counters.get(toDatabaseKey(key)); },
             async put(key, value) { await schemaStorage.counters.put(toDatabaseKey(key), value); },
             async del(key) { await schemaStorage.counters.del(toDatabaseKey(key)); },
-            async *keys() { for await (const key of schemaStorage.counters.keys()) { yield databaseKeyToNodeIdentifier(key); } },
+            async *keys() { for await (const key of schemaStorage.counters.keys()) { yield key; } },
         }),
         timestamps: makeIdentifierDatabase({
             async get(key) { return await schemaStorage.timestamps.get(toDatabaseKey(key)); },
             async put(key, value) { await schemaStorage.timestamps.put(toDatabaseKey(key), value); },
             async del(key) { await schemaStorage.timestamps.del(toDatabaseKey(key)); },
-            async *keys() { for await (const key of schemaStorage.timestamps.keys()) { yield databaseKeyToNodeIdentifier(key); } },
+            async *keys() { for await (const key of schemaStorage.timestamps.keys()) { yield key; } },
         }),
         withBatch,
         ensureMaterialized,

--- a/backend/src/generators/incremental_graph/identifier_resolver.js
+++ b/backend/src/generators/incremental_graph/identifier_resolver.js
@@ -20,7 +20,7 @@ const {
 /** @typedef {import('./database/root_database').RootDatabase} RootDatabase */
 /** @typedef {import('./database/root_database').GlobalVersionDatabase} GlobalVersionDatabase */
 /** @typedef {import('./database/types').NodeKeyString} NodeKeyString */
-/** @typedef {import('./database/node_identifier').NodeIdentifier} NodeIdentifier */
+/** @typedef {import('./database/types').NodeIdentifier} NodeIdentifier */
 /** @typedef {import('./graph_storage').BatchBuilder} BatchBuilder */
 /** @typedef {import('./database/identifier_lookup').IdentifierLookup} IdentifierLookup */
 

--- a/backend/src/generators/incremental_graph/invalidate.js
+++ b/backend/src/generators/incremental_graph/invalidate.js
@@ -26,7 +26,7 @@ const { checkArity, ensureNodeNameIsHead } = require("./shared");
 
 /**
  * @param {IncrementalGraphInvalidateAccess} incrementalGraph
- * @param {import('./database/node_identifier').NodeIdentifier} changedIdentifier
+ * @param {import('./database/types').NodeIdentifier} changedIdentifier
  * @param {BatchBuilder} batch
  * @param {Set<string>} [nodesBecomingOutdated]
  * @returns {Promise<void>}

--- a/backend/src/generators/incremental_graph/migration_runner.js
+++ b/backend/src/generators/incremental_graph/migration_runner.js
@@ -116,7 +116,7 @@ function canonicalizeMigrationNodeKey(nodeKey) {
  *   keyToSourceKey: (nodeKey: NodeKeyString) => NodeKeyString,
  *   keyToOutputKey: (nodeKey: NodeKeyString) => NodeKeyString,
  *   outputKeyToDecisionKey: (outputKey: NodeKeyString) => NodeKeyString,
- *   outputEntries: Array<[import('./database/node_identifier').NodeIdentifier, NodeKeyString]>,
+ *   outputEntries: Array<[import('./database/types').NodeIdentifier, NodeKeyString]>,
  * }>}
  */
 async function makeMigrationKeyPlan(prevStorage, materializedNodes) {
@@ -144,7 +144,7 @@ async function makeMigrationKeyPlan(prevStorage, materializedNodes) {
         };
     }
 
-    /** @type {Array<[import('./database/node_identifier').NodeIdentifier, NodeKeyString]>} */
+    /** @type {Array<[import('./database/types').NodeIdentifier, NodeKeyString]>} */
     const outputEntries = [];
     /** @type {Map<string, NodeKeyString>} */
     const decisionKeyByOutputKey = new Map();
@@ -299,7 +299,7 @@ async function buildDesiredRevdeps(prevStorage, decisions, keyPlan) {
  * @param {{
  *   keyToOutputKey: (nodeKey: NodeKeyString) => NodeKeyString,
  *   outputKeyToDecisionKey: (outputKey: NodeKeyString) => NodeKeyString,
- *   outputEntries: Array<[import('./database/node_identifier').NodeIdentifier, NodeKeyString]>,
+ *   outputEntries: Array<[import('./database/types').NodeIdentifier, NodeKeyString]>,
  * }} keyPlan
  * @returns {ReadableSchemaStorage}
  */

--- a/backend/src/generators/incremental_graph/types.js
+++ b/backend/src/generators/incremental_graph/types.js
@@ -49,7 +49,7 @@
 
 /**
  * Stable identifier used for persisted IncrementalGraph state.
- * @typedef {import('./database/node_identifier').NodeIdentifier} NodeIdentifier
+ * @typedef {import('./database/types').NodeIdentifier} NodeIdentifier
  */
 
 /**


### PR DESCRIPTION
### Motivation
- Convert persisted graph storage to be indexed by opaque `NodeIdentifier` values instead of `NodeKey`/`NodeKeyString`, and reserve `NodeKeyString` only for the explicit `identifiers_keys_map` lookup table. 
- Make the root-level database typing express that only `NodeIdentifier` (plus the two global keys `version` and `identifiers_keys_map`) may be used as durable sublevel keys so downstream modules can be ported to identifier-only internals.

### Description
- Change `DatabaseKey` to `NodeIdentifier | 'version' | 'identifiers_keys_map'` and update `DatabaseStoredValue` so identifier-addressed arrays are `NodeIdentifier[]` instead of `NodeKeyString[]` in `backend/src/generators/incremental_graph/database/types.js`.
- Update `DatabaseBatchOperation` and `SimpleSublevel` template defaults to use the new `DatabaseKey` so batch operations and sublevel typedefs expect identifier-addressed keys.
- Propagate identifier-addressed typing into schema storage typedefs in `backend/src/generators/incremental_graph/database/root_database.js` by switching `ValuesDatabase`, `FreshnessDatabase`, `InputsDatabase`, `RevdepsDatabase`, `CountersDatabase`, and `TimestampsDatabase` to be keyed by `NodeIdentifier` and make `revdeps` carry `NodeIdentifier[]` values.
- Adjust hostname staging helpers in `backend/src/generators/incremental_graph/database/hostname_storage.js` by typing revdeps as `NodeIdentifier[]`, removing the `stringToNodeKeyString` conversion for raw hostname-level keys, and returning plain strings for raw hostname keys.

### Testing
- Ran `npm install` successfully to prepare the workspace and dependencies. 
- Executed `npm run static-analysis` (which runs `tsc` + `eslint`) and it failed with TypeScript errors showing remaining typing mismatches where modules still assume `NodeKeyString`-indexed sublevels, notably in `backend/src/generators/incremental_graph/database/hostname_storage.js`, `backend/src/generators/incremental_graph/database/root_database.js`, and `backend/src/generators/incremental_graph/database/sync_merge.js` (parameter/signature incompatibilities such as `TS2322` / `TS2345`).
- Invoked `npm test` (Jest) during the investigation but the run was not completed/validated within the current iteration, so no full test-suite pass was produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08c9ecebc0832eb2214ba48b330f36)