### PR TITLE
Make incremental-graph storage identifier-native (use NodeIdentifier as DB key)

### DIFF
--- a/backend/src/generators/incremental_graph/class.js
+++ b/backend/src/generators/incremental_graph/class.js
@@ -9,7 +9,7 @@
 /** @typedef {import('./types').ResolvedConcreteNode} ResolvedConcreteNode */
 /** @typedef {import('./types').ConstValue} ConstValue */
 /** @typedef {import('./types').ComputedValue} ComputedValue */
-/** @typedef {import('./types').NodeKeyString} NodeKeyString */
+/** @typedef {import('./types').NodeIdentifier} NodeIdentifier */
 /** @typedef {import('./types').RecomputeResult} RecomputeResult */
 /** @typedef {import('./graph_storage').GraphStorage} GraphStorage */
 /** @typedef {import('./graph_storage').BatchBuilder} BatchBuilder */
@@ -29,6 +29,7 @@ const {
 } = require("./compiled_node");
 const { makeGraphStorage } = require("./graph_storage");
 const { makeIdentifierResolver } = require("./identifier_resolver");
+const { stringToNodeIdentifier } = require("./database/types");
 const {
     internalGetDbVersion,
     internalGetFreshness,
@@ -50,7 +51,7 @@ const {
     internalPull,
     internalSafePullWithStatus,
     internalUnsafePull,
-    internalPullByNodeKeyStringWithStatusDuringPull,
+    internalPullByNodeIdentifierWithStatusDuringPull,
 } = require("./pull");
 const { internalMaybeRecalculate } = require("./recompute");
 
@@ -135,7 +136,7 @@ class IncrementalGraphClass {
     }
 
     /**
-     * @param {NodeKeyString} concreteKeyCanonical
+     * @param {NodeIdentifier} concreteKeyCanonical
      * @param {CompiledNode} compiledNode
      * @param {Array<ConstValue>} bindings
      * @returns {ConcreteNode}
@@ -156,8 +157,9 @@ class IncrementalGraphClass {
 
     /**
      * @param {IdentifierResolver} identifierResolver
-     * @param {(batch: BatchBuilder) => Promise<*>} procedure
-     * @returns {Promise<*>}
+     * @template T
+     * @param {(batch: BatchBuilder) => Promise<T>} procedure
+     * @returns {Promise<T>}
      */
     async withIdentifierBatch(identifierResolver, procedure) {
         const schemaStorage = this.rootDatabase.getSchemaStorage();
@@ -180,10 +182,10 @@ class IncrementalGraphClass {
             outputKey: concreteNode.output,
             inputKeys: concreteNode.inputs,
             outputIdentifier: identifierResolver.getOrAllocateNodeIdentifier(
-                concreteNode.output
+                stringToNodeIdentifier(String(concreteNode.output))
             ),
             inputIdentifiers: concreteNode.inputs.map((inputKey) =>
-                identifierResolver.getOrAllocateNodeIdentifier(inputKey)
+                identifierResolver.getOrAllocateNodeIdentifier(stringToNodeIdentifier(String(inputKey)))
             ),
             computor: concreteNode.computor,
         };
@@ -232,12 +234,12 @@ class IncrementalGraphClass {
     }
 
     /**
-     * @param {NodeKeyString} nodeKeyStr
+     * @param {NodeIdentifier} nodeKeyStr
      * @param {IdentifierResolver} identifierResolver
      * @returns {Promise<RecomputeResult>}
      */
     async _pullDuringPull(nodeKeyStr, identifierResolver) {
-        return await internalPullByNodeKeyStringWithStatusDuringPull(
+        return await internalPullByNodeIdentifierWithStatusDuringPull(
             this,
             nodeKeyStr,
             identifierResolver

--- a/backend/src/generators/incremental_graph/database/hostname_storage.js
+++ b/backend/src/generators/incremental_graph/database/hostname_storage.js
@@ -11,7 +11,7 @@
  */
 
 const { makeTypedDatabase } = require('./typed_database');
-const { stringToNodeKeyString, stringToVersion } = require('./types');
+const { stringToNodeIdentifier, stringToVersion } = require('./types');
 const { RAW_BATCH_CHUNK_SIZE } = require('./constants');
 
 /**
@@ -67,13 +67,16 @@ function validateHostname(hostname) {
 /** @typedef {import('./types').ComputedValue} ComputedValue */
 /** @typedef {import('./types').Freshness} Freshness */
 /** @typedef {import('./types').InputsRecord} InputsRecord */
-/** @typedef {import('./types').NodeKeyString} NodeKeyString */
+/** @typedef {import('./types').NodeIdentifier} NodeIdentifier */
+/** @typedef {import('./types').DatabaseKey} DatabaseKey */
+/** @typedef {import('./types').DatabaseStoredValue} DatabaseStoredValue */
 /** @typedef {import('./types').Counter} Counter */
 /** @typedef {import('./types').TimestampRecord} TimestampRecord */
 
 /**
  * @template T
- * @typedef {import('./types').SimpleSublevel<T>} SimpleSublevel
+ * @template [K=DatabaseKey]
+ * @typedef {import('./types').SimpleSublevel<T, K>} SimpleSublevel
  */
 
 /**
@@ -89,17 +92,17 @@ function validateHostname(hostname) {
  * @returns {SchemaStorage}
  */
 function buildBareSchemaStorage(namespaceSublevel) {
-    /** @type {SimpleSublevel<ComputedValue>} */
+    /** @type {SimpleSublevel<ComputedValue, NodeIdentifier>} */
     const valuesSublevel = namespaceSublevel.sublevel('values', { valueEncoding: 'json' });
-    /** @type {SimpleSublevel<Freshness>} */
+    /** @type {SimpleSublevel<Freshness, NodeIdentifier>} */
     const freshnessSublevel = namespaceSublevel.sublevel('freshness', { valueEncoding: 'json' });
-    /** @type {SimpleSublevel<InputsRecord>} */
+    /** @type {SimpleSublevel<InputsRecord, NodeIdentifier>} */
     const inputsSublevel = namespaceSublevel.sublevel('inputs', { valueEncoding: 'json' });
-    /** @type {SimpleSublevel<NodeKeyString[]>} */
+    /** @type {SimpleSublevel<NodeIdentifier[], NodeIdentifier>} */
     const revdepsSublevel = namespaceSublevel.sublevel('revdeps', { valueEncoding: 'json' });
-    /** @type {SimpleSublevel<Counter>} */
+    /** @type {SimpleSublevel<Counter, NodeIdentifier>} */
     const countersSublevel = namespaceSublevel.sublevel('counters', { valueEncoding: 'json' });
-    /** @type {SimpleSublevel<TimestampRecord>} */
+    /** @type {SimpleSublevel<TimestampRecord, NodeIdentifier>} */
     const timestampsSublevel = namespaceSublevel.sublevel('timestamps', { valueEncoding: 'json' });
     /** @type {GlobalSublevelType} */
     const globalSublevel = namespaceSublevel.sublevel('global', { valueEncoding: 'json' });
@@ -169,10 +172,10 @@ async function clearHostnameStorage(db, hostname) {
  * @param {string} hostname
  * @param {string} sublevelName - e.g. 'meta', 'values', 'freshness', etc.
  * @param {string} subkey
- * @returns {NodeKeyString}
+ * @returns {DatabaseKey}
  */
 function hostnameRawKey(hostname, sublevelName, subkey) {
-    return stringToNodeKeyString(`!_h_${hostname}!!${sublevelName}!${subkey}`);
+    return stringToNodeIdentifier(`!_h_${hostname}!!${sublevelName}!${subkey}`);
 }
 
 /**
@@ -203,7 +206,7 @@ async function getHostnameGlobalVersion(db, hostname) {
  * @param {RootLevelType} db - The root LevelDB instance.
  * @param {string} hostname
  * @param {string} key - The key to write (e.g. 'version').
- * @param {*} value - The value to store.
+ * @param {DatabaseStoredValue} value - The value to store.
  * @returns {Promise<void>}
  * @throws {InvalidHostnameError} If the hostname is invalid.
  */
@@ -227,7 +230,7 @@ async function rawPutAllToHostname(db, hostname, entries) {
     validateHostname(hostname);
     /**
      * @param {{ sublevelName: string, subkey: string, value: * }} entry
-     * @returns {{ type: 'put', key: NodeKeyString, value: * }}
+     * @returns {{ type: 'put', key: DatabaseKey, value: * }}
      */
     function makePutOp(entry) {
         return {

--- a/backend/src/generators/incremental_graph/database/identifier_lookup.js
+++ b/backend/src/generators/incremental_graph/database/identifier_lookup.js
@@ -5,11 +5,8 @@ const {
     nodeIdentifierFromString,
     nodeIdentifierToString,
 } = require("./node_identifier");
-const {
-    nodeKeyStringToString,
-} = require("./types");
 
-/** @typedef {import("./node_identifier").NodeIdentifier} NodeIdentifier */
+/** @typedef {import("./types").NodeIdentifier} NodeIdentifier */
 /** @typedef {import("./types").NodeKeyString} NodeKeyString */
 
 /**
@@ -61,7 +58,7 @@ function isIdentifierAllocationError(object) {
 /**
  * @typedef {object} IdentifierLookup
  * @property {Map<string, NodeIdentifier>} keyToId - Semantic node key string -> opaque identifier.
- * @property {Map<string, NodeKeyString>} idToKey - Opaque identifier string -> semantic node key.
+ * @property {Map<string, NodeIdentifier>} idToKey - Opaque identifier string -> semantic node key.
  */
 
 /**
@@ -77,14 +74,14 @@ function makeEmptyIdentifierLookup() {
 /**
  * Build a validated in-memory lookup from persisted `[id, key]` entries.
  * The input must already be a strict bijection.
- * @param {Array<[NodeIdentifier, NodeKeyString]>} entries
+ * @param {Array<[NodeIdentifier, NodeIdentifier]>} entries
  * @returns {IdentifierLookup}
  */
 function makeIdentifierLookup(entries) {
     const lookup = makeEmptyIdentifierLookup();
     for (const [nodeIdentifier, nodeKey] of entries) {
         const identifierString = nodeIdentifierToString(nodeIdentifier);
-        const nodeKeyString = nodeKeyStringToString(nodeKey);
+        const nodeKeyString = nodeIdentifierToString(nodeKey);
         if (lookup.idToKey.has(identifierString)) {
             throw new IdentifierLookupError(`Duplicate node identifier in lookup map: ${identifierString}`);
         }
@@ -109,10 +106,10 @@ function cloneIdentifierLookup(lookup) {
 /**
  * Convert the lookup back into its persisted form, sorted by identifier string.
  * @param {IdentifierLookup} lookup
- * @returns {Array<[NodeIdentifier, NodeKeyString]>}
+ * @returns {Array<[NodeIdentifier, NodeIdentifier]>}
  */
 function serializeIdentifierLookup(lookup) {
-    /** @type {Array<[NodeIdentifier, NodeKeyString]>} */
+    /** @type {Array<[NodeIdentifier, NodeIdentifier]>} */
     const entries = [];
     for (const [identifierString, nodeKey] of lookup.idToKey.entries()) {
         entries.push([
@@ -129,18 +126,18 @@ function serializeIdentifierLookup(lookup) {
 /**
  * Read the identifier currently assigned to a semantic node key.
  * @param {IdentifierLookup} lookup
- * @param {NodeKeyString} nodeKey
+ * @param {NodeIdentifier} nodeKey
  * @returns {NodeIdentifier | undefined}
  */
 function nodeKeyToIdFromLookup(lookup, nodeKey) {
-    return lookup.keyToId.get(nodeKeyStringToString(nodeKey));
+    return lookup.keyToId.get(nodeIdentifierToString(nodeKey));
 }
 
 /**
  * Read the semantic node key currently assigned to an identifier.
  * @param {IdentifierLookup} lookup
  * @param {NodeIdentifier} nodeIdentifier
- * @returns {NodeKeyString | undefined}
+ * @returns {NodeIdentifier | undefined}
  */
 function nodeIdToKeyFromLookup(lookup, nodeIdentifier) {
     return lookup.idToKey.get(nodeIdentifierToString(nodeIdentifier));
@@ -151,16 +148,16 @@ function nodeIdToKeyFromLookup(lookup, nodeIdentifier) {
  * This throws if either side is already associated with a different counterpart.
  * @param {IdentifierLookup} lookup
  * @param {NodeIdentifier} nodeIdentifier
- * @param {NodeKeyString} nodeKey
+ * @param {NodeIdentifier} nodeKey
  * @returns {void}
  */
 function setIdentifierMapping(lookup, nodeIdentifier, nodeKey) {
     const identifierString = nodeIdentifierToString(nodeIdentifier);
-    const nodeKeyString = nodeKeyStringToString(nodeKey);
+    const nodeKeyString = nodeIdentifierToString(nodeKey);
     const existingKey = lookup.idToKey.get(identifierString);
     if (existingKey !== undefined && existingKey !== nodeKey) {
         throw new IdentifierLookupError(
-            `Node identifier ${identifierString} is already assigned to ${nodeKeyStringToString(existingKey)}`
+            `Node identifier ${identifierString} is already assigned to ${nodeIdentifierToString(existingKey)}`
         );
     }
     const existingIdentifier = lookup.keyToId.get(nodeKeyString);
@@ -176,11 +173,11 @@ function setIdentifierMapping(lookup, nodeIdentifier, nodeKey) {
 /**
  * Remove the mapping for a semantic node key if one exists.
  * @param {IdentifierLookup} lookup
- * @param {NodeKeyString} nodeKey
+ * @param {NodeIdentifier} nodeKey
  * @returns {void}
  */
 function deleteIdentifierMappingForNodeKey(lookup, nodeKey) {
-    const nodeKeyString = nodeKeyStringToString(nodeKey);
+    const nodeKeyString = nodeIdentifierToString(nodeKey);
     const existingIdentifier = lookup.keyToId.get(nodeKeyString);
     if (existingIdentifier === undefined) {
         return;
@@ -192,12 +189,12 @@ function deleteIdentifierMappingForNodeKey(lookup, nodeKey) {
 /**
  * Deterministically derive the legacy-migration identifier candidate for a node key.
  * Retry attempts perturb the hash input so collision handling is deterministic.
- * @param {NodeKeyString} nodeKey
+ * @param {NodeIdentifier} nodeKey
  * @param {number} attempt
  * @returns {NodeIdentifier}
  */
 function deterministicNodeIdentifierFromNodeKey(nodeKey, attempt = 0) {
-    const nodeKeyString = nodeKeyStringToString(nodeKey);
+    const nodeKeyString = nodeIdentifierToString(nodeKey);
     const digest = crypto
         .createHash("sha256")
         .update(`${nodeKeyString}:${String(attempt)}`)
@@ -218,7 +215,7 @@ function deterministicNodeIdentifierFromNodeKey(nodeKey, attempt = 0) {
  * Allocate a fresh identifier for a node key, retrying on collisions.
  * If the key already has an identifier, the existing identifier is reused.
  * @param {IdentifierLookup} lookup
- * @param {NodeKeyString} nodeKey
+ * @param {NodeIdentifier} nodeKey
  * @param {(attempt: number) => NodeIdentifier} makeIdentifier
  * @param {number} [maxAttempts=64]
  * @returns {NodeIdentifier}
@@ -238,14 +235,14 @@ function allocateNodeIdentifier(lookup, nodeKey, makeIdentifier, maxAttempts = 6
         }
     }
 
-    throw new IdentifierAllocationError(nodeKeyStringToString(nodeKey));
+    throw new IdentifierAllocationError(nodeIdentifierToString(nodeKey));
 }
 
 /**
  * Require the semantic node key for an identifier.
  * @param {IdentifierLookup} lookup
  * @param {NodeIdentifier} nodeIdentifier
- * @returns {NodeKeyString}
+ * @returns {NodeIdentifier}
  */
 function requireNodeKeyForIdentifier(lookup, nodeIdentifier) {
     const nodeKey = nodeIdToKeyFromLookup(lookup, nodeIdentifier);
@@ -260,14 +257,14 @@ function requireNodeKeyForIdentifier(lookup, nodeIdentifier) {
 /**
  * Require the identifier for a semantic node key.
  * @param {IdentifierLookup} lookup
- * @param {NodeKeyString} nodeKey
+ * @param {NodeIdentifier} nodeKey
  * @returns {NodeIdentifier}
  */
 function requireNodeIdentifierForKey(lookup, nodeKey) {
     const nodeIdentifier = nodeKeyToIdFromLookup(lookup, nodeKey);
     if (nodeIdentifier === undefined) {
         throw new IdentifierLookupError(
-            `Missing node identifier for key ${nodeKeyStringToString(nodeKey)}`
+            `Missing node identifier for key ${nodeIdentifierToString(nodeKey)}`
         );
     }
     return nodeIdentifier;

--- a/backend/src/generators/incremental_graph/database/node_identifier.js
+++ b/backend/src/generators/incremental_graph/database/node_identifier.js
@@ -1,5 +1,8 @@
 const random = require("../../../random");
-const { nodeKeyStringToString, stringToNodeKeyString } = require("./types");
+const {
+    nodeIdentifierToString: nodeIdentifierToRawString,
+    stringToNodeIdentifier,
+} = require("./types");
 
 /**
  * Persisted node identifiers are exactly 9 lowercase ASCII letters.
@@ -30,32 +33,8 @@ function isInvalidNodeIdentifierError(object) {
     return object instanceof InvalidNodeIdentifierError;
 }
 
-class NodeIdentifierClass {
-    /** @type {string} */
-    identifier;
-
-    /**
-     * @private
-     * @type {undefined}
-     */
-    __brand;
-
-    /**
-     * @param {string} identifier
-     */
-    constructor(identifier) {
-        this.identifier = identifier;
-        if (this.__brand !== undefined) {
-            throw new Error("NodeIdentifier is a nominal type and should not be instantiated directly");
-        }
-    }
-}
-
-/**
- * Opaque random identifier for a materialized incremental-graph node.
- * The string format is intentionally restricted to nine lowercase letters.
- * @typedef {NodeIdentifierClass} NodeIdentifier
- */
+/** @typedef {import('./types').NodeIdentifier} NodeIdentifier */
+/** @typedef {import('./types').DatabaseKey} DatabaseKey */
 
 /**
  * @typedef {object} Capabilities
@@ -89,7 +68,7 @@ function nodeIdentifierFromString(identifier) {
     if (!isValidNodeIdentifier(identifier)) {
         throw new InvalidNodeIdentifierError(identifier);
     }
-    return new NodeIdentifierClass(identifier);
+    return stringToNodeIdentifier(identifier);
 }
 
 /**
@@ -98,26 +77,26 @@ function nodeIdentifierFromString(identifier) {
  * @returns {string}
  */
 function nodeIdentifierToString(identifier) {
-    return identifier.identifier;
+    return nodeIdentifierToRawString(identifier);
 }
 
 /**
  * Convert an identifier to the branded database-key type used by typed sublevels.
  * This hides the NodeKeyString storage-brand detail from identifier-native callers.
  * @param {NodeIdentifier} identifier
- * @returns {import('./types').NodeKeyString}
+ * @returns {DatabaseKey}
  */
 function nodeIdentifierToDatabaseKey(identifier) {
-    return stringToNodeKeyString(nodeIdentifierToString(identifier));
+    return identifier;
 }
 
 /**
  * Convert a typed database key that is known to hold an identifier back into a NodeIdentifier.
- * @param {import('./types').NodeKeyString} key
+ * @param {DatabaseKey} key
  * @returns {NodeIdentifier}
  */
 function databaseKeyToNodeIdentifier(key) {
-    return nodeIdentifierFromString(nodeKeyStringToString(key));
+    return nodeIdentifierFromString(String(key));
 }
 
 /**

--- a/backend/src/generators/incremental_graph/database/root_database.js
+++ b/backend/src/generators/incremental_graph/database/root_database.js
@@ -8,7 +8,7 @@
 const { getVersion } = require('../../../version');
 const random = require('../../../random');
 const { makeTypedDatabase } = require('./typed_database');
-const { stringToVersion, stringToNodeKeyString, versionToString } = require('./types');
+const { stringToVersion, stringToNodeIdentifier, versionToString } = require('./types');
 const { RAW_BATCH_CHUNK_SIZE } = require('./constants');
 const {
     IDENTIFIERS_KEY,
@@ -47,8 +47,7 @@ const {
 /** @typedef {import('./types').DatabaseBatchOperation} DatabaseBatchOperation */
 /** @typedef {import('./types').DatabaseKey} DatabaseKey */
 /** @typedef {import('./types').DatabaseStoredValue} DatabaseStoredValue */
-/** @typedef {import('./types').NodeKeyString} NodeKeyString */
-/** @typedef {import('./node_identifier').NodeIdentifier} NodeIdentifier */
+/** @typedef {import('./types').NodeIdentifier} NodeIdentifier */
 /** @typedef {import('./types').Version} Version */
 /** @typedef {import('./identifier_lookup').IdentifierLookup} IdentifierLookup */
 
@@ -87,14 +86,14 @@ function assertNeverReplicaName(name) {
  * Database for storing node output values.
  * Key: persisted node identifier (e.g., "nodecachex")
  * Value: the computed value (object with type field)
- * @typedef {GenericDatabase<ComputedValue, NodeKeyString>} ValuesDatabase
+ * @typedef {GenericDatabase<ComputedValue, NodeIdentifier>} ValuesDatabase
  */
 
 /**
  * Database for storing node freshness state.
  * Key: persisted node identifier (e.g., "nodecachex")
  * Value: freshness state ('up-to-date' | 'potentially-outdated')
- * @typedef {GenericDatabase<Freshness, NodeKeyString>} FreshnessDatabase
+ * @typedef {GenericDatabase<Freshness, NodeIdentifier>} FreshnessDatabase
  */
 
 /**
@@ -108,28 +107,28 @@ function assertNeverReplicaName(name) {
  * Database for storing node input dependencies.
  * Key: persisted node identifier
  * Value: inputs record with identifier-addressed dependencies
- * @typedef {GenericDatabase<InputsRecord, NodeKeyString>} InputsDatabase
+ * @typedef {GenericDatabase<InputsRecord, NodeIdentifier>} InputsDatabase
  */
 
 /**
  * Database for reverse dependency index.
  * Key: persisted input identifier
  * Value: array of dependent identifiers sorted lexicographically by identifier
- * @typedef {GenericDatabase<NodeKeyString[], NodeKeyString>} RevdepsDatabase
+ * @typedef {GenericDatabase<NodeIdentifier[], NodeIdentifier>} RevdepsDatabase
  */
 
 /**
  * Database for storing node counters.
  * Key: persisted node identifier
  * Value: counter (monotonic integer tracking value changes)
- * @typedef {GenericDatabase<Counter, NodeKeyString>} CountersDatabase
+ * @typedef {GenericDatabase<Counter, NodeIdentifier>} CountersDatabase
  */
 
 /**
  * Database for storing node timestamps (creation and modification times).
  * Key: persisted node identifier
  * Value: timestamp record with createdAt and modifiedAt ISO strings
- * @typedef {GenericDatabase<TimestampRecord, NodeKeyString>} TimestampsDatabase
+ * @typedef {GenericDatabase<TimestampRecord, NodeIdentifier>} TimestampsDatabase
  */
 
 /**
@@ -170,7 +169,8 @@ async function loadIdentifierLookupFromGlobal(globalSublevel) {
 
 /**
  * @template T
- * @typedef {import('./types').SimpleSublevel<T>} SimpleSublevel
+ * @template [K=DatabaseKey]
+ * @typedef {import('./types').SimpleSublevel<T, K>} SimpleSublevel
  */
 
 /**
@@ -188,17 +188,17 @@ async function loadIdentifierLookupFromGlobal(globalSublevel) {
  * @returns {SchemaStorage}
  */
 function buildSchemaStorage(namespaceSublevel, globalSublevel, version) {
-    /** @type {SimpleSublevel<ComputedValue>} */
+    /** @type {SimpleSublevel<ComputedValue, NodeIdentifier>} */
     const valuesSublevel = namespaceSublevel.sublevel('values', { valueEncoding: 'json' });
-    /** @type {SimpleSublevel<Freshness>} */
+    /** @type {SimpleSublevel<Freshness, NodeIdentifier>} */
     const freshnessSublevel = namespaceSublevel.sublevel('freshness', { valueEncoding: 'json' });
-    /** @type {SimpleSublevel<InputsRecord>} */
+    /** @type {SimpleSublevel<InputsRecord, NodeIdentifier>} */
     const inputsSublevel = namespaceSublevel.sublevel('inputs', { valueEncoding: 'json' });
-    /** @type {SimpleSublevel<NodeKeyString[]>} */
+    /** @type {SimpleSublevel<NodeIdentifier[], NodeIdentifier>} */
     const revdepsSublevel = namespaceSublevel.sublevel('revdeps', { valueEncoding: 'json' });
-    /** @type {SimpleSublevel<Counter>} */
+    /** @type {SimpleSublevel<Counter, NodeIdentifier>} */
     const countersSublevel = namespaceSublevel.sublevel('counters', { valueEncoding: 'json' });
-    /** @type {SimpleSublevel<TimestampRecord>} */
+    /** @type {SimpleSublevel<TimestampRecord, NodeIdentifier>} */
     const timestampsSublevel = namespaceSublevel.sublevel('timestamps', { valueEncoding: 'json' });
 
     // True once this closure's first batch() verifies/writes global/version.
@@ -427,7 +427,7 @@ class RootDatabaseClass {
     }
 
     /**
-     * @param {NodeKeyString} nodeKey
+     * @param {NodeIdentifier} nodeKey
      * @returns {NodeIdentifier | undefined}
      */
     nodeKeyToId(nodeKey) {
@@ -439,7 +439,7 @@ class RootDatabaseClass {
 
     /**
      * @param {NodeIdentifier} nodeIdentifier
-     * @returns {NodeKeyString | undefined}
+     * @returns {NodeIdentifier | undefined}
      */
     nodeIdToKey(nodeIdentifier) {
         return nodeIdToKeyFromLookup(
@@ -633,7 +633,7 @@ class RootDatabaseClass {
      * Write a key/value pair into a hostname's staging global sublevel.
      * @param {string} hostname
      * @param {string} key - The key to write (e.g. 'version').
-     * @param {*} value - The value to store.
+     * @param {unknown} value - The value to store.
      * @returns {Promise<void>}
      */
     async setHostnameGlobal(hostname, key, value) {
@@ -700,7 +700,7 @@ class RootDatabaseClass {
     async _rawGetInSublevel(sublevelName, innerKey) {
         /** @type {SchemaSublevelType} */
         const sublevel = this.db.sublevel(sublevelName, { valueEncoding: 'json' });
-        return await sublevel.get(stringToNodeKeyString(innerKey));
+        return await sublevel.get(stringToNodeIdentifier(innerKey));
     }
 
     /**
@@ -723,14 +723,14 @@ class RootDatabaseClass {
      * Call _rawSync() once after all bulk unification writes are done to
      * ensure the writes are flushed to durable storage.
      *
-     * The `stringToNodeKeyString` conversion is required to satisfy the JSDoc
+     * The `stringToNodeIdentifier` conversion is required to satisfy the JSDoc
      * static typing expectations: `this.db` is documented as using
-     * `NodeKeyString` keys, so its `put` method is typed to require a
-     * `NodeKeyString`. At runtime `stringToNodeKeyString` is effectively a
+     * `NodeIdentifier` keys, so its `put` method is typed to require a
+     * `NodeIdentifier`. At runtime `stringToNodeIdentifier` is effectively a
      * no-op, so the raw sublevel-prefixed key passes through unchanged.
      *
      * @param {string} key
-     * @param {*} value
+     * @param {unknown} value
      * @returns {Promise<void>}
      */
     async _rawPut(key, value) {
@@ -741,7 +741,7 @@ class RootDatabaseClass {
         // AbstractPutOptions property and satisfies the weak-type check without
         // changing runtime behaviour.
         const opts = { sync: false, keyEncoding: undefined };
-        await this.db.put(stringToNodeKeyString(key), value, opts);
+        await this.db.put(stringToNodeIdentifier(key), value, opts);
     }
 
     /**
@@ -760,7 +760,7 @@ class RootDatabaseClass {
         // Pass sync:false to avoid per-write fsyncs during bulk unification.
         // See _rawPut() for the keyEncoding:undefined weak-type-check workaround.
         const opts = { sync: false, keyEncoding: undefined };
-        await this.db.del(stringToNodeKeyString(key), opts);
+        await this.db.del(stringToNodeIdentifier(key), opts);
     }
 
     /**
@@ -796,14 +796,14 @@ class RootDatabaseClass {
     async _rawPutAll(entries) {
         /**
          * Converts a plain raw-entry object into a LevelDB batch put operation,
-         * applying the JSDoc-level NodeKeyString wrapper expected by this.db.
+         * applying the JSDoc-level NodeIdentifier wrapper expected by this.db.
          * @param {{ key: string, value: * }} entry
-         * @returns {{ type: 'put', key: NodeKeyString, value: * }}
+         * @returns {{ type: 'put', key: DatabaseKey, value: * }}
          */
         function makePutOp(entry) {
             return {
                 type: 'put',
-                key: stringToNodeKeyString(entry.key),
+                key: stringToNodeIdentifier(entry.key),
                 value: entry.value,
             };
         }
@@ -824,7 +824,7 @@ class RootDatabaseClass {
      * @returns {Promise<void>}
      */
     async _rawDeleteKeys(keys) {
-        await this.db.batch(keys.map(k => ({ type: 'del', key: stringToNodeKeyString(k) })));
+        await this.db.batch(keys.map(k => ({ type: 'del', key: stringToNodeIdentifier(k) })));
     }
 
     /**

--- a/backend/src/generators/incremental_graph/database/sync_merge.js
+++ b/backend/src/generators/incremental_graph/database/sync_merge.js
@@ -45,17 +45,16 @@
  */
 
 const { topologicalSortFromMap, isTopologicalSortCycleError } = require('./topo_sort');
-const { stringToNodeKeyString, versionToString } = require('./types');
-const { compareNodeKeyStringByNodeKey } = require('./node_key');
+const { stringToNodeIdentifier, versionToString } = require('./types');
+const { compareNodeIdentifier } = require('./node_identifier');
 const { RAW_BATCH_CHUNK_SIZE } = require('./constants');
 const { makeDbToDbAdapter, unifyStores } = require('./unification');
 
 /** @typedef {import('./root_database').RootDatabase} RootDatabase */
 /** @typedef {import('./root_database').SchemaStorage} SchemaStorage */
 /** @typedef {import('./root_database').ReplicaName} ReplicaName */
-/** @typedef {import('./types').NodeKeyString} NodeKeyString */
+/** @typedef {import('./types').NodeIdentifier} NodeIdentifier */
 /** @typedef {import('./types').Version} Version */
-/** @typedef {import('./types').DatabaseBatchOperation} DatabaseBatchOperation */
 
 /**
  * @typedef {import('../../../logger').Logger} Logger
@@ -175,11 +174,11 @@ async function copyReplicaGently(rootDatabase, from, to) {
  *
  * @param {SchemaStorage} T - Target (inactive) replica storage.
  * @param {SchemaStorage} H - Hostname staging storage.
- * @param {NodeKeyString} key
- * @returns {Promise<DatabaseBatchOperation[]>}
+ * @param {NodeIdentifier} key
+ * @returns {Promise<Array<*>>}
  */
 async function buildTakeOps(T, H, key) {
-    /** @type {DatabaseBatchOperation[]} */
+    /** @type {Array<*>} */
     const ops = [];
 
     const hValue = await H.values.get(key);
@@ -225,7 +224,7 @@ async function buildTakeOps(T, H, key) {
  * typed revdeps to avoid unsafe value coercions.
  *
  * @param {SchemaStorage} T
- * @param {Map<NodeKeyString, NodeKeyString[]>} mergedInputsMap
+ * @param {Map<NodeIdentifier, NodeIdentifier[]>} mergedInputsMap
  * @returns {Promise<void>}
  */
 async function unifyRevdeps(T, mergedInputsMap) {
@@ -238,7 +237,7 @@ async function unifyRevdeps(T, mergedInputsMap) {
     // writing.  This is bounded by the number of nodes+edges in the graph,
     // not by value sizes, so it fits within the O(n) target where
     // n = max(max_value_size, num_nodes + num_edges).
-    /** @type {Map<string, Set<NodeKeyString>>} */
+    /** @type {Map<string, Set<NodeIdentifier>>} */
     const desiredSets = new Map();
 
     for (const [node, inputKeys] of mergedInputsMap) {
@@ -254,10 +253,10 @@ async function unifyRevdeps(T, mergedInputsMap) {
     }
 
     // Convert to sorted arrays for determinism and stable serialisation.
-    /** @type {Map<string, NodeKeyString[]>} */
+    /** @type {Map<string, NodeIdentifier[]>} */
     const desired = new Map();
     for (const [key, depSet] of desiredSets) {
-        desired.set(key, [...depSet].sort(compareNodeKeyStringByNodeKey));
+        desired.set(key, [...depSet].sort(compareNodeIdentifier));
     }
 
     // Materialise the current target key set.
@@ -270,10 +269,10 @@ async function unifyRevdeps(T, mergedInputsMap) {
     // Accumulate ops for batch writes chunked by RAW_BATCH_CHUNK_SIZE.
     // Memory: O(RAW_BATCH_CHUNK_SIZE × avg_revdep_size) per chunk — revdep
     // values are small (arrays of node-key strings), so each chunk is bounded.
-    /** @type {DatabaseBatchOperation[]} */
+    /** @type {Array<*>} */
     const ops = [];
     for (const [inputStr, dependents] of desired) {
-        const inputKey = stringToNodeKeyString(inputStr);
+        const inputKey = stringToNodeIdentifier(inputStr);
         if (!targetKeys.has(inputStr)) {
             ops.push(T.revdeps.putOp(inputKey, dependents));
         } else {
@@ -290,7 +289,7 @@ async function unifyRevdeps(T, mergedInputsMap) {
     // Delete stale entries.
     for (const existingKey of targetKeys) {
         if (!desired.has(existingKey)) {
-            ops.push(T.revdeps.delOp(stringToNodeKeyString(existingKey)));
+            ops.push(T.revdeps.delOp(stringToNodeIdentifier(existingKey)));
         }
         if (ops.length >= RAW_BATCH_CHUNK_SIZE) {
             await T.batch(ops.splice(0, ops.length));
@@ -364,11 +363,11 @@ async function mergeHostIntoReplica(logger, rootDatabase, hostname) {
     //      change because a taken node rewired its inputs.
 
     // ── 2a: Per-node timestamp comparison for T nodes ─────────────────────────
-    /** @type {Map<NodeKeyString, 'keep' | 'take'>} */
+    /** @type {Map<NodeIdentifier, 'keep' | 'take'>} */
     const initialDecisions = new Map();
-    /** @type {Set<NodeKeyString>} */
+    /** @type {Set<NodeIdentifier>} */
     const forceKeepRoots = new Set();
-    /** @type {Set<NodeKeyString>} */
+    /** @type {Set<NodeIdentifier>} */
     const forceTakeRoots = new Set();
 
     for await (const node of T.inputs.keys()) {
@@ -389,7 +388,7 @@ async function mergeHostIntoReplica(logger, rootDatabase, hostname) {
     }
 
     // ── 2b: Discover H-only nodes ─────────────────────────────────────────────
-    /** @type {Set<NodeKeyString>} */
+    /** @type {Set<NodeIdentifier>} */
     const hOnlyNodes = new Set();
     for await (const key of H.inputs.keys()) {
         if (!initialDecisions.has(key)) {
@@ -401,7 +400,7 @@ async function mergeHostIntoReplica(logger, rootDatabase, hostname) {
     // For 'take' nodes: use H.inputs (the remote may have rewired edges).
     // For 'keep' nodes: use T.inputs.
     // For H-only nodes: use H.inputs.
-    /** @type {Map<NodeKeyString, NodeKeyString[]>} */
+    /** @type {Map<NodeIdentifier, NodeIdentifier[]>} */
     const mergedInputsMap = new Map();
 
     for (const [node, decision] of initialDecisions) {
@@ -418,7 +417,7 @@ async function mergeHostIntoReplica(logger, rootDatabase, hostname) {
             record = await T.inputs.get(node);
         }
         const inputKeys = record
-            ? record.inputs.map(s => stringToNodeKeyString(s))
+            ? record.inputs.map(s => stringToNodeIdentifier(s))
             : [];
         mergedInputsMap.set(node, inputKeys);
     }
@@ -426,7 +425,7 @@ async function mergeHostIntoReplica(logger, rootDatabase, hostname) {
     for (const key of hOnlyNodes) {
         const record = await H.inputs.get(key);
         const inputKeys = record
-            ? record.inputs.map(s => stringToNodeKeyString(s))
+            ? record.inputs.map(s => stringToNodeIdentifier(s))
             : [];
         mergedInputsMap.set(key, inputKeys);
     }
@@ -440,9 +439,9 @@ async function mergeHostIntoReplica(logger, rootDatabase, hostname) {
     // Uses the merged inputs map so that rewired edges from taken nodes are
     // correctly accounted for (e.g. a taken node that now depends on a
     // force-kept ancestor will be tainted from both sides → 'invalidate').
-    /** @type {Set<NodeKeyString>} */
+    /** @type {Set<NodeIdentifier>} */
     const keepTainted = new Set(forceKeepRoots);
-    /** @type {Set<NodeKeyString>} */
+    /** @type {Set<NodeIdentifier>} */
     const takeTainted = new Set(forceTakeRoots);
 
     for (const node of topoList) {
@@ -454,7 +453,7 @@ async function mergeHostIntoReplica(logger, rootDatabase, hostname) {
     }
 
     // ── Step 5: Assign final decisions ──────────────────────────────────────
-    /** @type {Map<NodeKeyString, 'keep' | 'take' | 'invalidate'>} */
+    /** @type {Map<NodeIdentifier, 'keep' | 'take' | 'invalidate'>} */
     const decisions = new Map();
 
     for (const [node, initial] of initialDecisions) {
@@ -475,7 +474,7 @@ async function mergeHostIntoReplica(logger, rootDatabase, hostname) {
     // ── Step 6: Finalize H-only nodes ────────────────────────────────────────
     // H-only nodes are always taken, but their cached value may be stale if
     // any of their (merged-graph) ancestors were force-kept from T.
-    /** @type {Set<NodeKeyString>} */
+    /** @type {Set<NodeIdentifier>} */
     const hOnlyNeedsInvalidate = new Set();
 
     for (const key of hOnlyNodes) {
@@ -486,7 +485,7 @@ async function mergeHostIntoReplica(logger, rootDatabase, hostname) {
     }
 
     // ── Step 7: Apply decisions to T in chunks ──────────────────────────────
-    /** @type {DatabaseBatchOperation[]} */
+    /** @type {Array<*>} */
     let pendingOps = [];
 
     /**

--- a/backend/src/generators/incremental_graph/database/topo_sort.js
+++ b/backend/src/generators/incremental_graph/database/topo_sort.js
@@ -4,7 +4,7 @@
  * Provides topologicalSort(), which takes a SchemaStorage and returns the
  * nodes in topological order: root nodes (no inputs) first, leaf nodes (no
  * dependents) last.  Tie-breaking within the same depth level is
- * deterministic: nodes are sorted ascending by their NodeKeyString
+ * deterministic: nodes are sorted ascending by their NodeIdentifier
  * representation so the output is stable across runs.
  *
  * Uses Kahn's algorithm with a min-heap priority queue for O((N + E) log N)
@@ -12,10 +12,10 @@
  * if the graph contains a cycle (which is treated as data corruption).
  */
 
-const { compareNodeKeyStringByNodeKey } = require('./node_key');
-const { stringToNodeKeyString } = require('./types');
+const { compareNodeIdentifier } = require('./node_identifier');
+const { stringToNodeIdentifier } = require('./types');
 
-/** @typedef {import('./types').NodeKeyString} NodeKeyString */
+/** @typedef {import('./types').NodeIdentifier} NodeIdentifier */
 /** @typedef {import('./root_database').SchemaStorage} SchemaStorage */
 const CYCLE_MESSAGE_SAMPLE_LIMIT = 20;
 
@@ -135,7 +135,7 @@ class MinHeap {
  */
 class TopologicalSortCycleError extends Error {
     /**
-     * @param {NodeKeyString[]} cycle - A representative subset of nodes involved in the cycle.
+     * @param {NodeIdentifier[]} cycle - A representative subset of nodes involved in the cycle.
      */
     constructor(cycle) {
         const sample = cycle.slice(0, CYCLE_MESSAGE_SAMPLE_LIMIT);
@@ -164,10 +164,10 @@ function isTopologicalSortCycleError(object) {
  * sublevel as the canonical materialized-node registry).
  *
  * @param {SchemaStorage} storage
- * @returns {Promise<NodeKeyString[]>}
+ * @returns {Promise<NodeIdentifier[]>}
  */
 async function collectAllNodes(storage) {
-    /** @type {NodeKeyString[]} */
+    /** @type {NodeIdentifier[]} */
     const nodes = [];
     for await (const key of storage.inputs.keys()) {
         nodes.push(key);
@@ -185,9 +185,9 @@ async function collectAllNodes(storage) {
  * `topologicalSort` (reads from SchemaStorage) and `topologicalSortFromMap`
  * (operates directly on an already-built map).
  *
- * @param {Map<NodeKeyString, NodeKeyString[]>} inputsMap
+ * @param {Map<NodeIdentifier, NodeIdentifier[]>} inputsMap
  *   A map from each node to the list of its input nodes.
- * @returns {NodeKeyString[]}
+ * @returns {NodeIdentifier[]}
  * @throws {TopologicalSortCycleError} If the graph contains a cycle.
  */
 function topologicalSortFromMap(inputsMap) {
@@ -198,9 +198,9 @@ function topologicalSortFromMap(inputsMap) {
     }
 
     // Build: inDegree map and adjacency list (node → list of dependents).
-    /** @type {Map<NodeKeyString, number>} */
+    /** @type {Map<NodeIdentifier, number>} */
     const inDegree = new Map();
-    /** @type {Map<NodeKeyString, NodeKeyString[]>} */
+    /** @type {Map<NodeIdentifier, NodeIdentifier[]>} */
     const dependents = new Map();
 
     for (const node of allNodes) {
@@ -227,16 +227,16 @@ function topologicalSortFromMap(inputsMap) {
     }
 
     // Initialize priority queue with all nodes having in-degree 0.
-    const heap = new MinHeap(compareNodeKeyStringByNodeKey);
+    const heap = new MinHeap(compareNodeIdentifier);
     for (const [node, degree] of inDegree) {
         if (degree === 0) {
             heap.push(node);
         }
     }
 
-    /** @type {NodeKeyString[]} */
+    /** @type {NodeIdentifier[]} */
     const sorted = [];
-    /** @type {Map<NodeKeyString, number>} */
+    /** @type {Map<NodeIdentifier, number>} */
     const remaining = new Map(inDegree);
 
     while (heap.size > 0) {
@@ -270,10 +270,10 @@ function topologicalSortFromMap(inputsMap) {
  *
  * The ordering satisfies: if node B depends on node A, then A appears before
  * B in the result.  Within the same topological depth, nodes are sorted
- * ascending by their NodeKeyString representation.
+ * ascending by their NodeIdentifier representation.
  *
  * @param {SchemaStorage} storage - Schema storage whose inputs/revdeps graph to sort.
- * @returns {Promise<NodeKeyString[]>}
+ * @returns {Promise<NodeIdentifier[]>}
  * @throws {TopologicalSortCycleError} If the graph contains a cycle.
  */
 async function topologicalSort(storage) {
@@ -283,12 +283,12 @@ async function topologicalSort(storage) {
         return [];
     }
 
-    /** @type {Map<NodeKeyString, NodeKeyString[]>} */
+    /** @type {Map<NodeIdentifier, NodeIdentifier[]>} */
     const inputsMap = new Map();
     for (const node of allNodes) {
         const record = await storage.inputs.get(node);
         const inputs = record
-            ? record.inputs.map(s => stringToNodeKeyString(s))
+            ? record.inputs.map(s => stringToNodeIdentifier(s))
             : [];
         inputsMap.set(node, inputs);
     }

--- a/backend/src/generators/incremental_graph/database/typed_database.js
+++ b/backend/src/generators/incremental_graph/database/typed_database.js
@@ -35,11 +35,11 @@
  * @typedef {object} GenericDatabase
  * @property {(key: TKey) => Promise<TValue | undefined>} get - Retrieve a value
  * @property {(key: TKey, value: TValue) => Promise<void>} put - Store a value
- * @property {(key: TKey, value: *) => Promise<void>} rawPut - Store a value with sync:false (for unification adapters where runtime type is guaranteed by schema invariant)
+ * @property {(key: TKey, value: TValue) => Promise<void>} rawPut - Store a value with sync:false (for unification adapters where runtime type is guaranteed by schema invariant)
  * @property {(key: TKey) => Promise<void>} del - Delete a value
  * @property {(key: TKey) => Promise<void>} rawDel - Delete a value with sync:false (for unification adapters; mirrors rawPut)
  * @property {(key: TKey, value: TValue) => DatabasePutOperation<TValue, TKey>} putOp - Store a value operation
- * @property {(key: TKey, value: *) => DatabasePutOperation<TValue, TKey>} rawPutOp - Store a value operation accepting an untyped value (for unification adapters where runtime type is guaranteed by schema invariant)
+ * @property {(key: TKey, value: TValue) => DatabasePutOperation<TValue, TKey>} rawPutOp - Store a value operation accepting a value guaranteed by the caller's schema invariant
  * @property {(key: TKey) => DatabaseDelOperation<TValue, TKey>} delOp - Delete a value operation
  * @property {() => AsyncIterable<TKey>} keys - Iterate over all keys
  * @property {() => Promise<void>} clear - Clear all entries
@@ -100,7 +100,7 @@ class TypedDatabaseClass {
      * Callers must invoke rootDatabase._rawSync() once after all unification
      * writes are complete to ensure durability.
      * @param {TKey} key - The key to store
-     * @param {*} value - The value to store (must be TValue at runtime)
+     * @param {TValue} value - The value to store
      * @returns {Promise<void>}
      */
     async rawPut(key, value) {
@@ -156,7 +156,7 @@ class TypedDatabaseClass {
      * unknown at the call site.  Keeping this separate from putOp preserves
      * the typed boundary for normal callers.
      * @param {TKey} key - The key to store
-     * @param {*} value - The value to store (must be TValue at runtime)
+     * @param {TValue} value - The value to store
      * @returns {DatabasePutOperation<TValue, TKey>}
      */
     rawPutOp(key, value) {

--- a/backend/src/generators/incremental_graph/database/types.js
+++ b/backend/src/generators/incremental_graph/database/types.js
@@ -420,7 +420,7 @@ function versionToString(Version) {
  */
 
 /**
- * @typedef {ComputedValue | Freshness | InputsRecord | NodeKeyString[] | Counter | TimestampRecord | Version | IdentifiersKeysMap} DatabaseStoredValue
+ * @typedef {ComputedValue | Freshness | InputsRecord | NodeIdentifier[] | Counter | TimestampRecord | Version | IdentifiersKeysMap} DatabaseStoredValue
  */
 
 /**
@@ -447,7 +447,7 @@ function versionToString(Version) {
 
 /**
  * A batch operation for the database.
- * @typedef {DatabasePutOperation<ComputedValue> | DatabasePutOperation<Freshness> | DatabasePutOperation<InputsRecord> | DatabasePutOperation<NodeKeyString[]> | DatabasePutOperation<Counter> | DatabasePutOperation<TimestampRecord> | DatabasePutOperation<Version> | DatabasePutOperation<IdentifiersKeysMap> | DatabaseDelOperation<ComputedValue> | DatabaseDelOperation<Freshness> | DatabaseDelOperation<InputsRecord> | DatabaseDelOperation<NodeKeyString[]> | DatabaseDelOperation<Counter> | DatabaseDelOperation<TimestampRecord> | DatabaseDelOperation<Version> | DatabaseDelOperation<IdentifiersKeysMap>} DatabaseBatchOperation
+ * @typedef {DatabasePutOperation<ComputedValue> | DatabasePutOperation<Freshness> | DatabasePutOperation<InputsRecord> | DatabasePutOperation<NodeIdentifier[]> | DatabasePutOperation<Counter> | DatabasePutOperation<TimestampRecord> | DatabasePutOperation<Version> | DatabasePutOperation<IdentifiersKeysMap> | DatabaseDelOperation<ComputedValue> | DatabaseDelOperation<Freshness> | DatabaseDelOperation<InputsRecord> | DatabaseDelOperation<NodeIdentifier[]> | DatabaseDelOperation<Counter> | DatabaseDelOperation<TimestampRecord> | DatabaseDelOperation<Version> | DatabaseDelOperation<IdentifiersKeysMap>} DatabaseBatchOperation
  */
 
 /**
@@ -522,7 +522,7 @@ function schemaPatternToString(schemaPattern) {
  */
 
 /** 
- * @typedef {NodeKeyString} DatabaseKey
+ * @typedef {NodeIdentifier | 'version' | 'identifiers_keys_map'} DatabaseKey
  */
 
 /**
@@ -543,7 +543,7 @@ function schemaPatternToString(schemaPattern) {
 
 /**
  * @template T
- * @template [K=NodeKeyString]
+ * @template [K=DatabaseKey]
  * @typedef {AbstractSublevel<AbstractSublevel<RootLevelType, SublevelFormat, DatabaseKey, DatabaseStoredValue>, SublevelFormat, K, T>} SimpleSublevel
  */
 

--- a/backend/src/generators/incremental_graph/database/unification/db_to_db.js
+++ b/backend/src/generators/incremental_graph/database/unification/db_to_db.js
@@ -30,9 +30,9 @@
 
 /** @typedef {import('../root_database').SchemaStorage} SchemaStorage */
 /** @typedef {import('./core').UnificationAdapter} UnificationAdapter */
-/** @typedef {import('../types').NodeKeyString} NodeKeyString */
+/** @typedef {import('../types').NodeIdentifier} NodeIdentifier */
 
-const { stringToNodeKeyString } = require('../types');
+const { stringToNodeIdentifier } = require('../types');
 
 /**
  * Read-only view of a single sublevel — the minimum interface required by the
@@ -40,8 +40,8 @@ const { stringToNodeKeyString } = require('../types');
  * InMemorySchemaStorage sublevels satisfy this interface.
  *
  * @typedef {object} ReadableNodeSublevel
- * @property {(key: NodeKeyString) => Promise<unknown>} get
- * @property {() => AsyncIterable<NodeKeyString>} keys
+ * @property {(key: NodeIdentifier) => Promise<unknown>} get
+ * @property {() => AsyncIterable<NodeIdentifier>} keys
  */
 
 /**
@@ -184,12 +184,12 @@ function makeDbToDbAdapter(source, target, options = {}) {
             const { sublevel, nodeKey } = parseCompositeKey(compositeKey);
             if (sublevel === 'global') return await source.global.get(nodeKey);
             switch (sublevel) {
-                case 'values': return await source.values.get(stringToNodeKeyString(nodeKey));
-                case 'freshness': return await source.freshness.get(stringToNodeKeyString(nodeKey));
-                case 'inputs': return await source.inputs.get(stringToNodeKeyString(nodeKey));
-                case 'revdeps': return await source.revdeps.get(stringToNodeKeyString(nodeKey));
-                case 'counters': return await source.counters.get(stringToNodeKeyString(nodeKey));
-                case 'timestamps': return await source.timestamps.get(stringToNodeKeyString(nodeKey));
+                case 'values': return await source.values.get(stringToNodeIdentifier(nodeKey));
+                case 'freshness': return await source.freshness.get(stringToNodeIdentifier(nodeKey));
+                case 'inputs': return await source.inputs.get(stringToNodeIdentifier(nodeKey));
+                case 'revdeps': return await source.revdeps.get(stringToNodeIdentifier(nodeKey));
+                case 'counters': return await source.counters.get(stringToNodeIdentifier(nodeKey));
+                case 'timestamps': return await source.timestamps.get(stringToNodeIdentifier(nodeKey));
                 default: throw new Error(`Unknown sublevel name: ${sublevel}`);
             }
         },
@@ -198,12 +198,12 @@ function makeDbToDbAdapter(source, target, options = {}) {
             const { sublevel, nodeKey } = parseCompositeKey(compositeKey);
             if (sublevel === 'global') return await target.global.get(nodeKey);
             switch (sublevel) {
-                case 'values': return await target.values.get(stringToNodeKeyString(nodeKey));
-                case 'freshness': return await target.freshness.get(stringToNodeKeyString(nodeKey));
-                case 'inputs': return await target.inputs.get(stringToNodeKeyString(nodeKey));
-                case 'revdeps': return await target.revdeps.get(stringToNodeKeyString(nodeKey));
-                case 'counters': return await target.counters.get(stringToNodeKeyString(nodeKey));
-                case 'timestamps': return await target.timestamps.get(stringToNodeKeyString(nodeKey));
+                case 'values': return await target.values.get(stringToNodeIdentifier(nodeKey));
+                case 'freshness': return await target.freshness.get(stringToNodeIdentifier(nodeKey));
+                case 'inputs': return await target.inputs.get(stringToNodeIdentifier(nodeKey));
+                case 'revdeps': return await target.revdeps.get(stringToNodeIdentifier(nodeKey));
+                case 'counters': return await target.counters.get(stringToNodeIdentifier(nodeKey));
+                case 'timestamps': return await target.timestamps.get(stringToNodeIdentifier(nodeKey));
                 default: throw new Error(`Unknown sublevel name: ${sublevel}`);
             }
         },
@@ -219,12 +219,12 @@ function makeDbToDbAdapter(source, target, options = {}) {
                 return;
             }
             switch (sublevel) {
-                case 'values': await target.values.rawPut(stringToNodeKeyString(nodeKey), value); return;
-                case 'freshness': await target.freshness.rawPut(stringToNodeKeyString(nodeKey), value); return;
-                case 'inputs': await target.inputs.rawPut(stringToNodeKeyString(nodeKey), value); return;
-                case 'revdeps': await target.revdeps.rawPut(stringToNodeKeyString(nodeKey), value); return;
-                case 'counters': await target.counters.rawPut(stringToNodeKeyString(nodeKey), value); return;
-                case 'timestamps': await target.timestamps.rawPut(stringToNodeKeyString(nodeKey), value); return;
+                case 'values': await target.values.rawPut(stringToNodeIdentifier(nodeKey), value); return;
+                case 'freshness': await target.freshness.rawPut(stringToNodeIdentifier(nodeKey), value); return;
+                case 'inputs': await target.inputs.rawPut(stringToNodeIdentifier(nodeKey), value); return;
+                case 'revdeps': await target.revdeps.rawPut(stringToNodeIdentifier(nodeKey), value); return;
+                case 'counters': await target.counters.rawPut(stringToNodeIdentifier(nodeKey), value); return;
+                case 'timestamps': await target.timestamps.rawPut(stringToNodeIdentifier(nodeKey), value); return;
                 default: throw new Error(`Unknown sublevel name: ${sublevel}`);
             }
         },
@@ -236,12 +236,12 @@ function makeDbToDbAdapter(source, target, options = {}) {
                 return;
             }
             switch (sublevel) {
-                case 'values': await target.values.rawDel(stringToNodeKeyString(nodeKey)); return;
-                case 'freshness': await target.freshness.rawDel(stringToNodeKeyString(nodeKey)); return;
-                case 'inputs': await target.inputs.rawDel(stringToNodeKeyString(nodeKey)); return;
-                case 'revdeps': await target.revdeps.rawDel(stringToNodeKeyString(nodeKey)); return;
-                case 'counters': await target.counters.rawDel(stringToNodeKeyString(nodeKey)); return;
-                case 'timestamps': await target.timestamps.rawDel(stringToNodeKeyString(nodeKey)); return;
+                case 'values': await target.values.rawDel(stringToNodeIdentifier(nodeKey)); return;
+                case 'freshness': await target.freshness.rawDel(stringToNodeIdentifier(nodeKey)); return;
+                case 'inputs': await target.inputs.rawDel(stringToNodeIdentifier(nodeKey)); return;
+                case 'revdeps': await target.revdeps.rawDel(stringToNodeIdentifier(nodeKey)); return;
+                case 'counters': await target.counters.rawDel(stringToNodeIdentifier(nodeKey)); return;
+                case 'timestamps': await target.timestamps.rawDel(stringToNodeIdentifier(nodeKey)); return;
                 default: throw new Error(`Unknown sublevel name: ${sublevel}`);
             }
         },
@@ -317,7 +317,7 @@ function makeInMemorySchemaStorage() {
             // rawPut() is identical to put() at runtime — the distinction exists
             // only at the JSDoc/type level so unification adapters can call it
             // without the TValue constraint while normal callers keep the typed API.
-            async rawPut(/** @type {string} */ key, /** @type {*} */ value) {
+            async rawPut(/** @type {string} */ key, /** @type {unknown} */ value) {
                 store.set(String(key), value);
             },
             async del(/** @type {string} */ key) {
@@ -332,7 +332,7 @@ function makeInMemorySchemaStorage() {
                 return { type: 'put', sublevelTag: sublevelName, key: String(key), value };
             },
             /** @returns {InMemoryPutOp} */
-            rawPutOp(/** @type {string} */ key, /** @type {*} */ value) {
+            rawPutOp(/** @type {string} */ key, /** @type {unknown} */ value) {
                 return { type: 'put', sublevelTag: sublevelName, key: String(key), value };
             },
             /** @returns {InMemoryDelOp} */
@@ -345,7 +345,7 @@ function makeInMemorySchemaStorage() {
                 // JS default string comparison matches byte order.
                 const sorted = [...store.keys()].sort();
                 for (const k of sorted) {
-                    yield stringToNodeKeyString(k);
+                    yield stringToNodeIdentifier(k);
                 }
             },
             async clear() {

--- a/backend/src/generators/incremental_graph/graph_storage.js
+++ b/backend/src/generators/incremental_graph/graph_storage.js
@@ -5,11 +5,9 @@
  */
 
 const {
-    databaseKeyToNodeIdentifier,
-    nodeIdentifierFromString,
-    nodeIdentifierToDatabaseKey,
     nodeIdentifierToString,
-} = require('./database');
+    stringToNodeIdentifier,
+} = require('./database/types');
 
 /** @typedef {import('./database/root_database').RootDatabase} RootDatabase */
 /** @typedef {import('./database/root_database').SchemaStorage} SchemaStorage */
@@ -24,7 +22,7 @@ const {
 /** @typedef {import('./database/types').Counter} Counter */
 /** @typedef {import('./database/types').TimestampRecord} TimestampRecord */
 /** @typedef {import('./database/types').InputsRecord} InputsRecord */
-/** @typedef {import('./database/node_identifier').NodeIdentifier} NodeIdentifier */
+/** @typedef {import('./database/types').NodeIdentifier} NodeIdentifier */
 
 /**
  * @template TValue
@@ -77,10 +75,10 @@ const {
 /**
  * Convert a nominal identifier to the underlying database key used by typed sublevels.
  * @param {NodeIdentifier} nodeIdentifier
- * @returns {import('./database/types').NodeKeyString}
+ * @returns {NodeIdentifier}
  */
 function toDatabaseKey(nodeIdentifier) {
-    return nodeIdentifierToDatabaseKey(nodeIdentifier);
+    return nodeIdentifier;
 }
 
 /**
@@ -268,7 +266,7 @@ function makeBatchBuilder(schemaStorage) {
                     if (stored === undefined) {
                         return undefined;
                     }
-                    return stored.map(databaseKeyToNodeIdentifier);
+                    return stored;
                 },
             },
             counters: {
@@ -421,7 +419,7 @@ function makeGraphStorage(rootDatabase) {
         if (record === undefined) {
             return null;
         }
-        return record.inputs.map((input) => nodeIdentifierFromString(input));
+        return record.inputs.map((input) => stringToNodeIdentifier(input));
     }
 
     /**
@@ -430,7 +428,7 @@ function makeGraphStorage(rootDatabase) {
     async function listMaterializedNodes() {
         const nodes = [];
         for await (const key of schemaStorage.inputs.keys()) {
-            nodes.push(databaseKeyToNodeIdentifier(key));
+            nodes.push(key);
         }
         return nodes;
     }
@@ -440,42 +438,42 @@ function makeGraphStorage(rootDatabase) {
             async get(key) { return await schemaStorage.values.get(toDatabaseKey(key)); },
             async put(key, value) { await schemaStorage.values.put(toDatabaseKey(key), value); },
             async del(key) { await schemaStorage.values.del(toDatabaseKey(key)); },
-            async *keys() { for await (const key of schemaStorage.values.keys()) { yield databaseKeyToNodeIdentifier(key); } },
+            async *keys() { for await (const key of schemaStorage.values.keys()) { yield key; } },
         }),
         freshness: makeIdentifierDatabase({
             async get(key) { return await schemaStorage.freshness.get(toDatabaseKey(key)); },
             async put(key, value) { await schemaStorage.freshness.put(toDatabaseKey(key), value); },
             async del(key) { await schemaStorage.freshness.del(toDatabaseKey(key)); },
-            async *keys() { for await (const key of schemaStorage.freshness.keys()) { yield databaseKeyToNodeIdentifier(key); } },
+            async *keys() { for await (const key of schemaStorage.freshness.keys()) { yield key; } },
         }),
         inputs: makeIdentifierDatabase({
             async get(key) { return await schemaStorage.inputs.get(toDatabaseKey(key)); },
             async put(key, value) { await schemaStorage.inputs.put(toDatabaseKey(key), value); },
             async del(key) { await schemaStorage.inputs.del(toDatabaseKey(key)); },
-            async *keys() { for await (const key of schemaStorage.inputs.keys()) { yield databaseKeyToNodeIdentifier(key); } },
+            async *keys() { for await (const key of schemaStorage.inputs.keys()) { yield key; } },
         }),
         revdeps: makeIdentifierDatabase({
             async get(key) {
                 const stored = await schemaStorage.revdeps.get(toDatabaseKey(key));
-                return stored === undefined ? undefined : stored.map(databaseKeyToNodeIdentifier);
+                return stored;
             },
             async put(key, value) {
                 await schemaStorage.revdeps.put(toDatabaseKey(key), value.map(toDatabaseKey));
             },
             async del(key) { await schemaStorage.revdeps.del(toDatabaseKey(key)); },
-            async *keys() { for await (const key of schemaStorage.revdeps.keys()) { yield databaseKeyToNodeIdentifier(key); } },
+            async *keys() { for await (const key of schemaStorage.revdeps.keys()) { yield key; } },
         }),
         counters: makeIdentifierDatabase({
             async get(key) { return await schemaStorage.counters.get(toDatabaseKey(key)); },
             async put(key, value) { await schemaStorage.counters.put(toDatabaseKey(key), value); },
             async del(key) { await schemaStorage.counters.del(toDatabaseKey(key)); },
-            async *keys() { for await (const key of schemaStorage.counters.keys()) { yield databaseKeyToNodeIdentifier(key); } },
+            async *keys() { for await (const key of schemaStorage.counters.keys()) { yield key; } },
         }),
         timestamps: makeIdentifierDatabase({
             async get(key) { return await schemaStorage.timestamps.get(toDatabaseKey(key)); },
             async put(key, value) { await schemaStorage.timestamps.put(toDatabaseKey(key), value); },
             async del(key) { await schemaStorage.timestamps.del(toDatabaseKey(key)); },
-            async *keys() { for await (const key of schemaStorage.timestamps.keys()) { yield databaseKeyToNodeIdentifier(key); } },
+            async *keys() { for await (const key of schemaStorage.timestamps.keys()) { yield key; } },
         }),
         withBatch,
         ensureMaterialized,

--- a/backend/src/generators/incremental_graph/identifier_resolver.js
+++ b/backend/src/generators/incremental_graph/identifier_resolver.js
@@ -20,7 +20,7 @@ const {
 /** @typedef {import('./database/root_database').RootDatabase} RootDatabase */
 /** @typedef {import('./database/root_database').GlobalVersionDatabase} GlobalVersionDatabase */
 /** @typedef {import('./database/types').NodeKeyString} NodeKeyString */
-/** @typedef {import('./database/node_identifier').NodeIdentifier} NodeIdentifier */
+/** @typedef {import('./database/types').NodeIdentifier} NodeIdentifier */
 /** @typedef {import('./graph_storage').BatchBuilder} BatchBuilder */
 /** @typedef {import('./database/identifier_lookup').IdentifierLookup} IdentifierLookup */
 
@@ -33,9 +33,9 @@ const fallbackIdentifierLookups = new WeakMap();
  * translated at most once during the operation.
  * @typedef {object} IdentifierResolver
  * @property {IdentifierLookup} lookup - Mutable lookup snapshot for the current operation.
- * @property {(nodeKey: NodeKeyString) => NodeIdentifier | undefined} lookupNodeIdentifier - Read an existing identifier without allocating a new one.
- * @property {(nodeKey: NodeKeyString) => NodeIdentifier} getOrAllocateNodeIdentifier - Read an existing identifier or allocate one for the current operation.
- * @property {(nodeIdentifier: NodeIdentifier) => NodeKeyString} requireNodeKey - Convert an identifier back to its semantic node key.
+ * @property {(nodeKey: NodeIdentifier) => NodeIdentifier | undefined} lookupNodeIdentifier - Read an existing identifier without allocating a new one.
+ * @property {(nodeKey: NodeIdentifier) => NodeIdentifier} getOrAllocateNodeIdentifier - Read an existing identifier or allocate one for the current operation.
+ * @property {(nodeIdentifier: NodeIdentifier) => NodeIdentifier} requireNodeKey - Convert an identifier back to its semantic node key.
  * @property {(batch: BatchBuilder, globalDatabase?: GlobalVersionDatabase) => void} queueLookupPersistence - Append the lookup write to the current batch when allocations happened.
  * @property {(rootDatabase: RootDatabase) => void} commitPersistedLookup - Publish the committed lookup snapshot back into the open RootDatabase.
  */
@@ -65,7 +65,7 @@ function getActiveLookup(rootDatabase) {
  * Compatibility test doubles fall back to deterministic identifiers derived from the key.
  * @param {RootDatabase} rootDatabase
  * @param {IdentifierLookup} lookup
- * @param {NodeKeyString} nodeKey
+ * @param {NodeIdentifier} nodeKey
  * @returns {NodeIdentifier}
  */
 function allocateIdentifier(rootDatabase, lookup, nodeKey) {
@@ -86,12 +86,12 @@ function makeIdentifierResolver(rootDatabase) {
     const lookup = cloneIdentifierLookup(getActiveLookup(rootDatabase));
     /** @type {Map<string, NodeIdentifier>} */
     const identifiersByNodeKey = new Map();
-    /** @type {Map<string, NodeKeyString>} */
+    /** @type {Map<string, NodeIdentifier>} */
     const nodeKeysByIdentifier = new Map();
     let hasPendingLookupWrite = false;
 
     /**
-     * @param {NodeKeyString} nodeKey
+     * @param {NodeIdentifier} nodeKey
      * @param {NodeIdentifier} nodeIdentifier
      * @returns {NodeIdentifier}
      */
@@ -102,7 +102,7 @@ function makeIdentifierResolver(rootDatabase) {
     }
 
     /**
-     * @param {NodeKeyString} nodeKey
+     * @param {NodeIdentifier} nodeKey
      * @returns {NodeIdentifier | undefined}
      */
     function lookupNodeIdentifier(nodeKey) {
@@ -118,7 +118,7 @@ function makeIdentifierResolver(rootDatabase) {
     }
 
     /**
-     * @param {NodeKeyString} nodeKey
+     * @param {NodeIdentifier} nodeKey
      * @returns {NodeIdentifier}
      */
     function getOrAllocateNodeIdentifier(nodeKey) {
@@ -135,7 +135,7 @@ function makeIdentifierResolver(rootDatabase) {
 
     /**
      * @param {NodeIdentifier} nodeIdentifier
-     * @returns {NodeKeyString}
+     * @returns {NodeIdentifier}
      */
     function requireNodeKey(nodeIdentifier) {
         const identifierString = nodeIdentifierToString(nodeIdentifier);

--- a/backend/src/generators/incremental_graph/inspection.js
+++ b/backend/src/generators/incremental_graph/inspection.js
@@ -19,6 +19,7 @@ const {
     stringToNodeName,
     versionToString,
 } = require("./database");
+const { stringToNodeIdentifier, stringToNodeKeyString } = require("./database/types");
 const { makeInvalidNodeError, makeMissingTimestampError } = require("./errors");
 const { deserializeNodeKey, serializeNodeKey } = require("./database");
 const { fromISOString } = require("../../datetime");
@@ -48,7 +49,7 @@ async function internalGetFreshness(
         const nodeKey = { head: nodeName, args: bindings };
         const concreteKey = serializeNodeKey(nodeKey);
         const identifierResolver = incrementalGraph.makeIdentifierResolver();
-        const nodeIdentifier = identifierResolver.lookupNodeIdentifier(concreteKey);
+        const nodeIdentifier = identifierResolver.lookupNodeIdentifier(stringToNodeIdentifier(String(concreteKey)));
         if (nodeIdentifier === undefined) {
             return "missing";
         }
@@ -79,7 +80,7 @@ async function internalGetValue(incrementalGraph, head, bindings = []) {
         const nodeKey = { head: nodeName, args: bindings };
         const concreteKey = serializeNodeKey(nodeKey);
         const identifierResolver = incrementalGraph.makeIdentifierResolver();
-        const nodeIdentifier = identifierResolver.lookupNodeIdentifier(concreteKey);
+        const nodeIdentifier = identifierResolver.lookupNodeIdentifier(stringToNodeIdentifier(String(concreteKey)));
         if (nodeIdentifier === undefined) {
             return undefined;
         }
@@ -115,7 +116,7 @@ async function internalListMaterializedNodes(incrementalGraph) {
         const materializedNodes = await incrementalGraph.storage.listMaterializedNodes();
         return materializedNodes.map((nodeIdentifier) => {
             const nodeKey = identifierResolver.requireNodeKey(nodeIdentifier);
-            const parsed = deserializeNodeKey(nodeKey);
+            const parsed = deserializeNodeKey(stringToNodeKeyString(String(nodeKey)));
             return [nodeNameToString(parsed.head), parsed.args];
         });
     });
@@ -153,7 +154,7 @@ async function internalGetCreationTime(
         const nodeKey = { head: nodeNameTyped, args: bindings };
         const concreteKey = serializeNodeKey(nodeKey);
         const identifierResolver = incrementalGraph.makeIdentifierResolver();
-        const nodeIdentifier = identifierResolver.lookupNodeIdentifier(concreteKey);
+        const nodeIdentifier = identifierResolver.lookupNodeIdentifier(stringToNodeIdentifier(String(concreteKey)));
         if (nodeIdentifier === undefined) {
             throw makeMissingTimestampError(concreteKey);
         }
@@ -189,7 +190,7 @@ async function internalGetModificationTime(
         const nodeKey = { head: nodeNameTyped, args: bindings };
         const concreteKey = serializeNodeKey(nodeKey);
         const identifierResolver = incrementalGraph.makeIdentifierResolver();
-        const nodeIdentifier = identifierResolver.lookupNodeIdentifier(concreteKey);
+        const nodeIdentifier = identifierResolver.lookupNodeIdentifier(stringToNodeIdentifier(String(concreteKey)));
         if (nodeIdentifier === undefined) {
             throw makeMissingTimestampError(concreteKey);
         }

--- a/backend/src/generators/incremental_graph/invalidate.js
+++ b/backend/src/generators/incremental_graph/invalidate.js
@@ -4,7 +4,7 @@
 
 /** @typedef {import('./graph_storage').BatchBuilder} BatchBuilder */
 /** @typedef {import('./types').ConstValue} ConstValue */
-/** @typedef {import('./types').NodeKeyString} NodeKeyString */
+/** @typedef {import('./types').NodeIdentifier} NodeIdentifier */
 /** @typedef {import('./identifier_resolver').IdentifierResolver} IdentifierResolver */
 /**
  * @typedef {object} IncrementalGraphInvalidateAccess
@@ -14,7 +14,7 @@
  * @property {() => IdentifierResolver} makeIdentifierResolver
  * @property {(identifierResolver: IdentifierResolver, procedure: (batch: BatchBuilder) => Promise<void>) => Promise<void>} withIdentifierBatch
  * @property {(nodeDefinition: import('./types').ConcreteNode, identifierResolver: IdentifierResolver) => import('./types').ResolvedConcreteNode} resolveConcreteNode
- * @property {(nodeKeyStr: NodeKeyString, compiledNode: import('./types').CompiledNode, bindings: Array<ConstValue>) => import('./types').ConcreteNode} getOrCreateConcreteNode
+ * @property {(nodeKeyStr: NodeIdentifier, compiledNode: import('./types').CompiledNode, bindings: Array<ConstValue>) => import('./types').ConcreteNode} getOrCreateConcreteNode
  */
 
 const { stringToNodeName } = require("./database");
@@ -26,7 +26,7 @@ const { checkArity, ensureNodeNameIsHead } = require("./shared");
 
 /**
  * @param {IncrementalGraphInvalidateAccess} incrementalGraph
- * @param {import('./database/node_identifier').NodeIdentifier} changedIdentifier
+ * @param {import('./database/types').NodeIdentifier} changedIdentifier
  * @param {BatchBuilder} batch
  * @param {Set<string>} [nodesBecomingOutdated]
  * @returns {Promise<void>}

--- a/backend/src/generators/incremental_graph/migration.js
+++ b/backend/src/generators/incremental_graph/migration.js
@@ -3,6 +3,7 @@
 
 const { stringToNodeName } = require("./database");
 const { deserializeNodeKey } = require("./database");
+const { stringToNodeKeyString } = require("./database/types");
 
 /**
  * @typedef {import('../interface/types').GeneratorsCapabilities} GeneratorsCapabilities
@@ -13,17 +14,17 @@ const { deserializeNodeKey } = require("./database");
  */
 
 /**
- * @typedef {import('./errors').NodeKeyString} NodeKeyString
+ * @typedef {import('./database/types').NodeIdentifier} NodeIdentifier
  */
 
 /**
- * @param {NodeKeyString} nodeKey
+ * @param {NodeIdentifier} nodeKey
  * @returns {import('./types').NodeName}
  */
 function nodeHeadForMigrationNode(nodeKey) {
     const nodeKeyString = String(nodeKey);
     if (nodeKeyString.startsWith("{")) {
-        return deserializeNodeKey(nodeKey).head;
+        return deserializeNodeKey(stringToNodeKeyString(nodeKeyString)).head;
     }
     return stringToNodeName(nodeKeyString);
 }

--- a/backend/src/generators/incremental_graph/migration_runner.js
+++ b/backend/src/generators/incremental_graph/migration_runner.js
@@ -22,8 +22,8 @@ const {
     serializeNodeKey,
     serializeIdentifierLookup,
     stringToNodeName,
-    stringToNodeKeyString,
 } = require("./database");
+const { stringToNodeIdentifier } = require("./database/types");
 const { withExclusiveMode } = require("./lock");
 const { makeMigrationStorage } = require("./migration_storage");
 const { checkpointMigration } = require("./database");
@@ -31,7 +31,7 @@ const { unifyStores, makeDbToDbAdapter } = require("./database");
 
 /** @typedef {import('./database/root_database').RootDatabase} RootDatabase */
 /** @typedef {import('./database/root_database').SchemaStorage} SchemaStorage */
-/** @typedef {import('./database/types').NodeKeyString} NodeKeyString */
+/** @typedef {import('./database/types').NodeIdentifier} NodeIdentifier */
 /** @typedef {import('./database/types').ComputedValue} ComputedValue */
 /** @typedef {import('./database/types').Counter} Counter */
 /** @typedef {import('./database/types').Freshness} Freshness */
@@ -86,10 +86,10 @@ const { unifyStores, makeDbToDbAdapter } = require("./database");
 /**
  * Collect all materialized node keys from a schema storage.
  * @param {SchemaStorage} storage
- * @returns {Promise<NodeKeyString[]>}
+ * @returns {Promise<NodeIdentifier[]>}
  */
 async function loadMaterializedNodes(storage) {
-    /** @type {NodeKeyString[]} */
+    /** @type {NodeIdentifier[]} */
     const nodes = [];
     for await (const key of storage.inputs.keys()) {
         nodes.push(key);
@@ -98,25 +98,25 @@ async function loadMaterializedNodes(storage) {
 }
 
 /**
- * @param {NodeKeyString} nodeKey
- * @returns {NodeKeyString}
+ * @param {NodeIdentifier} nodeKey
+ * @returns {NodeIdentifier}
  */
 function canonicalizeMigrationNodeKey(nodeKey) {
     const nodeKeyString = String(nodeKey);
     if (nodeKeyString.startsWith("{")) {
-        return stringToNodeKeyString(nodeKeyString);
+        return stringToNodeIdentifier(nodeKeyString);
     }
     return serializeNodeKey({ head: stringToNodeName(nodeKeyString), args: [] });
 }
 
 /**
  * @param {SchemaStorage} prevStorage
- * @param {NodeKeyString[]} materializedNodes
+ * @param {NodeIdentifier[]} materializedNodes
  * @returns {Promise<{
- *   keyToSourceKey: (nodeKey: NodeKeyString) => NodeKeyString,
- *   keyToOutputKey: (nodeKey: NodeKeyString) => NodeKeyString,
- *   outputKeyToDecisionKey: (outputKey: NodeKeyString) => NodeKeyString,
- *   outputEntries: Array<[import('./database/node_identifier').NodeIdentifier, NodeKeyString]>,
+ *   keyToSourceKey: (nodeKey: NodeIdentifier) => NodeIdentifier,
+ *   keyToOutputKey: (nodeKey: NodeIdentifier) => NodeIdentifier,
+ *   outputKeyToDecisionKey: (outputKey: NodeIdentifier) => NodeIdentifier,
+ *   outputEntries: Array<[import('./database/types').NodeIdentifier, NodeIdentifier]>,
  * }>}
  */
 async function makeMigrationKeyPlan(prevStorage, materializedNodes) {
@@ -125,12 +125,12 @@ async function makeMigrationKeyPlan(prevStorage, materializedNodes) {
         const lookup = makeIdentifierLookup(persistedEntries);
         return {
             keyToSourceKey(nodeKey) {
-                return stringToNodeKeyString(
+                return stringToNodeIdentifier(
                     nodeIdentifierToString(requireNodeIdentifierForKey(lookup, nodeKey))
                 );
             },
             keyToOutputKey(nodeKey) {
-                return stringToNodeKeyString(
+                return stringToNodeIdentifier(
                     nodeIdentifierToString(requireNodeIdentifierForKey(lookup, nodeKey))
                 );
             },
@@ -144,14 +144,14 @@ async function makeMigrationKeyPlan(prevStorage, materializedNodes) {
         };
     }
 
-    /** @type {Array<[import('./database/node_identifier').NodeIdentifier, NodeKeyString]>} */
+    /** @type {Array<[import('./database/types').NodeIdentifier, NodeIdentifier]>} */
     const outputEntries = [];
-    /** @type {Map<string, NodeKeyString>} */
+    /** @type {Map<string, NodeIdentifier>} */
     const decisionKeyByOutputKey = new Map();
     for (const nodeKey of materializedNodes) {
         const canonicalKey = canonicalizeMigrationNodeKey(nodeKey);
         const nodeIdentifier = deterministicNodeIdentifierFromNodeKey(canonicalKey);
-        const outputKey = stringToNodeKeyString(nodeIdentifierToString(nodeIdentifier));
+        const outputKey = stringToNodeIdentifier(nodeIdentifierToString(nodeIdentifier));
         outputEntries.push([nodeIdentifier, canonicalKey]);
         decisionKeyByOutputKey.set(String(outputKey), nodeKey);
     }
@@ -161,12 +161,12 @@ async function makeMigrationKeyPlan(prevStorage, materializedNodes) {
         },
         keyToOutputKey(nodeKey) {
             const canonicalKey = canonicalizeMigrationNodeKey(nodeKey);
-            return stringToNodeKeyString(
+            return stringToNodeIdentifier(
                 nodeIdentifierToString(deterministicNodeIdentifierFromNodeKey(canonicalKey))
             );
         },
         outputKeyToDecisionKey(outputKey) {
-            return decisionKeyByOutputKey.get(String(outputKey)) ?? stringToNodeKeyString(String(outputKey));
+            return decisionKeyByOutputKey.get(String(outputKey)) ?? stringToNodeIdentifier(String(outputKey));
         },
         outputEntries: serializeIdentifierLookup(makeIdentifierLookup(outputEntries)),
     };
@@ -177,17 +177,17 @@ async function makeMigrationKeyPlan(prevStorage, materializedNodes) {
  * node keys even when the persisted replica is already identifier-native.
  * @param {SchemaStorage} prevStorage
  * @param {{
- *   keyToSourceKey: (nodeKey: NodeKeyString) => NodeKeyString,
- *   keyToOutputKey: (nodeKey: NodeKeyString) => NodeKeyString,
- *   outputKeyToDecisionKey: (outputKey: NodeKeyString) => NodeKeyString,
+ *   keyToSourceKey: (nodeKey: NodeIdentifier) => NodeIdentifier,
+ *   keyToOutputKey: (nodeKey: NodeIdentifier) => NodeIdentifier,
+ *   outputKeyToDecisionKey: (outputKey: NodeIdentifier) => NodeIdentifier,
  * }} keyPlan
  * @returns {ReadableMigrationStorage}
  */
 function makeMigrationDecisionStorage(prevStorage, keyPlan) {
     /**
      * @template TValue
-     * @param {{ get(key: NodeKeyString): Promise<TValue | undefined> }} database
-     * @returns {{ get(key: NodeKeyString): Promise<TValue | undefined> }}
+     * @param {{ get(key: NodeIdentifier): Promise<TValue | undefined> }} database
+     * @returns {{ get(key: NodeIdentifier): Promise<TValue | undefined> }}
      */
     function makeSimpleDatabase(database) {
         return {
@@ -208,7 +208,7 @@ function makeMigrationDecisionStorage(prevStorage, keyPlan) {
                 }
                 return {
                     inputs: record.inputs.map((input) =>
-                        String(keyPlan.outputKeyToDecisionKey(stringToNodeKeyString(input)))
+                        String(keyPlan.outputKeyToDecisionKey(stringToNodeIdentifier(input)))
                     ),
                     inputCounters: record.inputCounters,
                 };
@@ -240,12 +240,12 @@ function makeMigrationDecisionStorage(prevStorage, keyPlan) {
  * at a time).
  *
  * @param {ReadableMigrationStorage} prevStorage
- * @param {Map<NodeKeyString, Decision>} decisions
- * @param {{ keyToOutputKey: (nodeKey: NodeKeyString) => NodeKeyString }} keyPlan
- * @returns {Promise<Map<NodeKeyString, NodeKeyString[]>>}
+ * @param {Map<NodeIdentifier, Decision>} decisions
+ * @param {{ keyToOutputKey: (nodeKey: NodeIdentifier) => NodeIdentifier }} keyPlan
+ * @returns {Promise<Map<NodeIdentifier, NodeIdentifier[]>>}
  */
 async function buildDesiredRevdeps(prevStorage, decisions, keyPlan) {
-    /** @type {Map<string, Set<NodeKeyString>>} */
+    /** @type {Map<string, Set<NodeIdentifier>>} */
     const revdepSets = new Map();
 
     for (const [nodeKey, decision] of decisions) {
@@ -255,7 +255,7 @@ async function buildDesiredRevdeps(prevStorage, decisions, keyPlan) {
         if (!inputsRecord) continue;
 
         for (const inputStr of inputsRecord.inputs) {
-            const inputKey = stringToNodeKeyString(inputStr);
+            const inputKey = stringToNodeIdentifier(inputStr);
             const inputDecision = decisions.get(inputKey);
             if (inputDecision && inputDecision.kind === "delete") continue;
             const outputInputKey = keyPlan.keyToOutputKey(inputKey);
@@ -269,10 +269,10 @@ async function buildDesiredRevdeps(prevStorage, decisions, keyPlan) {
         }
     }
 
-    /** @type {Map<NodeKeyString, NodeKeyString[]>} */
+    /** @type {Map<NodeIdentifier, NodeIdentifier[]>} */
     const result = new Map();
     for (const [inputStr, depSet] of revdepSets) {
-        const inputKey = stringToNodeKeyString(inputStr);
+        const inputKey = stringToNodeIdentifier(inputStr);
         result.set(
             inputKey,
             [...depSet].sort((left, right) => String(left).localeCompare(String(right)))
@@ -293,13 +293,13 @@ async function buildDesiredRevdeps(prevStorage, decisions, keyPlan) {
  * trade-off that avoids per-value memory retention.
  *
  * @param {ReadableMigrationStorage} prevStorage
- * @param {Map<NodeKeyString, Decision>} decisions
- * @param {Map<NodeKeyString, NodeKeyString[]>} desiredRevdeps
+ * @param {Map<NodeIdentifier, Decision>} decisions
+ * @param {Map<NodeIdentifier, NodeIdentifier[]>} desiredRevdeps
  * @param {import('./database/types').Version} newVersion
  * @param {{
- *   keyToOutputKey: (nodeKey: NodeKeyString) => NodeKeyString,
- *   outputKeyToDecisionKey: (outputKey: NodeKeyString) => NodeKeyString,
- *   outputEntries: Array<[import('./database/node_identifier').NodeIdentifier, NodeKeyString]>,
+ *   keyToOutputKey: (nodeKey: NodeIdentifier) => NodeIdentifier,
+ *   outputKeyToDecisionKey: (outputKey: NodeIdentifier) => NodeIdentifier,
+ *   outputEntries: Array<[import('./database/types').NodeIdentifier, NodeIdentifier]>,
  * }} keyPlan
  * @returns {ReadableSchemaStorage}
  */
@@ -329,7 +329,7 @@ function makeLazyMigrationSource(prevStorage, decisions, desiredRevdeps, newVers
                     // 'invalidate': no value in values sublevel
                 }
             },
-            async get(/** @type {NodeKeyString} */ key) {
+            async get(/** @type {NodeIdentifier} */ key) {
                 const decisionKey = keyPlan.outputKeyToDecisionKey(key);
                 const decision = decisions.get(decisionKey);
                 if (!decision) return undefined;
@@ -353,7 +353,7 @@ function makeLazyMigrationSource(prevStorage, decisions, desiredRevdeps, newVers
                     }
                 }
             },
-            async get(/** @type {NodeKeyString} */ key) {
+            async get(/** @type {NodeIdentifier} */ key) {
                 const decisionKey = keyPlan.outputKeyToDecisionKey(key);
                 const decision = decisions.get(decisionKey);
                 if (!decision) return undefined;
@@ -376,7 +376,7 @@ function makeLazyMigrationSource(prevStorage, decisions, desiredRevdeps, newVers
                     }
                 }
             },
-            async get(/** @type {NodeKeyString} */ key) {
+            async get(/** @type {NodeIdentifier} */ key) {
                 const decisionKey = keyPlan.outputKeyToDecisionKey(key);
                 const decision = decisions.get(decisionKey);
                 if (!decision || decision.kind === "delete") return undefined;
@@ -387,7 +387,7 @@ function makeLazyMigrationSource(prevStorage, decisions, desiredRevdeps, newVers
                 }
                 return {
                     inputs: record.inputs.map((input) =>
-                        String(keyPlan.keyToOutputKey(stringToNodeKeyString(input)))
+                        String(keyPlan.keyToOutputKey(stringToNodeIdentifier(input)))
                     ),
                     inputCounters: record.inputCounters,
                 };
@@ -399,7 +399,7 @@ function makeLazyMigrationSource(prevStorage, decisions, desiredRevdeps, newVers
                     yield key;
                 }
             },
-            async get(/** @type {NodeKeyString} */ key) {
+            async get(/** @type {NodeIdentifier} */ key) {
                 return desiredRevdeps.get(key);
             },
         },
@@ -417,7 +417,7 @@ function makeLazyMigrationSource(prevStorage, decisions, desiredRevdeps, newVers
                     }
                 }
             },
-            async get(/** @type {NodeKeyString} */ key) {
+            async get(/** @type {NodeIdentifier} */ key) {
                 const decisionKey = keyPlan.outputKeyToDecisionKey(key);
                 const decision = decisions.get(decisionKey);
                 if (!decision || decision.kind === "delete") return undefined;
@@ -439,7 +439,7 @@ function makeLazyMigrationSource(prevStorage, decisions, desiredRevdeps, newVers
                     if (ts !== undefined) yield keyPlan.keyToOutputKey(nodeKey);
                 }
             },
-            async get(/** @type {NodeKeyString} */ key) {
+            async get(/** @type {NodeIdentifier} */ key) {
                 const decisionKey = keyPlan.outputKeyToDecisionKey(key);
                 const decision = decisions.get(decisionKey);
                 if (!decision || decision.kind === "delete" || decision.kind === "create") return undefined;

--- a/backend/src/generators/incremental_graph/migration_storage.js
+++ b/backend/src/generators/incremental_graph/migration_storage.js
@@ -3,7 +3,7 @@
  * Provides a strict decision-based API for migrating previous-version graph data.
  */
 
-const { stringToNodeKeyString } = require("./database");
+const { stringToNodeIdentifier, stringToNodeKeyString } = require("./database/types");
 const { deserializeNodeKey } = require("./database");
 const { stringToNodeName } = require("./database");
 const {
@@ -19,7 +19,7 @@ const {
 } = require("./migration_errors");
 
 /** @typedef {import('./database/types').ComputedValue} ComputedValue */
-/** @typedef {import('./database/types').NodeKeyString} NodeKeyString */
+/** @typedef {import('./database/types').NodeIdentifier} NodeIdentifier */
 /** @typedef {import('./types').CompiledNode} CompiledNode */
 /** @typedef {import('./types').NodeName} NodeName */
 
@@ -27,40 +27,40 @@ const {
  * Read-only database view used by migration decision logic.
  * Migration callbacks never write directly to the previous replica.
  * @typedef {object} ReadableMigrationStorage
- * @property {{ get(nodeKey: NodeKeyString): Promise<ComputedValue | undefined> }} values
- * @property {{ get(nodeKey: NodeKeyString): Promise<import('./database/types').Freshness | undefined> }} freshness
- * @property {{ get(nodeKey: NodeKeyString): Promise<import('./database/root_database').InputsRecord | undefined> }} inputs
- * @property {{ get(nodeKey: NodeKeyString): Promise<NodeKeyString[] | undefined> }} revdeps
- * @property {{ get(nodeKey: NodeKeyString): Promise<number | undefined> }} counters
- * @property {{ get(nodeKey: NodeKeyString): Promise<import('./database/types').TimestampRecord | undefined> }} timestamps
+ * @property {{ get(nodeKey: NodeIdentifier): Promise<ComputedValue | undefined> }} values
+ * @property {{ get(nodeKey: NodeIdentifier): Promise<import('./database/types').Freshness | undefined> }} freshness
+ * @property {{ get(nodeKey: NodeIdentifier): Promise<import('./database/root_database').InputsRecord | undefined> }} inputs
+ * @property {{ get(nodeKey: NodeIdentifier): Promise<NodeIdentifier[] | undefined> }} revdeps
+ * @property {{ get(nodeKey: NodeIdentifier): Promise<number | undefined> }} counters
+ * @property {{ get(nodeKey: NodeIdentifier): Promise<import('./database/types').TimestampRecord | undefined> }} timestamps
  * @property {{ get(key: string): Promise<unknown> }} [global]
- * @property {(operations: Array<*>) => Promise<void>} [batch]
+ * @property {(operations: import('./database/types').DatabaseBatchOperation[]) => Promise<void>} [batch]
  */
 
 /**
  * @typedef {{ kind: 'keep' }} KeepDecision
- * @typedef {{ kind: 'override', value: (nodeKey: NodeKeyString) => Promise<ComputedValue> }} OverrideDecision
+ * @typedef {{ kind: 'override', value: (nodeKey: NodeIdentifier) => Promise<ComputedValue> }} OverrideDecision
  * @typedef {{ kind: 'invalidate' }} InvalidateDecision
  * @typedef {{ kind: 'delete' }} DeleteDecision
- * @typedef {{ kind: 'create', value: (nodeKey: NodeKeyString) => Promise<ComputedValue> }} CreateDecision
+ * @typedef {{ kind: 'create', value: (nodeKey: NodeIdentifier) => Promise<ComputedValue> }} CreateDecision
  * @typedef {KeepDecision | OverrideDecision | InvalidateDecision | DeleteDecision | CreateDecision} Decision
  */
 
 /**
- * @param {NodeKeyString} nodeKey
- * @returns {{ head: NodeName, args: Array<*> }}
+ * @param {NodeIdentifier} nodeKey
+ * @returns {{ head: NodeName, args: Array<unknown> }}
  */
 function parseMigrationNodeKey(nodeKey) {
     const nodeKeyString = String(nodeKey);
     if (nodeKeyString.startsWith("{")) {
-        return deserializeNodeKey(nodeKey);
+        return deserializeNodeKey(stringToNodeKeyString(nodeKeyString));
     }
     return { head: stringToNodeName(nodeKeyString), args: [] };
 }
 
 /**
  * Checks whether a node is compatible with the new schema.
- * @param {NodeKeyString} nodeKey
+ * @param {NodeIdentifier} nodeKey
  * @param {Map<NodeName, CompiledNode>} newHeadIndex
  * @returns {void}
  */
@@ -85,23 +85,23 @@ function checkSchemaCompatibility(nodeKey, newHeadIndex) {
 /**
  * Reads the inputs list for a node from the previous storage.
  * Throws MissingDependencyMetadataError if the record is absent or corrupted.
- * @param {NodeKeyString} nodeKey
+ * @param {NodeIdentifier} nodeKey
  * @param {ReadableMigrationStorage} prevStorage
- * @returns {Promise<NodeKeyString[]>}
+ * @returns {Promise<NodeIdentifier[]>}
  */
 async function readInputsRecord(nodeKey, prevStorage) {
     const record = await prevStorage.inputs.get(nodeKey);
     if (!record) {
         throw makeMissingDependencyMetadataError(nodeKey);
     }
-    return record.inputs.map(stringToNodeKeyString);
+    return record.inputs.map(stringToNodeIdentifier);
 }
 
 /**
  * Reads the dependents list for a node from the previous storage.
- * @param {NodeKeyString} nodeKey
+ * @param {NodeIdentifier} nodeKey
  * @param {ReadableMigrationStorage} prevStorage
- * @returns {Promise<NodeKeyString[]>}
+ * @returns {Promise<NodeIdentifier[]>}
  */
 async function readDependents(nodeKey, prevStorage) {
     const dependents = await prevStorage.revdeps.get(nodeKey);
@@ -128,21 +128,21 @@ class MigrationStorageClass {
     /**
      * The set of all nodes materialized in the previous version (scope S).
      * @private
-     * @type {Set<NodeKeyString>}
+     * @type {Set<NodeIdentifier>}
      */
     materializedNodes;
 
     /**
      * Accumulated per-node decisions.
      * @private
-     * @type {Map<NodeKeyString, Decision>}
+     * @type {Map<NodeIdentifier, Decision>}
      */
     decisions;
 
     /**
      * @param {ReadableMigrationStorage} prevStorage
      * @param {Map<NodeName, CompiledNode>} newHeadIndex
-     * @param {NodeKeyString[]} materializedNodes
+     * @param {NodeIdentifier[]} materializedNodes
      */
     constructor(prevStorage, newHeadIndex, materializedNodes) {
         this.prevStorage = prevStorage;
@@ -155,7 +155,7 @@ class MigrationStorageClass {
      * Read the previous-version value for a node.
      * The return type is not ComputedValue because the type may have changed in the new schema,
      * and it's up to the migration callback to handle it.
-     * @param {NodeKeyString} nodeKey
+     * @param {NodeIdentifier} nodeKey
      * @returns {Promise<{}>}
      */
     async get(nodeKey) {
@@ -171,7 +171,7 @@ class MigrationStorageClass {
 
     /**
      * Check whether a node is in the previous-version materialized set S.
-     * @param {NodeKeyString} nodeKey
+     * @param {NodeIdentifier} nodeKey
      * @returns {Promise<boolean>}
      */
     async has(nodeKey) {
@@ -181,7 +181,7 @@ class MigrationStorageClass {
     /**
      * Assign a KEEP decision to a node.
      * Idempotent if the same decision already exists.
-     * @param {NodeKeyString} nodeKey
+     * @param {NodeIdentifier} nodeKey
      * @returns {Promise<void>}
      */
     async keep(nodeKey) {
@@ -199,8 +199,8 @@ class MigrationStorageClass {
 
     /**
      * Assign an OVERRIDE decision to a node with a new value.
-     * @param {NodeKeyString} nodeKey
-     * @param {(nodeKey: NodeKeyString) => Promise<ComputedValue>} value
+     * @param {NodeIdentifier} nodeKey
+     * @param {(nodeKey: NodeIdentifier) => Promise<ComputedValue>} value
      * @returns {Promise<void>}
      */
     async override(nodeKey, value) {
@@ -222,7 +222,7 @@ class MigrationStorageClass {
     /**
      * Assign an INVALIDATE decision to a node.
      * Idempotent if the same decision already exists.
-     * @param {NodeKeyString} nodeKey
+     * @param {NodeIdentifier} nodeKey
      * @returns {Promise<void>}
      */
     async invalidate(nodeKey) {
@@ -243,7 +243,7 @@ class MigrationStorageClass {
      * Assign a DELETE decision to a node.
      * Idempotent if the same decision already exists.
      * DELETE propagation to dependents is deferred to finalize().
-     * @param {NodeKeyString} nodeKey
+     * @param {NodeIdentifier} nodeKey
      * @returns {Promise<void>}
      */
     async delete(nodeKey) {
@@ -263,8 +263,8 @@ class MigrationStorageClass {
      * The node must NOT exist in the previous version (use override() instead).
      * The node must exist in the new schema.
      * The new node is created as up-to-date with the provided value and empty inputs.
-     * @param {NodeKeyString} nodeKey
-     * @param {(nodeKey: NodeKeyString) => Promise<ComputedValue>} value
+     * @param {NodeIdentifier} nodeKey
+     * @param {(nodeKey: NodeIdentifier) => Promise<ComputedValue>} value
      * @returns {Promise<void>}
      */
     async create(nodeKey, value) {
@@ -281,7 +281,7 @@ class MigrationStorageClass {
 
     /**
      * Iterate over all nodes in S (previous-version materialized set).
-     * @returns {AsyncGenerator<NodeKeyString>}
+     * @returns {AsyncGenerator<NodeIdentifier>}
      */
     async *listMaterializedNodes() {
         for (const nodeKey of this.materializedNodes) {
@@ -291,8 +291,8 @@ class MigrationStorageClass {
 
     /**
      * Get the inputs of a node from the previous-version graph.
-     * @param {NodeKeyString} nodeKey
-     * @returns {Promise<readonly NodeKeyString[]>}
+     * @param {NodeIdentifier} nodeKey
+     * @returns {Promise<readonly NodeIdentifier[]>}
      */
     async getInputs(nodeKey) {
         if (!this.materializedNodes.has(nodeKey)) {
@@ -303,8 +303,8 @@ class MigrationStorageClass {
 
     /**
      * Get the dependents of a node from the previous-version graph.
-     * @param {NodeKeyString} nodeKey
-     * @returns {Promise<readonly NodeKeyString[]>}
+     * @param {NodeIdentifier} nodeKey
+     * @returns {Promise<readonly NodeIdentifier[]>}
      */
     async getDependents(nodeKey) {
         if (!this.materializedNodes.has(nodeKey)) {
@@ -318,8 +318,8 @@ class MigrationStorageClass {
      * Stops at already-invalidated or deleted nodes.
      * Throws on conflict with KEEP/OVERRIDE decisions.
      * @private
-     * @param {NodeKeyString} nodeKey
-     * @param {Set<NodeKeyString>} visited
+     * @param {NodeIdentifier} nodeKey
+     * @param {Set<NodeIdentifier>} visited
      * @returns {Promise<void>}
      */
     async _propagateInvalidate(nodeKey, visited) {
@@ -344,7 +344,7 @@ class MigrationStorageClass {
     /**
      * Finalize the migration: propagate DELETE decisions, check fan-in constraints,
      * and verify every node in S has exactly one decision.
-     * @returns {Promise<Map<NodeKeyString, Decision>>}
+     * @returns {Promise<Map<NodeIdentifier, Decision>>}
      */
     async finalize() {
         await this._propagateDeletesAndCheckFanIn();
@@ -359,7 +359,7 @@ class MigrationStorageClass {
      * @returns {Promise<void>}
      */
     async _propagateDeletesAndCheckFanIn() {
-        /** @type {NodeKeyString[]} */
+        /** @type {NodeIdentifier[]} */
         const queue = [];
         for (const [nodeKey, decision] of this.decisions) {
             if (decision.kind === "delete") {
@@ -409,7 +409,7 @@ class MigrationStorageClass {
      * @returns {void}
      */
     _checkCompleteness() {
-        /** @type {NodeKeyString[]} */
+        /** @type {NodeIdentifier[]} */
         const undecided = [];
         for (const nodeKey of this.materializedNodes) {
             if (!this.decisions.has(nodeKey)) {
@@ -426,7 +426,7 @@ class MigrationStorageClass {
  * Factory function to create a MigrationStorage instance.
  * @param {ReadableMigrationStorage} prevStorage
  * @param {Map<NodeName, CompiledNode>} newHeadIndex
- * @param {NodeKeyString[]} materializedNodes
+ * @param {NodeIdentifier[]} materializedNodes
  * @returns {MigrationStorageClass}
  */
 function makeMigrationStorage(prevStorage, newHeadIndex, materializedNodes) {

--- a/backend/src/generators/incremental_graph/pull.js
+++ b/backend/src/generators/incremental_graph/pull.js
@@ -6,7 +6,7 @@
 /** @typedef {import('./types').ComputedValue} ComputedValue */
 /** @typedef {import('./types').ConstValue} ConstValue */
 /** @typedef {import('./types').NodeName} NodeName */
-/** @typedef {import('./types').NodeKeyString} NodeKeyString */
+/** @typedef {import('./types').NodeIdentifier} NodeIdentifier */
 /** @typedef {import('./types').RecomputeResult} RecomputeResult */
 /** @typedef {import('./identifier_resolver').IdentifierResolver} IdentifierResolver */
 /**
@@ -17,11 +17,12 @@
  * @property {() => IdentifierResolver} makeIdentifierResolver
  * @property {(identifierResolver: IdentifierResolver, procedure: (batch: BatchBuilder) => Promise<RecomputeResult>) => Promise<RecomputeResult>} withIdentifierBatch
  * @property {(nodeDefinition: import('./types').ConcreteNode, identifierResolver: IdentifierResolver) => import('./types').ResolvedConcreteNode} resolveConcreteNode
- * @property {(nodeKeyStr: NodeKeyString, compiledNode: import('./types').CompiledNode, bindings: Array<ConstValue>) => import('./types').ConcreteNode} getOrCreateConcreteNode
+ * @property {(nodeKeyStr: NodeIdentifier, compiledNode: import('./types').CompiledNode, bindings: Array<ConstValue>) => import('./types').ConcreteNode} getOrCreateConcreteNode
  * @property {(nodeDefinition: import('./types').ResolvedConcreteNode, batch: BatchBuilder, identifierResolver: IdentifierResolver) => Promise<RecomputeResult>} maybeRecalculate
  */
 
 const { nodeKeyStringToString, stringToNodeName } = require("./database");
+const { stringToNodeIdentifier, stringToNodeKeyString } = require("./database/types");
 const { makeInvalidNodeError } = require("./errors");
 const { withPullMode, withPullNodeMutex } = require("./lock");
 const { deserializeNodeKey, serializeNodeKey } = require("./database");
@@ -99,24 +100,24 @@ async function internalPullWithStatus(
 ) {
     const nodeKey = { head: nodeName, args: bindings };
     const concreteKey = serializeNodeKey(nodeKey);
-    return await internalPullByNodeKeyStringWithStatusDuringPull(
+    return await internalPullByNodeIdentifierWithStatusDuringPull(
         incrementalGraph,
-        concreteKey,
+        stringToNodeIdentifier(String(concreteKey)),
         incrementalGraph.makeIdentifierResolver()
     );
 }
 
 /**
  * @param {IncrementalGraphPullAccess} incrementalGraph
- * @param {NodeKeyString} nodeKeyStr
+ * @param {NodeIdentifier} nodeKeyStr
  * @returns {Promise<RecomputeResult>}
  */
-async function internalPullByNodeKeyStringWithStatus(
+async function internalPullByNodeIdentifierWithStatus(
     incrementalGraph,
     nodeKeyStr
 ) {
     return withPullMode(incrementalGraph.sleeper, () =>
-        internalPullByNodeKeyStringWithStatusDuringPull(
+        internalPullByNodeIdentifierWithStatusDuringPull(
             incrementalGraph,
             nodeKeyStr
         )
@@ -125,16 +126,16 @@ async function internalPullByNodeKeyStringWithStatus(
 
 /**
  * @param {IncrementalGraphPullAccess} incrementalGraph
- * @param {NodeKeyString} nodeKeyStr
+ * @param {NodeIdentifier} nodeKeyStr
  * @param {IdentifierResolver} [identifierResolver=incrementalGraph.makeIdentifierResolver()]
  * @returns {Promise<RecomputeResult>}
  */
-async function internalPullByNodeKeyStringWithStatusDuringPull(
+async function internalPullByNodeIdentifierWithStatusDuringPull(
     incrementalGraph,
     nodeKeyStr,
     identifierResolver = incrementalGraph.makeIdentifierResolver()
 ) {
-    const nodeKey = deserializeNodeKey(nodeKeyStr);
+    const nodeKey = deserializeNodeKey(stringToNodeKeyString(String(nodeKeyStr)));
     const nodeName = nodeKey.head;
     const bindings = nodeKey.args;
     const compiledNode = incrementalGraph.headIndex.get(nodeName);
@@ -156,7 +157,7 @@ async function internalPullByNodeKeyStringWithStatusDuringPull(
      */
     const run = async (batch) => {
         const outputIdentifier = identifierResolver.getOrAllocateNodeIdentifier(
-            concreteNode.output
+            stringToNodeIdentifier(String(concreteNode.output))
         );
         const nodeFreshness = await batch.freshness.get(
             outputIdentifier
@@ -189,8 +190,8 @@ async function internalPullByNodeKeyStringWithStatusDuringPull(
 
 module.exports = {
     internalPull,
-    internalPullByNodeKeyStringWithStatusDuringPull,
-    internalPullByNodeKeyStringWithStatus,
+    internalPullByNodeIdentifierWithStatusDuringPull,
+    internalPullByNodeIdentifierWithStatus,
     internalSafePullWithStatus,
     internalPullWithStatus,
     internalUnsafePull,

--- a/backend/src/generators/incremental_graph/recompute.js
+++ b/backend/src/generators/incremental_graph/recompute.js
@@ -11,13 +11,14 @@
  * @property {import('./graph_storage').GraphStorage} storage
  * @property {import('../../datetime').Datetime} datetime
  * @property {import('../../sleeper').SleepCapability} sleeper
- * @property {(nodeKeyStr: import('./types').NodeKeyString, identifierResolver: IdentifierResolver) => Promise<RecomputeResult>} _pullDuringPull
+ * @property {(nodeKeyStr: import('./types').NodeIdentifier, identifierResolver: IdentifierResolver) => Promise<RecomputeResult>} _pullDuringPull
  */
 
 const { makeInvalidComputorReturnValueError, makeInvalidUnchangedError } = require("./errors");
 const { deserializeNodeKey } = require("./database");
 const { isUnchanged } = require("./unchanged");
 const { nodeIdentifierToString } = require("./database");
+const { stringToNodeIdentifier } = require("./database/types");
 /**
  * @param {IncrementalGraphRecomputeAccess} incrementalGraph
  * @param {ResolvedConcreteNode} nodeDefinition
@@ -46,7 +47,7 @@ async function internalMaybeRecalculate(
         }
         const { value: inputValue } =
             await incrementalGraph._pullDuringPull(
-                inputKey,
+                stringToNodeIdentifier(String(inputKey)),
                 identifierResolver
             );
         inputValues.push(inputValue);

--- a/backend/src/generators/incremental_graph/types.js
+++ b/backend/src/generators/incremental_graph/types.js
@@ -49,7 +49,7 @@
 
 /**
  * Stable identifier used for persisted IncrementalGraph state.
- * @typedef {import('./database/node_identifier').NodeIdentifier} NodeIdentifier
+ * @typedef {import('./database/types').NodeIdentifier} NodeIdentifier
  */
 
 /**


### PR DESCRIPTION
### Motivation

- Convert the incremental-graph persistence layer to use compact persisted identifiers instead of semantic node-key strings to simplify storage, reduce unsafe conversions, and make DB key types consistent and explicit.
- Prepare the codebase for identifier-native operations (hostname staging, unification, migration and runtime) by centralizing conversions to/from `NodeIdentifier`.

### Description

- Replace use of `NodeKeyString` as the primary on-disk key with `NodeIdentifier`/`DatabaseKey` across the database, storage and runtime layers and add `DatabaseStoredValue` where needed.
- Update modules to use `stringToNodeIdentifier` / `nodeIdentifierToString` conversions and remove many intermediate string wrappers (changes in `root_database.js`, `hostname_storage.js`, `typed_database.js`, `db_to_db.js`, `graph_storage.js`, and others).
- Adapt identifier lookup and allocation to treat both sides of the bijection as identifier-typed values, updating `identifier_lookup.js`, `node_identifier.js`, and `identifier_resolver.js` accordingly.
- Make corresponding typing and API adjustments in higher-level logic: pull/recompute/migration/topo-sort/sync-merge/invalidate/migration_storage to operate in identifier-native form and fix signatures (including a small generic improvement to `withIdentifierBatch`).

### Testing

- Ran the full test suite (`yarn test`) against the branch and all tests completed successfully.
- Executed incremental-graph focused tests (migration, sync/merge, topo-sort and pull/recompute unit tests) and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08c9ecebc0832eb2214ba48b330f36)