### PR TITLE
RootDatabase: atomic replica state via single `_computed` bundle

### DIFF
--- a/backend/src/generators/incremental_graph/database/root_database.js
+++ b/backend/src/generators/incremental_graph/database/root_database.js
@@ -252,11 +252,11 @@ class RootDatabaseClass {
     db;
 
     /**
-     * Cached name of the currently active replica ("x" or "y").
+     * Computed active replica bundle.
      * @private
-     * @type {ReplicaName}
+     * @type {{ replicaName: ReplicaName, namespaceSublevel: SchemaSublevelType, globalSublevel: GlobalSublevelType, schemaStorage: SchemaStorage, identifierLookup: IdentifierLookup }}
      */
-    _cachedValueOfCurrentReplica;
+    _computed;
 
     /**
      * Root-level `_meta` sublevel used to persist the replica pointer.
@@ -265,55 +265,11 @@ class RootDatabaseClass {
     _rootMetaSublevel;
 
     /**
-     * Global sublevels for each replica (used by getGlobalVersion / setGlobalVersion).
-     * @private
-     * @type {GlobalSublevelType}
-     */
-    _xGlobalSublevel;
-
-    /**
-     * @private
-     * @type {GlobalSublevelType}
-     */
-    _yGlobalSublevel;
-
-    /**
-     * Top-level namespace sublevels for each replica (used by clearReplicaStorage).
-     * @private
-     * @type {SchemaSublevelType}
-     */
-    _xNamespaceSublevel;
-
-    /**
-     * @private
-     * @type {SchemaSublevelType}
-     */
-    _yNamespaceSublevel;
-
-    /**
-     * Pre-built schema storages for each replica.
-     * @private
-     * @type {SchemaStorage}
-     */
-    _xSchemaStorage;
-
-    /**
-     * @private
-     * @type {SchemaStorage}
-     */
-    _ySchemaStorage;
-
-    /**
      * @private
      * @type {import('../../../random/seed').NonDeterministicSeed}
      */
     _seed;
 
-    /**
-     * @private
-     * @type {IdentifierLookup}
-     */
-    _identifierLookup;
 
     /**
      * @constructor
@@ -325,20 +281,51 @@ class RootDatabaseClass {
     constructor(db, version, currentReplicaName, seed) {
         this.db = db;
         this.version = version;
-        this._cachedValueOfCurrentReplica = currentReplicaName;
         this._seed = seed;
 
         // Root-level _meta sublevel for the replica pointer.
         this._rootMetaSublevel = db.sublevel('_meta', { valueEncoding: 'json' });
 
-        // Build per-replica sublevels and schema storages.
-        this._xNamespaceSublevel = db.sublevel('x', { valueEncoding: 'json' });
-        this._yNamespaceSublevel = db.sublevel('y', { valueEncoding: 'json' });
-        this._xGlobalSublevel = this._xNamespaceSublevel.sublevel('global', { valueEncoding: 'json' });
-        this._yGlobalSublevel = this._yNamespaceSublevel.sublevel('global', { valueEncoding: 'json' });
-        this._xSchemaStorage = buildSchemaStorage(this._xNamespaceSublevel, this._xGlobalSublevel, version);
-        this._ySchemaStorage = buildSchemaStorage(this._yNamespaceSublevel, this._yGlobalSublevel, version);
-        this._identifierLookup = makeEmptyIdentifierLookup();
+        const namespaceSublevel = this.replicaNamespaceSublevel(currentReplicaName);
+        const globalSublevel = this.replicaGlobalSublevel(currentReplicaName);
+        this._computed = {
+            replicaName: currentReplicaName,
+            namespaceSublevel,
+            globalSublevel,
+            schemaStorage: buildSchemaStorage(namespaceSublevel, globalSublevel, version),
+            identifierLookup: makeEmptyIdentifierLookup(),
+        };
+    }
+
+
+    /**
+     * @param {ReplicaName} name
+     * @returns {SchemaSublevelType}
+     */
+    replicaNamespaceSublevel(name) {
+        return this.db.sublevel(name, { valueEncoding: 'json' });
+    }
+
+    /**
+     * @param {ReplicaName} name
+     * @returns {GlobalSublevelType}
+     */
+    replicaGlobalSublevel(name) {
+        return this.replicaNamespaceSublevel(name).sublevel('global', { valueEncoding: 'json' });
+    }
+
+    /**
+     * @param {ReplicaName} name
+     * @returns {void}
+     */
+    assertValidReplicaName(name) {
+        if (name === 'x') {
+            return;
+        }
+        if (name === 'y') {
+            return;
+        }
+        assertNeverReplicaName(name);
     }
 
     /**
@@ -347,14 +334,14 @@ class RootDatabaseClass {
      * @returns {ReplicaName}
      */
     currentReplicaName() {
-        return this._cachedValueOfCurrentReplica;
+        return this._computed.replicaName;
     }
 
     /**
      * @returns {IdentifierLookup}
      */
     cloneActiveIdentifierLookup() {
-        return cloneIdentifierLookup(this._identifierLookup);
+        return cloneIdentifierLookup(this._computed.identifierLookup);
     }
 
     /**
@@ -362,7 +349,7 @@ class RootDatabaseClass {
      * @returns {void}
      */
     replaceActiveIdentifierLookup(lookup) {
-        this._identifierLookup = lookup;
+        this._computed.identifierLookup = lookup;
     }
 
     /**
@@ -370,7 +357,7 @@ class RootDatabaseClass {
      * @returns {NodeIdentifier | undefined}
      */
     nodeKeyToId(nodeKey) {
-        return nodeKeyToIdFromLookup(this._identifierLookup, nodeKey);
+        return nodeKeyToIdFromLookup(this._computed.identifierLookup, nodeKey);
     }
 
     /**
@@ -378,7 +365,7 @@ class RootDatabaseClass {
      * @returns {NodeIdentifier | undefined}
      */
     nodeIdToKey(nodeIdentifier) {
-        return nodeIdToKeyFromLookup(this._identifierLookup, nodeIdentifier);
+        return nodeIdToKeyFromLookup(this._computed.identifierLookup, nodeIdentifier);
     }
 
     /**
@@ -392,7 +379,7 @@ class RootDatabaseClass {
      * @returns {Promise<void>}
      */
     async initializeActiveIdentifierLookup() {
-        this._identifierLookup = await this.loadIdentifierLookupForReplica(this.currentReplicaName());
+        this._computed.identifierLookup = await this.loadIdentifierLookupForReplica(this.currentReplicaName());
     }
 
     /**
@@ -400,13 +387,7 @@ class RootDatabaseClass {
      * @returns {Promise<IdentifierLookup>}
      */
     async loadIdentifierLookupForReplica(name) {
-        if (name === 'x') {
-            return loadIdentifierLookupFromGlobal(this._xGlobalSublevel);
-        } else if (name === 'y') {
-            return loadIdentifierLookupFromGlobal(this._yGlobalSublevel);
-        } else {
-            return assertNeverReplicaName(name);
-        }
+        return loadIdentifierLookupFromGlobal(this.replicaGlobalSublevel(name));
     }
 
     /**
@@ -414,7 +395,7 @@ class RootDatabaseClass {
      * @returns {ReplicaName}
      */
     otherReplicaName() {
-        const current = this._cachedValueOfCurrentReplica;
+        const current = this._computed.replicaName;
         if (current === 'x') {
             return 'y';
         } else if (current === 'y') {
@@ -434,18 +415,14 @@ class RootDatabaseClass {
      * @returns {Promise<void>}
      */
     async setCurrentReplicaPointer(name) {
-        if (name === 'x') {
-            // x is valid
-        } else if (name === 'y') {
-            // y is valid
-        } else {
-            assertNeverReplicaName(name);
-        }
+        this.assertValidReplicaName(name);
         try {
-            const nextIdentifierLookup = await this.loadIdentifierLookupForReplica(name);
+            const namespaceSublevel = this.replicaNamespaceSublevel(name);
+            const globalSublevel = this.replicaGlobalSublevel(name);
+            const schemaStorage = buildSchemaStorage(namespaceSublevel, globalSublevel, this.version);
+            const identifierLookup = await loadIdentifierLookupFromGlobal(globalSublevel);
             await this._rootMetaSublevel.put('current_replica', name);
-            this._cachedValueOfCurrentReplica = name;
-            this._identifierLookup = nextIdentifierLookup;
+            this._computed = { replicaName: name, namespaceSublevel, globalSublevel, schemaStorage, identifierLookup };
         } catch (err) {
             throw new SwitchReplicaError(name, err);
         }
@@ -457,14 +434,7 @@ class RootDatabaseClass {
      * @returns {SchemaStorage}
      */
     getSchemaStorage() {
-        const current = this._cachedValueOfCurrentReplica;
-        if (current === 'x') {
-            return this._xSchemaStorage;
-        } else if (current === 'y') {
-            return this._ySchemaStorage;
-        } else {
-            return assertNeverReplicaName(current);
-        }
+        return this._computed.schemaStorage;
     }
 
     /**
@@ -475,13 +445,10 @@ class RootDatabaseClass {
      * @returns {SchemaStorage}
      */
     schemaStorageForReplica(name) {
-        if (name === 'x') {
-            return this._xSchemaStorage;
-        } else if (name === 'y') {
-            return this._ySchemaStorage;
-        } else {
-            return assertNeverReplicaName(name);
-        }
+        this.assertValidReplicaName(name);
+        const namespaceSublevel = this.replicaNamespaceSublevel(name);
+        const globalSublevel = this.replicaGlobalSublevel(name);
+        return buildSchemaStorage(namespaceSublevel, globalSublevel, this.version);
     }
 
     /**
@@ -490,16 +457,7 @@ class RootDatabaseClass {
      * @returns {Promise<Version | undefined>}
      */
     async getGlobalVersion() {
-        const current = this._cachedValueOfCurrentReplica;
-        let globalSublevel;
-        if (current === 'x') {
-            globalSublevel = this._xGlobalSublevel;
-        } else if (current === 'y') {
-            globalSublevel = this._yGlobalSublevel;
-        } else {
-            return assertNeverReplicaName(current);
-        }
-        return await globalSublevel.get('version');
+        return await this._computed.globalSublevel.get('version');
     }
 
     /**
@@ -508,16 +466,7 @@ class RootDatabaseClass {
      * @returns {Promise<void>}
      */
     async setGlobalVersion(version) {
-        const current = this._cachedValueOfCurrentReplica;
-        let globalSublevel;
-        if (current === 'x') {
-            globalSublevel = this._xGlobalSublevel;
-        } else if (current === 'y') {
-            globalSublevel = this._yGlobalSublevel;
-        } else {
-            return assertNeverReplicaName(current);
-        }
-        await globalSublevel.put('version', version);
+        await this._computed.globalSublevel.put('version', version);
     }
 
     /**
@@ -531,22 +480,18 @@ class RootDatabaseClass {
      * @returns {Promise<void>}
      */
     async clearReplicaStorage(name) {
-        if (name === 'x') {
-            await this._xNamespaceSublevel.clear();
-            // Rebuild to reset the version-initialisation cache in the new closure.
-            this._xSchemaStorage = buildSchemaStorage(this._xNamespaceSublevel, this._xGlobalSublevel, this.version);
-            if (this.currentReplicaName() === 'x') {
-                this._identifierLookup = await loadIdentifierLookupFromGlobal(this._xGlobalSublevel);
-            }
-        } else if (name === 'y') {
-            await this._yNamespaceSublevel.clear();
-            // Rebuild to reset the version-initialisation cache in the new closure.
-            this._ySchemaStorage = buildSchemaStorage(this._yNamespaceSublevel, this._yGlobalSublevel, this.version);
-            if (this.currentReplicaName() === 'y') {
-                this._identifierLookup = await loadIdentifierLookupFromGlobal(this._yGlobalSublevel);
-            }
-        } else {
-            return assertNeverReplicaName(name);
+        this.assertValidReplicaName(name);
+        const namespaceSublevel = this.replicaNamespaceSublevel(name);
+        await namespaceSublevel.clear();
+        if (this.currentReplicaName() === name) {
+            const globalSublevel = this.replicaGlobalSublevel(name);
+            this._computed = {
+                replicaName: name,
+                namespaceSublevel,
+                globalSublevel,
+                schemaStorage: buildSchemaStorage(namespaceSublevel, globalSublevel, this.version),
+                identifierLookup: await loadIdentifierLookupFromGlobal(globalSublevel),
+            };
         }
     }
 

--- a/backend/tests/database.test.js
+++ b/backend/tests/database.test.js
@@ -533,8 +533,10 @@ describe('generators/database', () => {
                 await db.setCurrentReplicaPointer('y');
 
                 expect(db.currentReplicaName()).toBe('y');
-                expect(db.getSchemaStorage()).toBe(yStorage);
                 expect(db.getSchemaStorage()).not.toBe(xStorage);
+                const activeYStorage = db.getSchemaStorage();
+                await activeYStorage.global.put('switch_check', 'ok');
+                expect(await yStorage.global.get('switch_check')).toBe('ok');
 
                 await db.close();
             } finally {

--- a/docs/pr1335-review1-.md
+++ b/docs/pr1335-review1-.md
@@ -1,0 +1,49 @@
+# PR #1335 Review Feedback #1: Problem Analysis
+
+## Feedback summary
+The review requests refactoring `root_database.js` so replica-switching state is **atomic and single-sourced**.
+
+## Core problem
+Current `RootDatabase` behavior spreads active and inactive replica state across many mutable fields:
+
+- `_cachedValueOfCurrentReplica`
+- `_xNamespaceSublevel` / `_yNamespaceSublevel`
+- `_xGlobalSublevel` / `_yGlobalSublevel`
+- `_xSchemaStorage` / `_ySchemaStorage`
+- `_identifierLookup`
+
+This creates multiple mutation surfaces and can lead to drift between fields that are conceptually one runtime state.
+
+## Why non-atomicity is dangerous
+On switch operations, some values can be prepared or updated at different times. Even when this is usually correct, the shape itself allows inconsistent intermediate states in memory if an error occurs at the wrong point.
+
+The review wants a strong invariant:
+
+- Build candidate state fully first.
+- Persist pointer.
+- Commit one assignment to live runtime state.
+
+## Architectural requirement from the review
+The object should keep only these durable fields:
+
+- `db`
+- `_rootMetaSublevel`
+- `version`
+- `_seed`
+- `_computed`
+
+Where `_computed` is the only mutable active bundle:
+
+- `replicaName`
+- `namespaceSublevel`
+- `globalSublevel`
+- `schemaStorage`
+- `identifierLookup`
+
+## Impacted behavior
+- `setCurrentReplicaPointer(name)` must become transactional in structure.
+- Inactive-replica access should be derived on demand, not cached as permanent twin fields.
+- Migration flows that use `schemaStorageForReplica(name)` continue to work, but through derived handles.
+
+## Expected outcome
+A single coherent commit point (`this._computed = ...`) after successful persistence, preventing partial runtime transitions.

--- a/docs/pr1335-review1-impl.md
+++ b/docs/pr1335-review1-impl.md
@@ -1,0 +1,51 @@
+# Detailed Implementation Plan for PR #1335 Review Feedback #1
+
+## 1) Refactor internal state model in `root_database.js`
+
+- Remove per-replica cached fields:
+  - `_xNamespaceSublevel`, `_yNamespaceSublevel`
+  - `_xGlobalSublevel`, `_yGlobalSublevel`
+  - `_xSchemaStorage`, `_ySchemaStorage`
+  - `_cachedValueOfCurrentReplica`
+  - `_identifierLookup`
+- Add/standardize `_computed` as the active runtime bundle.
+
+## 2) Add replica-derivation helpers
+
+- Implement:
+  - `replicaNamespaceSublevel(name)`
+  - `replicaGlobalSublevel(name)`
+- Keep validation local to replica-sensitive entry points so invalid names still throw `InvalidReplicaPointerError`.
+
+## 3) Rebuild active initialization path
+
+- Constructor should:
+  - derive active namespace/global from initial replica name
+  - build active schema storage
+  - initialize empty lookup
+  - assign `_computed`
+
+## 4) Make `setCurrentReplicaPointer` atomic
+
+- Validate `name`.
+- Build all candidate parts locally.
+- Persist pointer to `_meta/current_replica`.
+- Assign `_computed` once.
+- Wrap failures in `SwitchReplicaError`.
+
+## 5) Update dependent methods
+
+- `currentReplicaName`, `getSchemaStorage`, `getGlobalVersion`, `setGlobalVersion`, and lookup helpers should read/write through `_computed`.
+- `schemaStorageForReplica(name)` should derive on demand and return a fresh schema storage.
+- `clearReplicaStorage(name)` should clear derived namespace; if active, rebuild `_computed` from cleared namespace.
+
+## 6) Verification
+
+- Focused tests:
+  - database replica-switch and storage tests.
+  - migration/sync tests touching `schemaStorageForReplica` and switch cutover semantics.
+- Full checks:
+  - `npm test`
+  - `npm run static-analysis`
+  - `npm run build`
+- Fix regressions and rerun until all pass.

--- a/docs/pr1335-review1-strat.md
+++ b/docs/pr1335-review1-strat.md
@@ -1,0 +1,48 @@
+# Strategy to Address PR #1335 Review Feedback #1
+
+## Principles
+
+1. **Single source of truth**
+   - Keep all active-replica runtime derivations in one `_computed` object.
+
+2. **Atomic cutover semantics**
+   - No live-state mutation before all candidate parts are built and persistence succeeds.
+
+3. **On-demand inactive access**
+   - Derive inactive replica sublevels/storages from `db` and replica name when needed.
+
+4. **Behavioral compatibility**
+   - Preserve existing public API and migration call patterns.
+
+5. **Test-first validation loop**
+   - Run focused tests for replica and migration behavior.
+   - Run full checks (`npm test`, `npm run static-analysis`, `npm run build`) and iterate until green.
+
+## Strategic approach
+
+### A. Collapse mutable state
+Replace parallel per-replica mutable fields with one mutable bundle `_computed`.
+
+### B. Introduce pure derivation helpers
+Use helpers like:
+- `replicaNamespaceSublevel(name)`
+- `replicaGlobalSublevel(name)`
+- `schemaStorageForReplica(name)`
+
+These should derive from `db` every call and avoid long-lived dual caches.
+
+### C. Refactor switch flow into staged transaction
+Implement `setCurrentReplicaPointer(name)` as:
+1. validate input
+2. derive candidate namespace/global handles
+3. build candidate schema storage
+4. load candidate identifier lookup
+5. persist `_meta/current_replica`
+6. single assignment to `_computed`
+
+### D. Preserve clear semantics
+`clearReplicaStorage(name)` should clear that namespace and, only if it is active, rebuild `_computed` for that active replica.
+
+### E. Reconcile tests and docs
+- Update any tests that depended on previous internal caching behavior.
+- Document architectural rationale and invariants.

--- a/docs/pr1335.md
+++ b/docs/pr1335.md
@@ -1,0 +1,35 @@
+# PR #1335: Switch IncrementalGraph persistence and migration to node identifiers
+
+## High-level intent
+PR [#1335](https://github.com/ottojung/volodyslav/pull/1335) moves IncrementalGraph persistence away from key-centric storage and toward identifier-centric storage. The conceptual goal is to make node identifiers the canonical persisted identity across runtime graph operations, migration, and replica switching.
+
+The PR is currently open (draft), targets `master`, and is large (`65` changed files, roughly `+2701/-2262`, `26` commits).
+
+## Conceptual architecture change
+
+1. **Storage identity shift**
+   - Previously, many storage paths used user-facing node keys as a first-class persistence identity.
+   - The PR shifts storage semantics so persistent operations run on stable node identifiers.
+   - Key↔identifier mapping becomes a boundary concern rather than a storage-layer concern.
+
+2. **Migration semantics sharpened**
+   - Migration and sync paths are adjusted to preserve identifier continuity while still supporting two-replica operation (`x` and `y`).
+   - The code keeps clear staging vs active-replica behavior, with switch-over performed only after target replica build steps complete.
+
+3. **Type and test surface modernization**
+   - Tests were expanded heavily around migration, revdeps ordering, timestamps, and sync behavior.
+   - Error boundaries were made more explicit in the migration/switch flow.
+
+## Low-level, particular choices visible from the PR metadata and branch state
+
+- PR title explicitly encodes the primary design move: identifier-native persistence.
+- The branch checklist emphasizes:
+  - re-checking current CI/static-analysis state,
+  - reverting a semantic-storage split that was deemed architecturally wrong,
+  - making `graph_storage.js` purely `NodeIdentifier`-based,
+  - preserving migration coverage after refactoring.
+- Active review feedback indicates follow-up architectural tightening is still needed in `root_database.js` for atomic replica switching.
+
+## Why this PR matters
+
+This PR is not just a refactor; it changes the persistence contract for IncrementalGraph. If finished correctly, it reduces ambiguity around identity, makes migration behavior easier to reason about, and improves durability/consistency guarantees around replica cutover.


### PR DESCRIPTION
### Motivation

- Ensure replica switching is atomic and single-sourced so in-memory runtime state cannot diverge during a cutover. 
- Simplify the runtime model by collapsing parallel per-replica cached fields into one coherent active bundle. 
- Support on-demand access to inactive replicas while preserving migration semantics that require two physical namespaces (`x` and `y`).

### Description

- Replace the many per-replica cached fields with a single mutable `_computed` object that contains `replicaName`, `namespaceSublevel`, `globalSublevel`, `schemaStorage`, and `identifierLookup` and make this the only live replica state. 
- Add derivation helpers `replicaNamespaceSublevel(name)` and `replicaGlobalSublevel(name)` and `assertValidReplicaName(name)` so inactive replica handles are obtained on demand instead of cached long-term. 
- Make `setCurrentReplicaPointer(name)` staged and atomic by building candidate `namespaceSublevel`, `globalSublevel`, `schemaStorage`, and `identifierLookup` locally, persisting `'_meta/current_replica'`, then assigning `this._computed` once; failures are wrapped in `SwitchReplicaError`. 
- Change `schemaStorageForReplica(name)` to return a fresh `SchemaStorage` built on demand, update `clearReplicaStorage(name)` to clear the physical namespace and rebuild `_computed` only when the cleared namespace is active, and update lookup/utility methods to read/write through `_computed`. 
- Update the affected test `backend/tests/database.test.js` to validate functional behavior of derived storages and add documentation files (`docs/pr1335.md`, `docs/pr1335-review1-.md`, `docs/pr1335-review1-strat.md`, `docs/pr1335-review1-impl.md`).

### Testing

- Ran the focused test `npx jest backend/tests/database.test.js --runInBand` which was used to validate replica switch semantics and was adjusted to assert functional equivalence of derived storages; it passed after the fix. 
- Ran the full test suite with `npm test`, which completed successfully (`All tests passed`). 
- Ran static analysis with `npm run static-analysis` and the build with `npm run build`, both of which completed successfully. 
- All automated checks in this environment passed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c0a04a354832e9f81542e9edcd8ca)