### PR TITLE
Refactor RootDatabase replica state to single atomic computed bundle

### DIFF
--- a/backend/src/generators/incremental_graph/database/root_database.js
+++ b/backend/src/generators/incremental_graph/database/root_database.js
@@ -49,6 +49,14 @@ const {
 /** @typedef {import('./types').Version} Version */
 /** @typedef {import('./types').IdentifiersKeysMap} IdentifiersKeysMap */
 /** @typedef {import('./identifier_lookup').IdentifierLookup} IdentifierLookup */
+/**
+ * @typedef {object} ActiveReplicaComputed
+ * @property {ReplicaName} replicaName
+ * @property {SchemaSublevelType} namespaceSublevel
+ * @property {GlobalSublevelType} globalSublevel
+ * @property {SchemaStorage} schemaStorage
+ * @property {IdentifierLookup} identifierLookup
+ */
 
 /**
  * Common base type for any abstract-level database instance at any nesting depth.
@@ -239,9 +247,8 @@ function buildSchemaStorage(namespaceSublevel, globalSublevel, version) {
 /**
  * Root database class with replica-pointer awareness.
  *
- * Maintains a cached `_meta/current_replica` pointer (always "x" or "y") and
- * exposes both schema storages so that migration can write to the inactive
- * replica without touching the active one.
+ * Maintains a cached `_meta/current_replica` pointer (always "x" or "y").
+ * All active, replica-derived runtime state is represented by `_computed`.
  */
 class RootDatabaseClass {
     /**
@@ -252,56 +259,10 @@ class RootDatabaseClass {
     db;
 
     /**
-     * Cached name of the currently active replica ("x" or "y").
-     * @private
-     * @type {ReplicaName}
-     */
-    _cachedValueOfCurrentReplica;
-
-    /**
      * Root-level `_meta` sublevel used to persist the replica pointer.
      * @private
      */
     _rootMetaSublevel;
-
-    /**
-     * Global sublevels for each replica (used by getGlobalVersion / setGlobalVersion).
-     * @private
-     * @type {GlobalSublevelType}
-     */
-    _xGlobalSublevel;
-
-    /**
-     * @private
-     * @type {GlobalSublevelType}
-     */
-    _yGlobalSublevel;
-
-    /**
-     * Top-level namespace sublevels for each replica (used by clearReplicaStorage).
-     * @private
-     * @type {SchemaSublevelType}
-     */
-    _xNamespaceSublevel;
-
-    /**
-     * @private
-     * @type {SchemaSublevelType}
-     */
-    _yNamespaceSublevel;
-
-    /**
-     * Pre-built schema storages for each replica.
-     * @private
-     * @type {SchemaStorage}
-     */
-    _xSchemaStorage;
-
-    /**
-     * @private
-     * @type {SchemaStorage}
-     */
-    _ySchemaStorage;
 
     /**
      * @private
@@ -311,9 +272,9 @@ class RootDatabaseClass {
 
     /**
      * @private
-     * @type {IdentifierLookup}
+     * @type {ActiveReplicaComputed}
      */
-    _identifierLookup;
+    _computed;
 
     /**
      * @constructor
@@ -325,20 +286,20 @@ class RootDatabaseClass {
     constructor(db, version, currentReplicaName, seed) {
         this.db = db;
         this.version = version;
-        this._cachedValueOfCurrentReplica = currentReplicaName;
         this._seed = seed;
 
         // Root-level _meta sublevel for the replica pointer.
         this._rootMetaSublevel = db.sublevel('_meta', { valueEncoding: 'json' });
 
-        // Build per-replica sublevels and schema storages.
-        this._xNamespaceSublevel = db.sublevel('x', { valueEncoding: 'json' });
-        this._yNamespaceSublevel = db.sublevel('y', { valueEncoding: 'json' });
-        this._xGlobalSublevel = this._xNamespaceSublevel.sublevel('global', { valueEncoding: 'json' });
-        this._yGlobalSublevel = this._yNamespaceSublevel.sublevel('global', { valueEncoding: 'json' });
-        this._xSchemaStorage = buildSchemaStorage(this._xNamespaceSublevel, this._xGlobalSublevel, version);
-        this._ySchemaStorage = buildSchemaStorage(this._yNamespaceSublevel, this._yGlobalSublevel, version);
-        this._identifierLookup = makeEmptyIdentifierLookup();
+        const namespaceSublevel = this.replicaNamespaceSublevel(currentReplicaName);
+        const globalSublevel = this.replicaGlobalSublevel(currentReplicaName);
+        this._computed = {
+            replicaName: currentReplicaName,
+            namespaceSublevel,
+            globalSublevel,
+            schemaStorage: buildSchemaStorage(namespaceSublevel, globalSublevel, version),
+            identifierLookup: makeEmptyIdentifierLookup(),
+        };
     }
 
     /**
@@ -347,14 +308,14 @@ class RootDatabaseClass {
      * @returns {ReplicaName}
      */
     currentReplicaName() {
-        return this._cachedValueOfCurrentReplica;
+        return this._computed.replicaName;
     }
 
     /**
      * @returns {IdentifierLookup}
      */
     cloneActiveIdentifierLookup() {
-        return cloneIdentifierLookup(this._identifierLookup);
+        return cloneIdentifierLookup(this._computed.identifierLookup);
     }
 
     /**
@@ -362,7 +323,7 @@ class RootDatabaseClass {
      * @returns {void}
      */
     replaceActiveIdentifierLookup(lookup) {
-        this._identifierLookup = lookup;
+        this._computed.identifierLookup = lookup;
     }
 
     /**
@@ -370,7 +331,7 @@ class RootDatabaseClass {
      * @returns {NodeIdentifier | undefined}
      */
     nodeKeyToId(nodeKey) {
-        return nodeKeyToIdFromLookup(this._identifierLookup, nodeKey);
+        return nodeKeyToIdFromLookup(this._computed.identifierLookup, nodeKey);
     }
 
     /**
@@ -378,7 +339,7 @@ class RootDatabaseClass {
      * @returns {NodeIdentifier | undefined}
      */
     nodeIdToKey(nodeIdentifier) {
-        return nodeIdToKeyFromLookup(this._identifierLookup, nodeIdentifier);
+        return nodeIdToKeyFromLookup(this._computed.identifierLookup, nodeIdentifier);
     }
 
     /**
@@ -392,7 +353,7 @@ class RootDatabaseClass {
      * @returns {Promise<void>}
      */
     async initializeActiveIdentifierLookup() {
-        this._identifierLookup = await this.loadIdentifierLookupForReplica(this.currentReplicaName());
+        this._computed.identifierLookup = await loadIdentifierLookupFromGlobal(this._computed.globalSublevel);
     }
 
     /**
@@ -400,13 +361,7 @@ class RootDatabaseClass {
      * @returns {Promise<IdentifierLookup>}
      */
     async loadIdentifierLookupForReplica(name) {
-        if (name === 'x') {
-            return loadIdentifierLookupFromGlobal(this._xGlobalSublevel);
-        } else if (name === 'y') {
-            return loadIdentifierLookupFromGlobal(this._yGlobalSublevel);
-        } else {
-            return assertNeverReplicaName(name);
-        }
+        return loadIdentifierLookupFromGlobal(this.replicaGlobalSublevel(name));
     }
 
     /**
@@ -414,14 +369,14 @@ class RootDatabaseClass {
      * @returns {ReplicaName}
      */
     otherReplicaName() {
-        const current = this._cachedValueOfCurrentReplica;
+        const current = this._computed.replicaName;
         if (current === 'x') {
             return 'y';
-        } else if (current === 'y') {
-            return 'x';
-        } else {
-            return assertNeverReplicaName(current);
         }
+        if (current === 'y') {
+            return 'x';
+        }
+        return assertNeverReplicaName(current);
     }
 
     /**
@@ -442,10 +397,12 @@ class RootDatabaseClass {
             assertNeverReplicaName(name);
         }
         try {
-            const nextIdentifierLookup = await this.loadIdentifierLookupForReplica(name);
+            const namespaceSublevel = this.replicaNamespaceSublevel(name);
+            const globalSublevel = this.replicaGlobalSublevel(name);
+            const schemaStorage = buildSchemaStorage(namespaceSublevel, globalSublevel, this.version);
+            const identifierLookup = await loadIdentifierLookupFromGlobal(globalSublevel);
             await this._rootMetaSublevel.put('current_replica', name);
-            this._cachedValueOfCurrentReplica = name;
-            this._identifierLookup = nextIdentifierLookup;
+            this._computed = { replicaName: name, namespaceSublevel, globalSublevel, schemaStorage, identifierLookup };
         } catch (err) {
             throw new SwitchReplicaError(name, err);
         }
@@ -457,14 +414,7 @@ class RootDatabaseClass {
      * @returns {SchemaStorage}
      */
     getSchemaStorage() {
-        const current = this._cachedValueOfCurrentReplica;
-        if (current === 'x') {
-            return this._xSchemaStorage;
-        } else if (current === 'y') {
-            return this._ySchemaStorage;
-        } else {
-            return assertNeverReplicaName(current);
-        }
+        return this._computed.schemaStorage;
     }
 
     /**
@@ -475,13 +425,11 @@ class RootDatabaseClass {
      * @returns {SchemaStorage}
      */
     schemaStorageForReplica(name) {
-        if (name === 'x') {
-            return this._xSchemaStorage;
-        } else if (name === 'y') {
-            return this._ySchemaStorage;
-        } else {
-            return assertNeverReplicaName(name);
-        }
+        return buildSchemaStorage(
+            this.replicaNamespaceSublevel(name),
+            this.replicaGlobalSublevel(name),
+            this.version
+        );
     }
 
     /**
@@ -490,16 +438,7 @@ class RootDatabaseClass {
      * @returns {Promise<Version | undefined>}
      */
     async getGlobalVersion() {
-        const current = this._cachedValueOfCurrentReplica;
-        let globalSublevel;
-        if (current === 'x') {
-            globalSublevel = this._xGlobalSublevel;
-        } else if (current === 'y') {
-            globalSublevel = this._yGlobalSublevel;
-        } else {
-            return assertNeverReplicaName(current);
-        }
-        return await globalSublevel.get('version');
+        return await this._computed.globalSublevel.get('version');
     }
 
     /**
@@ -508,16 +447,7 @@ class RootDatabaseClass {
      * @returns {Promise<void>}
      */
     async setGlobalVersion(version) {
-        const current = this._cachedValueOfCurrentReplica;
-        let globalSublevel;
-        if (current === 'x') {
-            globalSublevel = this._xGlobalSublevel;
-        } else if (current === 'y') {
-            globalSublevel = this._yGlobalSublevel;
-        } else {
-            return assertNeverReplicaName(current);
-        }
-        await globalSublevel.put('version', version);
+        await this._computed.globalSublevel.put('version', version);
     }
 
     /**
@@ -531,23 +461,37 @@ class RootDatabaseClass {
      * @returns {Promise<void>}
      */
     async clearReplicaStorage(name) {
-        if (name === 'x') {
-            await this._xNamespaceSublevel.clear();
-            // Rebuild to reset the version-initialisation cache in the new closure.
-            this._xSchemaStorage = buildSchemaStorage(this._xNamespaceSublevel, this._xGlobalSublevel, this.version);
-            if (this.currentReplicaName() === 'x') {
-                this._identifierLookup = await loadIdentifierLookupFromGlobal(this._xGlobalSublevel);
-            }
-        } else if (name === 'y') {
-            await this._yNamespaceSublevel.clear();
-            // Rebuild to reset the version-initialisation cache in the new closure.
-            this._ySchemaStorage = buildSchemaStorage(this._yNamespaceSublevel, this._yGlobalSublevel, this.version);
-            if (this.currentReplicaName() === 'y') {
-                this._identifierLookup = await loadIdentifierLookupFromGlobal(this._yGlobalSublevel);
-            }
-        } else {
-            return assertNeverReplicaName(name);
+        const namespaceSublevel = this.replicaNamespaceSublevel(name);
+        const globalSublevel = this.replicaGlobalSublevel(name);
+        await namespaceSublevel.clear();
+        if (this.currentReplicaName() === name) {
+            this._computed = {
+                replicaName: name,
+                namespaceSublevel,
+                globalSublevel,
+                schemaStorage: buildSchemaStorage(namespaceSublevel, globalSublevel, this.version),
+                identifierLookup: await loadIdentifierLookupFromGlobal(globalSublevel),
+            };
         }
+    }
+
+    /**
+     * @param {ReplicaName} name
+     * @returns {SchemaSublevelType}
+     */
+    replicaNamespaceSublevel(name) {
+        if (name === 'x' || name === 'y') {
+            return this.db.sublevel(name, { valueEncoding: 'json' });
+        }
+        return assertNeverReplicaName(name);
+    }
+
+    /**
+     * @param {ReplicaName} name
+     * @returns {GlobalSublevelType}
+     */
+    replicaGlobalSublevel(name) {
+        return this.replicaNamespaceSublevel(name).sublevel('global', { valueEncoding: 'json' });
     }
 
     /**

--- a/backend/tests/database.test.js
+++ b/backend/tests/database.test.js
@@ -528,13 +528,11 @@ describe('generators/database', () => {
                 expect(db.currentReplicaName()).toBe('x');
 
                 const xStorage = db.schemaStorageForReplica('x');
-                const yStorage = db.schemaStorageForReplica('y');
-
                 await db.setCurrentReplicaPointer('y');
 
                 expect(db.currentReplicaName()).toBe('y');
-                expect(db.getSchemaStorage()).toBe(yStorage);
                 expect(db.getSchemaStorage()).not.toBe(xStorage);
+                expect(db.schemaStorageForReplica('y')).not.toBe(xStorage);
 
                 await db.close();
             } finally {

--- a/docs/pr1335-review1-.md
+++ b/docs/pr1335-review1-.md
@@ -1,0 +1,34 @@
+# PR #1335 Review 1 — Problem Analysis
+
+## Feedback theme
+The feedback identifies a state-management design flaw in `root_database.js`: active replica state is spread across multiple mutable fields, so replica switching is not modeled as one coherent transactional state transition.
+
+## Precise problem
+Current design keeps duplicate mutable runtime state:
+- active replica name cache
+- per-replica cached namespace/global sublevels
+- per-replica cached schema storages
+- separately cached identifier lookup
+
+This fragmentation creates risk of divergence (e.g., pointer changed but some dependent fields stale).
+
+## Required architectural correction
+Use a single active-state object (`this._computed`) as the one mutable reference for all active replica-derived runtime handles:
+- replicaName
+- namespaceSublevel
+- globalSublevel
+- schemaStorage
+- identifierLookup
+
+Replica switch must be atomic in structure:
+1. validate name
+2. derive candidate sublevels from db
+3. build candidate schema storage
+4. load candidate identifier lookup
+5. persist pointer
+6. commit by replacing `this._computed` once
+
+## Storage model distinction
+- Physical DB still uses two replica namespaces (`x`, `y`).
+- Runtime object should cache only the active bundle.
+- Inactive replica handles should be derived on demand from helper methods, not kept as permanent parallel cached fields.

--- a/docs/pr1335-review1-impl.md
+++ b/docs/pr1335-review1-impl.md
@@ -1,0 +1,49 @@
+# PR #1335 Review 1 — Detailed Implementation Plan
+
+## 1) Data model updates in `root_database.js`
+- Remove mutable fields for:
+  - cached replica name
+  - x/y namespace/global sublevels
+  - x/y schema storages
+  - standalone active identifier lookup
+- Add `_computed` as the only mutable active-state reference.
+
+## 2) Constructor rewrite
+- Keep stable fields: `db`, `_rootMetaSublevel`, `version`, `_seed`.
+- Build initial active bundle from `currentReplicaName`:
+  - namespace/global handles from helper methods
+  - schema storage from `buildSchemaStorage`
+  - empty identifier lookup as initial in-memory map
+
+## 3) Helper methods
+- Add helper methods for per-replica derived handles:
+  - `replicaNamespaceSublevel(name)`
+  - `replicaGlobalSublevel(name)`
+- Keep `schemaStorageForReplica(name)` as on-demand builder using helpers.
+
+## 4) Active-access method rewrites
+- `currentReplicaName()` returns `_computed.replicaName`.
+- lookup getters/setters and translation methods use `_computed.identifierLookup`.
+- `getSchemaStorage`, `getGlobalVersion`, `setGlobalVersion` use `_computed` fields.
+
+## 5) Atomic switch rewrite
+- In `setCurrentReplicaPointer(name)`:
+  1. validate
+  2. derive candidate sublevels
+  3. build candidate schema storage
+  4. load candidate identifier lookup
+  5. persist `current_replica`
+  6. assign `_computed` once
+- Preserve `SwitchReplicaError` wrapping behavior.
+
+## 6) Clear-storage behavior
+- Clear derived namespace for target replica.
+- If cleared replica is active, rebuild and replace `_computed` to reset storage closure state and refresh active lookup.
+
+## 7) Validation loop
+- Run:
+  - `npm install`
+  - `npm test`
+  - `npm run static-analysis`
+  - `npm run build`
+- Fix any failures until all pass.

--- a/docs/pr1335-review1-strat.md
+++ b/docs/pr1335-review1-strat.md
@@ -1,0 +1,23 @@
+# PR #1335 Review 1 — Refactor Strategy
+
+## Guiding principles
+1. **Single source of truth**: only `_computed` represents active runtime replica state.
+2. **Atomic commit point**: replica switches mutate active state exactly once, after all candidate computation + persistence succeeds.
+3. **On-demand inactive access**: derive inactive handles from `db` and replica name when needed.
+4. **No behavior shortcuts**: keep two-namespace semantics and migration capabilities intact.
+
+## Strategy steps
+1. Replace fragmented mutable fields with `_computed` bundle.
+2. Introduce deterministic helpers:
+   - `replicaNamespaceSublevel(name)`
+   - `replicaGlobalSublevel(name)`
+   - `schemaStorageForReplica(name)` from helpers.
+3. Refactor read/write methods (`getSchemaStorage`, global version methods, lookup methods) to use `_computed`.
+4. Refactor `setCurrentReplicaPointer(name)` to fully stage candidate bundle before persisting pointer and committing `_computed`.
+5. Keep `clearReplicaStorage(name)` compatible with atomic model by rebuilding active `_computed` only when cleared replica is active.
+6. Validate with static-analysis and full tests, then iterate on failures.
+
+## Expected outcomes
+- Eliminates divergence between active pointer and related cached handles.
+- Makes switch logic transactional by structure.
+- Preserves ability to work with both physical replicas.

--- a/docs/pr1335.md
+++ b/docs/pr1335.md
@@ -1,0 +1,25 @@
+# PR #1335 Study Notes
+
+## PR identity
+- PR: https://github.com/ottojung/volodyslav/pull/1335
+- Title: **Switch IncrementalGraph persistence and migration to node identifiers**.
+- Scope: move IncrementalGraph persistence from semantic/node-key addressing to identifier-native storage, and preserve migration correctness.
+
+## High-level conceptual change
+- The storage boundary is shifted so persistence code works on **NodeIdentifier** as the canonical key.
+- Key-to-identifier translation is intended to happen at the runtime boundary (IncrementalGraph operations), not inside low-level storage.
+- Migration paths are updated so legacy snapshots can be restored into the identifier model.
+
+## Architectural intent captured in PR discussion
+- `graph_storage.js` should not depend on `NodeKey` concepts.
+- Tests should be preserved or rewritten equivalently, not removed.
+- Static-analysis and test regressions are expected to be fixed directly.
+
+## Low-level choices visible from conversation
+- Multiple commits focused on: identifier-native persistence, legacy migration handling, documentation restoration, and follow-up refactors.
+- Reviewer comments pushed for strict layering: storage purity, comments/type docs restoration, and full test integrity.
+
+## Why this PR matters
+- It reduces identifier/key conversion churn.
+- It aligns persisted shape with runtime identity semantics.
+- It prepares the codebase for safer migration and replica workflows by narrowing responsibilities per layer.


### PR DESCRIPTION
### Motivation
- Eliminate duplicated mutable runtime state in `RootDatabase` that risked divergence between the active replica pointer and its dependent handles.
- Make replica switching transactional: compute candidate handles and lookup first, persist the pointer, then install the new active bundle in a single assignment.

### Description
- Replace per-replica cached fields with a single active-state bundle `this._computed` that contains `replicaName`, `namespaceSublevel`, `globalSublevel`, `schemaStorage`, and `identifierLookup` in `backend/src/generators/incremental_graph/database/root_database.js`.
- Rework `constructor` to build the initial `_computed` bundle for the starting replica using `replicaNamespaceSublevel` and `replicaGlobalSublevel` helpers and `buildSchemaStorage`.
- Make `setCurrentReplicaPointer(name)` atomic by staging `namespaceSublevel`, `globalSublevel`, `schemaStorage`, and `identifierLookup` before persisting `_meta/current_replica` and then committing `_computed` in one assignment; preserve the `SwitchReplicaError` wrapper.
- Provide on-demand helpers `replicaNamespaceSublevel(name)` and `replicaGlobalSublevel(name)` and change `schemaStorageForReplica(name)` to build a storage instance on demand rather than keeping `_x`/`_y` cached storages; update `clearReplicaStorage(name)` to rebuild `_computed` only when the cleared replica is active.
- Update tests and add documentation: changed expectations in `backend/tests/database.test.js` and added `docs/pr1335.md`, `docs/pr1335-review1-.md`, `docs/pr1335-review1-strat.md`, and `docs/pr1335-review1-impl.md` describing the PR, the feedback, strategy, and implementation plan.

### Testing
- Installed dependencies with `npm install` (completed successfully).
- Ran targeted unit tests `npx jest backend/tests/database.test.js --runInBand`, which passed (all tests in that file succeeded).
- Ran static analysis with `npm run static-analysis` (TypeScript + ESLint), which passed after fixes to types and tests.
- Built the frontend with `npm run build`, which completed successfully.
- Note: a full `npm test` run was attempted in this environment but did not complete reliably; focused automated verification (targeted tests, static analysis, and build) all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c0a01c4f8832ebb51b9687c4e9519)