### PR TITLE
Fix identifier lookup durability, allocation retries, and pull normalization (PR1335 review fixes)

### DIFF
--- a/backend/src/generators/incremental_graph/database/sync_merge.js
+++ b/backend/src/generators/incremental_graph/database/sync_merge.js
@@ -592,8 +592,7 @@ async function mergeHostIntoReplica(logger, rootDatabase, hostname) {
                 : makeEmptyIdentifierLookup();
         const mergedLookup = mergeIdentifierLookups(targetLookup, hostLookup);
 
-        pendingOps.push(T.global.putOp('identifiers_keys_map', serializeIdentifierLookup(mergedLookup)));
-        await flushPendingOps();
+        await T.global.put('identifiers_keys_map', serializeIdentifierLookup(mergedLookup));
 
         // Gently update revdeps using the merged inputs map.  Only changed entries
         // are written; stale entries are deleted.  unifyRevdeps uses mergedInputsMap

--- a/backend/src/generators/incremental_graph/identifier_resolver.js
+++ b/backend/src/generators/incremental_graph/identifier_resolver.js
@@ -70,11 +70,11 @@ function getActiveLookup(rootDatabase) {
  * @returns {NodeIdentifier}
  */
 function allocateIdentifier(rootDatabase, lookup, nodeKey) {
-    return allocateNodeIdentifier(lookup, nodeKey, () => {
+    return allocateNodeIdentifier(lookup, nodeKey, (attempt) => {
         if (typeof rootDatabase.generateNodeIdentifier === "function") {
             return rootDatabase.generateNodeIdentifier();
         }
-        return deterministicNodeIdentifierFromNodeKey(nodeKey);
+        return deterministicNodeIdentifierFromNodeKey(nodeKey, attempt);
     });
 }
 

--- a/backend/src/generators/incremental_graph/pull.js
+++ b/backend/src/generators/incremental_graph/pull.js
@@ -156,7 +156,7 @@ async function internalPullByNodeIdentifierWithStatusDuringPull(
     checkArity(compiledNode, bindings);
 
     const concreteNode = incrementalGraph.getOrCreateConcreteNode(
-        nodeKeyStr,
+        nodeKeyIdentifier,
         compiledNode,
         bindings
     );
@@ -177,7 +177,7 @@ async function internalPullByNodeIdentifierWithStatusDuringPull(
             const result = await batch.values.get(outputIdentifier);
             if (result === undefined) {
                 throw new Error(
-                    `Impossible: up-to-date node has no stored value: ${nodeIdentifierToString(nodeKeyStr)}`
+                    `Impossible: up-to-date node has no stored value: ${nodeIdentifierToString(nodeKeyIdentifier)}`
                 );
             }
             return { value: result, status: "cached" };
@@ -193,7 +193,7 @@ async function internalPullByNodeIdentifierWithStatusDuringPull(
             identifierResolver
         );
     };
-    return withPullNodeMutex(incrementalGraph.sleeper, nodeKeyStr, () =>
+    return withPullNodeMutex(incrementalGraph.sleeper, nodeKeyIdentifier, () =>
         incrementalGraph.withIdentifierBatch(identifierResolver, run)
     );
 }

--- a/docs/pr1335-review1-.md
+++ b/docs/pr1335-review1-.md
@@ -1,0 +1,50 @@
+# PR #1335 Review Thread 1 — Problem Analysis
+
+Thread: `pullrequestreview-4323287876`
+
+This review identifies **three correctness defects** in the current implementation after the identifier migration.
+
+## 1) Lost `identifiers_keys_map` persistence in sync merge
+
+### Where
+`backend/src/generators/incremental_graph/database/sync_merge.js`
+
+### Problem
+The code enqueues the merged global lookup write with `pendingOps.push(...)` and then calls `await flushPendingOps()`. The helper flushes only when `pendingOps.length >= RAW_BATCH_CHUNK_SIZE`. For a single global write, this threshold is usually not met, meaning the write can remain buffered and never persisted before subsequent steps (`unifyRevdeps`, replica-pointer switch).
+
+### Why this is serious
+- Active replica may switch while lookup map write is missing.
+- Identifier resolution after merge can observe stale/incomplete key↔id mapping.
+- This can produce latent data corruption symptoms (wrong lookup misses, unnecessary reallocation, or semantic/id drift).
+
+## 2) Deterministic allocation retries ignore attempt index
+
+### Where
+`backend/src/generators/incremental_graph/identifier_resolver.js`
+
+### Problem
+The allocator passes `() => ...` callback into `allocateNodeIdentifier(...)`, ignoring the `attempt` argument used by collision retries. In deterministic fallback mode (no `generateNodeIdentifier` implementation), retries generate the same candidate repeatedly and fail even though attempt-indexed deterministic alternatives are available.
+
+### Why this is serious
+- Collision handling is effectively disabled in fallback mode.
+- Behavior becomes brittle for tests, compatibility doubles, and any environment without random-id generator wiring.
+
+## 3) Pull-by-identifier path inconsistently uses resolved semantic key
+
+### Where
+`backend/src/generators/incremental_graph/pull.js`
+
+### Problem
+`requireNodeKey(nodeKeyStr)` resolves semantic key from identifier, but downstream concrete-node cache creation and mutex scoping still use original `nodeKeyStr` value. If caller passes persisted identifier, downstream logic can treat identifier string as semantic key material.
+
+### Why this is serious
+- Can poison concrete-node cache keys.
+- Can create duplicate/incorrect node instantiations for same semantic node.
+- Can cause wrong mapping during `getOrAllocateNodeIdentifier(concreteNode.output)`.
+- Mutex key inconsistency can reduce deduplication of concurrent pulls of same semantic node.
+
+## Root cause pattern
+Across all three comments, the theme is **boundary consistency**:
+- writes must be committed at durability boundaries,
+- retry contracts must propagate fully,
+- key-vs-identifier normalization must be applied once and used consistently afterward.

--- a/docs/pr1335-review1-impl.md
+++ b/docs/pr1335-review1-impl.md
@@ -1,0 +1,58 @@
+# PR #1335 Review Thread 1 — Detailed Implementation Plan
+
+## Step 1: Fix merge durability for identifier lookup persistence
+
+### File
+`backend/src/generators/incremental_graph/database/sync_merge.js`
+
+### Change
+- In `hasChanges` branch, after computing `mergedLookup`, replace:
+  - `pendingOps.push(T.global.putOp(...))` + `flushPendingOps()`
+- with:
+  - `await T.global.put(...)`
+
+### Expected effect
+- Guarantees `identifiers_keys_map` persistence immediately and unconditionally before `unifyRevdeps()` and `setCurrentReplicaPointer()`.
+
+## Step 2: Fix allocation retry callback plumbing
+
+### File
+`backend/src/generators/incremental_graph/identifier_resolver.js`
+
+### Change
+- Update allocator callback from `() =>` to `(attempt) =>`.
+- Route fallback generation through `deterministicNodeIdentifierFromNodeKey(nodeKey, attempt)`.
+
+### Expected effect
+- Retry attempts produce distinct deterministic candidates under collisions.
+
+## Step 3: Normalize semantic key usage in pull flow
+
+### File
+`backend/src/generators/incremental_graph/pull.js`
+
+### Change
+- In `internalPullByNodeIdentifierWithStatusDuringPull(...)`, after resolution:
+  - use resolved `nodeKeyIdentifier` when calling `getOrCreateConcreteNode(...)`.
+  - use resolved `nodeKeyIdentifier` for `withPullNodeMutex(...)` key.
+  - use resolved `nodeKeyIdentifier` in invariant error message for missing cached value.
+
+### Expected effect
+- Avoids treating persisted identifier as semantic key in concrete-node and mutex paths.
+
+## Step 4: Execute validation workflow
+
+Run in order:
+1. `npm install`
+2. Focused tests:
+   - `npx jest backend/tests/identifier_resolver.test.js`
+   - `npx jest backend/tests/sync_merge.test.js`
+3. Full validation:
+   - `npm test`
+   - `npm run static-analysis`
+   - `npm run build`
+
+## Step 5: Commit and PR metadata
+
+- Commit all document + code updates with a message describing review-thread fixes.
+- Create PR message via `make_pr` summarizing defects addressed and validation evidence.

--- a/docs/pr1335-review1-strat.md
+++ b/docs/pr1335-review1-strat.md
@@ -1,0 +1,41 @@
+# PR #1335 Review Thread 1 — Remediation Strategy
+
+## Guiding principles
+
+1. **Durability before phase transitions**
+   Any global-lookup mutation must be durably written before revdep rewrite and replica pointer mutation.
+
+2. **Contract fidelity**
+   If an API provides retry-attempt state (`attempt`), pass it through exactly where deterministic fallback logic depends on it.
+
+3. **Single normalization point**
+   Pull entrypoints receiving “identifier-or-key” should normalize once and then use the normalized semantic form consistently in cache and synchronization paths.
+
+4. **Minimal blast radius**
+   Keep changes local to commented paths; avoid incidental refactors while preserving behavior elsewhere.
+
+## Strategic changes
+
+### A) Sync merge durability fix
+- Replace buffered pending-op usage for `identifiers_keys_map` with an explicit immediate `T.batch([putOp])` write.
+- This removes chunk-threshold dependence for this critical singleton write.
+
+### B) Allocation retry propagation fix
+- Update callback signature to `(attempt) => ...`.
+- Pass `attempt` to deterministic fallback derivation.
+- Keep random generator path behavior unchanged.
+
+### C) Pull key/identifier consistency fix
+- Continue tolerant resolution (`try requireNodeKey` else fallback).
+- After resolution, use normalized value for:
+  - concrete-node cache key,
+  - pull mutex key,
+  - related invariant error message context.
+
+## Verification strategy
+
+1. Run focused tests touching modified units (`identifier_resolver`, `sync_merge`).
+2. Run full test suite.
+3. Run static analysis.
+4. Run build.
+5. If failures occur, iterate only with principled fixes (no disabling tests/lints, no bypass shortcuts).

--- a/docs/pr1335.md
+++ b/docs/pr1335.md
@@ -1,0 +1,55 @@
+# PR #1335 — Switch IncrementalGraph persistence and migration to node identifiers
+
+## High-level intent
+PR #1335 moves IncrementalGraph persistence from semantic `NodeKey` strings (serialized `{head,args}`) to compact persisted `NodeIdentifier` keys. Conceptually, this decouples:
+
+- **runtime semantics** (graph node meaning = `NodeKey`), from
+- **storage addressing** (on-disk identity = `NodeIdentifier`).
+
+The migration direction is to keep semantic-key resolution in IncrementalGraph runtime boundaries, while keeping lower storage/database layers identifier-native.
+
+## Conceptual architecture changes
+
+1. **Identifier lookup as global metadata**
+   - Adds/extends `identifiers_keys_map` in global storage as the bidirectional bridge between semantic node keys and persisted identifiers.
+   - Lookup is merged and persisted during graph operations and sync flows.
+
+2. **Identifier-native graph storage**
+   - Graph tables (`inputs`, `freshness`, `values`, `timestamps`, `revdeps`) operate on identifiers.
+   - Serialization and render/import paths are updated to include identifier-keyed graph records and global lookup state.
+
+3. **Migration correctness focus**
+   - Existing datasets keyed by semantic keys are migrated into identifier-keyed storage.
+   - Migration preserves revdep ordering/integrity and timestamp/freshness state.
+
+4. **IncrementalGraph resolver boundary**
+   - Introduces resolver behavior that maps key↔id per operation and amortizes repeated conversions.
+   - Pull/recompute pipelines call through resolver to avoid contaminating identifier-native persistence logic with semantic-key addressing.
+
+## Low-level implementation choices in the PR
+
+- Introduces/expands `identifier_lookup` utilities (`nodeKeyToId`, `nodeIdToKey`, serialization, merge behavior, deterministic fallback allocation).
+- Adds resolver object lifecycle (`makeIdentifierResolver`) with:
+  - per-operation caches,
+  - deferred global lookup persistence,
+  - committed lookup publication to root database.
+- Updates merge logic (`sync_merge`) to merge host/target identifier lookup state while merging graph node records.
+- Extends database rendering and test fixtures to round-trip `identifiers_keys_map` and identifier-addressed data.
+- Adds/updates migration tests for revdeps ordering, timestamps behavior, and identifier mapping continuity.
+
+## Tradeoffs and rationale
+
+- **Pros**
+  - Smaller/more stable persisted keys.
+  - Cleaner separation of semantic model vs storage model.
+  - Better future freedom for key-shape evolution.
+- **Costs**
+  - Extra resolver complexity and consistency requirements.
+  - Merge and pull paths must be precise about “semantic key vs identifier” interpretation.
+  - More nuanced migration/backfill logic.
+
+## Known risk surfaces highlighted by review feedback
+
+- Buffered writes can be dropped if global lookup updates rely on chunked batch flush helper paths incorrectly.
+- Identifier allocation retry callback must consume retry attempts for deterministic fallback collision handling.
+- Pull-by-identifier entry points must consistently normalize semantic-key usage for concrete-node caching and mutex scoping.


### PR DESCRIPTION
### Motivation

- Address correctness defects identified in review thread `pullrequestreview-4323287876` affecting identifier lookup durability during merges, deterministic allocation retry behavior, and key-vs-identifier normalization in pull paths. 
- Ensure identifier ↔ semantic-key boundaries are consistent so storage remains identifier-native while runtime uses semantic keys. 
- Prevent latent data corruption and duplicate allocations by fixing write durability, retry propagation, and caching/mutex keying.

### Description

- Persist merged global lookup immediately by replacing the buffered `pendingOps` write with an unconditional `T.global.put('identifiers_keys_map', ...)` in `backend/src/generators/incremental_graph/database/sync_merge.js` so the lookup is durable before `unifyRevdeps()` and replica-pointer changes. 
- Propagate allocation retry attempts by changing the allocate callback to accept `(attempt)` and call `deterministicNodeIdentifierFromNodeKey(nodeKey, attempt)` in `backend/src/generators/incremental_graph/identifier_resolver.js`. 
- Normalize the pull entry flow to consistently use the resolved semantic key (`nodeKeyIdentifier`) for concrete-node creation, mutex scoping, and invariant messages in `backend/src/generators/incremental_graph/pull.js`. 
- Add documentation artifacts describing the PR, the review analysis, the remediation strategy, and the implementation plan at `docs/pr1335.md`, `docs/pr1335-review1-.md`, `docs/pr1335-review1-strat.md`, and `docs/pr1335-review1-impl.md`.

### Testing

- Ran `npm install` successfully to prepare the workspace. 
- Ran focused unit tests `npx jest backend/tests/identifier_resolver.test.js` and `npx jest backend/tests/sync_merge.test.js`, both of which passed. 
- Ran the full test suite with `npm test`; an initial run hit a flaky timeout in an unrelated test but a subsequent run completed successfully with all suites passing. 
- Ran static analysis with `npm run static-analysis` and the build with `npm run build`, both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cd7f6213c832e8ab76986a4d3dbc4)