### PR TITLE
Fix sync identifier collisions and persist legacy-migration mappings (PR1335 followups)

### DIFF
--- a/backend/src/generators/incremental_graph/database/identifier_lookup.js
+++ b/backend/src/generators/incremental_graph/database/identifier_lookup.js
@@ -234,6 +234,25 @@ function mergeIdentifierLookups(base, overlay) {
     return merged;
 }
 
+
+/**
+ * Reconcile overlay lookup so semantic keys present in base reuse base identifiers.
+ * @param {IdentifierLookup} base
+ * @param {IdentifierLookup} overlay
+ * @returns {IdentifierLookup}
+ */
+function reconcileLookupKeysToBase(base, overlay) {
+    const reconciled = cloneIdentifierLookup(overlay);
+    for (const [, nodeKey] of base.idToKey.entries()) {
+        const baseIdentifier = nodeKeyToIdFromLookup(base, nodeKey);
+        const overlayIdentifier = nodeKeyToIdFromLookup(reconciled, nodeKey);
+        if (baseIdentifier !== undefined && overlayIdentifier !== undefined && baseIdentifier !== overlayIdentifier) {
+            deleteIdentifierMappingForNodeKey(reconciled, nodeKey);
+            setIdentifierMapping(reconciled, baseIdentifier, nodeKey);
+        }
+    }
+    return reconciled;
+}
 /**
  * Allocate a fresh identifier for a node key, retrying on collisions.
  * If the key already has an identifier, the existing identifier is reused.
@@ -308,6 +327,7 @@ module.exports = {
     makeIdentifierLookup,
     nodeIdToKeyFromLookup,
     nodeKeyToIdFromLookup,
+    reconcileLookupKeysToBase,
     requireNodeIdentifierForKey,
     requireNodeKeyForIdentifier,
     serializeIdentifierLookup,

--- a/backend/src/generators/incremental_graph/database/sync_merge.js
+++ b/backend/src/generators/incremental_graph/database/sync_merge.js
@@ -53,6 +53,7 @@ const {
     makeEmptyIdentifierLookup,
     makeIdentifierLookup,
     mergeIdentifierLookups,
+    reconcileLookupKeysToBase,
     serializeIdentifierLookup,
 } = require('./identifier_lookup');
 
@@ -572,8 +573,7 @@ async function mergeHostIntoReplica(logger, rootDatabase, hostname) {
     }
 
     const decisionValues = [...decisions.values()];
-    const kept = decisionValues.filter(d => d === 'keep').length, taken = decisionValues.filter(d => d === 'take').length, invalidated = decisionValues.filter(d => d === 'invalidate').length;
-    const hasChanges = taken + invalidated > 0;
+    const kept = decisionValues.filter(d => d === 'keep').length, taken = decisionValues.filter(d => d === 'take').length, invalidated = decisionValues.filter(d => d === 'invalidate').length, hasChanges = taken + invalidated > 0;
 
     if (hasChanges) {
         const hostIdentifierValue = await H.global.get('identifiers_keys_map');
@@ -589,7 +589,7 @@ async function mergeHostIntoReplica(logger, rootDatabase, hostname) {
             : Array.isArray(targetIdentifierValue)
                 ? makeIdentifierLookup(targetIdentifierValue)
                 : makeEmptyIdentifierLookup();
-        const mergedLookup = mergeIdentifierLookups(targetLookup, hostLookup);
+        const mergedLookup = mergeIdentifierLookups(targetLookup, reconcileLookupKeysToBase(targetLookup, hostLookup));
 
         pendingOps.push(T.global.putOp('identifiers_keys_map', serializeIdentifierLookup(mergedLookup)));
         await flushPendingOps();

--- a/backend/src/generators/incremental_graph/migration_runner.js
+++ b/backend/src/generators/incremental_graph/migration_runner.js
@@ -15,6 +15,7 @@ const {
     allocateNodeIdentifier,
     deterministicNodeIdentifierFromNodeKey,
     IDENTIFIERS_KEY,
+    makeEmptyIdentifierLookup,
     makeIdentifierLookup,
     nodeIdentifierFromString,
     nodeIdentifierToString,
@@ -23,6 +24,7 @@ const {
     requireNodeKeyForIdentifier,
     serializeNodeKey,
     serializeIdentifierLookup,
+    setIdentifierMapping,
     stringToNodeIdentifier,
     stringToNodeName,
     getRootDatabase,
@@ -172,15 +174,14 @@ async function makeMigrationKeyPlan(prevStorage, materializedNodes) {
         };
     }
 
-    /** @type {Array<[import('./database/types').NodeIdentifier, NodeIdentifier]>} */
-    const outputEntries = [];
+    const lookup = makeEmptyIdentifierLookup();
     /** @type {Map<string, NodeIdentifier>} */
     const decisionKeyByOutputKey = new Map();
     for (const nodeKey of materializedNodes) {
         const canonicalKey = canonicalizeMigrationNodeKey(nodeKey);
         const nodeIdentifier = deterministicNodeIdentifierFromNodeKey(canonicalKey);
+        setIdentifierMapping(lookup, nodeIdentifier, canonicalKey);
         const outputKey = stringToNodeIdentifier(nodeIdentifierToString(nodeIdentifier));
-        outputEntries.push([nodeIdentifier, canonicalKey]);
         decisionKeyByOutputKey.set(String(outputKey), nodeKey);
     }
     return {
@@ -189,14 +190,21 @@ async function makeMigrationKeyPlan(prevStorage, materializedNodes) {
         },
         keyToOutputKey(nodeKey) {
             const canonicalKey = canonicalizeMigrationNodeKey(nodeKey);
-            return stringToNodeIdentifier(
-                nodeIdentifierToString(deterministicNodeIdentifierFromNodeKey(canonicalKey))
+            const nodeIdentifier = allocateNodeIdentifier(
+                lookup,
+                canonicalKey,
+                (attempt) => deterministicNodeIdentifierFromNodeKey(canonicalKey, attempt)
             );
+            const outputKey = stringToNodeIdentifier(nodeIdentifierToString(nodeIdentifier));
+            decisionKeyByOutputKey.set(String(outputKey), nodeKey);
+            return outputKey;
         },
         outputKeyToDecisionKey(outputKey) {
             return decisionKeyByOutputKey.get(String(outputKey)) ?? stringToNodeIdentifier(String(outputKey));
         },
-        outputEntries: serializeIdentifierLookup(makeIdentifierLookup(outputEntries)),
+        get outputEntries() {
+            return serializeIdentifierLookup(lookup);
+        },
     };
 }
 

--- a/backend/tests/migration_runner.test.js
+++ b/backend/tests/migration_runner.test.js
@@ -1493,4 +1493,40 @@ describe("retry after failure", () => {
 
         expect(mock.setCurrentReplicaPointerCalled).toBe(true);
     });
+
+    test("legacy migration persists identifier mappings for nodes created during callback", async () => {
+        const capabilities = await getTestCapabilities();
+        const previousStorage = makeSchemaStorage();
+        const currentStorage = makeSchemaStorage();
+        const nodeA = toJsonKey("A");
+        const nodeB = toJsonKey("B");
+
+        await previousStorage.inputs.put(nodeA, { inputs: [], inputCounters: [] });
+        await previousStorage.values.put(nodeA, { type: "all_events", events: [] });
+        await previousStorage.freshness.put(nodeA, "up-to-date");
+
+        const { yStorage } = makeYDb(currentStorage);
+        const { rootDatabase } = makeRootDatabaseMock({
+            prevVersion: "previous",
+            currentVersion: "current",
+            xStorage: previousStorage,
+            yStorage,
+        });
+
+        const nodeDefs = [
+            { output: "A", inputs: [], computor: async () => ({ type: "all_events", events: [] }), isDeterministic: true, hasSideEffects: false },
+            { output: "B", inputs: [], computor: async () => ({ type: "all_events", events: [] }), isDeterministic: true, hasSideEffects: false },
+        ];
+
+        await runMigration(capabilities, rootDatabase, nodeDefs, async (storage) => {
+            await storage.create(nodeB, async () => ({ type: "all_events", events: [] }));
+            await storage.keep(nodeA);
+        });
+
+        const keyMap = await currentStorage.global.get('identifiers_keys_map');
+        const persistedKeys = new Set((keyMap ?? []).map((entry) => entry[1]));
+        expect(persistedKeys.has(nodeA)).toBe(true);
+        expect(persistedKeys.has(nodeB)).toBe(true);
+    });
+
 });

--- a/backend/tests/sync_merge.test.js
+++ b/backend/tests/sync_merge.test.js
@@ -473,4 +473,38 @@ describe('mergeHostIntoReplica', () => {
             if (db) await db.close();
         }
     });
+
+    test('reconciles identifier collisions for same semantic key before lookup merge', async () => {
+        const capabilities = getTestCapabilities();
+        let db;
+        try {
+            db = await getRootDatabase(capabilities);
+            const logger = makeLogger();
+            const hostname = 'peer';
+            const appVersionStr = db.version;
+            await db.setGlobalVersion(appVersionStr);
+            await db.setHostnameGlobal(hostname, 'version', appVersionStr);
+
+            const nodeA = nk('same-key');
+            const localValue = { value: { id: 'local', type: 'test', description: 'local value' }, isDirty: false };
+            const remoteValue = { value: { id: 'remote', type: 'test', description: 'remote value' }, isDirty: false };
+
+            const L = db.schemaStorageForReplica('x');
+            await writeNode(L, nodeA, TS1, [], localValue);
+            await L.global.put('identifiers_keys_map', [['aaaaaaaaa', nodeA]]);
+
+            const H = db.hostnameSchemaStorage(hostname);
+            await writeNode(H, nodeA, TS2, [], remoteValue);
+            await H.global.put('identifiers_keys_map', [['bbbbbbbbb', nodeA]]);
+
+            db = await mergeAndReopenIfSwitched(capabilities, logger, db, hostname);
+
+            const active = db.schemaStorageForReplica(db.currentReplicaName());
+            await expect(active.global.get('identifiers_keys_map')).resolves.toEqual([['aaaaaaaaa', nodeA]]);
+            await expect(active.values.get(nodeA)).resolves.toEqual(remoteValue);
+        } finally {
+            if (db) await db.close();
+        }
+    });
+
 });

--- a/docs/pr1335-review1-impl.md
+++ b/docs/pr1335-review1-impl.md
@@ -1,0 +1,59 @@
+# Detailed implementation plan for PR #1335 review set 1
+
+## 1) Sync reconciliation implementation
+### File
+`backend/src/generators/incremental_graph/database/sync_merge.js`
+
+### Steps
+1. Import lookup helpers needed for controlled rewrites:
+   - `nodeKeyToIdFromLookup`
+   - `deleteIdentifierMappingForNodeKey`
+   - `setIdentifierMapping`
+2. Add helper `reconcileHostLookupToTarget(targetLookup, hostLookup)`:
+   - Clone host lookup.
+   - Iterate semantic keys present in target.
+   - If same semantic key exists in host under different identifier, remove host mapping and set mapping to target identifier.
+3. At merge point:
+   - Build `reconciledHostLookup`.
+   - Call `mergeIdentifierLookups(targetLookup, reconciledHostLookup)`.
+
+### Expected behavior
+- No `IdentifierLookupError` for benign same-key identifier divergence.
+- Merged lookup preserves target identifiers for overlapping semantic keys.
+
+## 2) Legacy migration mapping persistence implementation
+### File
+`backend/src/generators/incremental_graph/migration_runner.js`
+
+### Steps
+1. In legacy branch (no persisted `identifiers_keys_map`), initialize mutable `lookup = makeEmptyIdentifierLookup()`.
+2. Seed lookup with deterministic mappings for preexisting materialized nodes.
+3. Update `keyToOutputKey` to allocate through `allocateNodeIdentifier(lookup, canonicalKey, deterministic...)`.
+4. Keep `decisionKeyByOutputKey` updated for all allocations.
+5. Replace static `outputEntries` array with getter returning `serializeIdentifierLookup(lookup)`.
+
+### Expected behavior
+- Any node touched/created during migration and assigned an output identifier has a persisted mapping.
+
+## 3) Tests
+### Sync regression test
+- Add test in `backend/tests/sync_merge.test.js`:
+  - Local and host both contain same semantic node key.
+  - Each has distinct identifier mapping.
+  - Merge should succeed and persisted `identifiers_keys_map` should converge to target identifier mapping.
+
+### Migration regression test
+- Add test in `backend/tests/migration_runner.test.js`:
+  - Legacy source without identifier map.
+  - Migration callback creates new node via `storage.create(...)`.
+  - Output `identifiers_keys_map` includes both original and newly created semantic keys.
+
+## 4) Validation commands
+1. `npm install`
+2. Focused tests:
+   - `npx jest backend/tests/sync_merge.test.js`
+   - `npx jest backend/tests/migration_runner.test.js`
+3. Full checks:
+   - `npm test`
+   - `npm run static-analysis`
+   - `npm run build`

--- a/docs/pr1335-review1-strat.md
+++ b/docs/pr1335-review1-strat.md
@@ -1,0 +1,26 @@
+# Strategy to address PR #1335 review feedback (review set 1)
+
+## Principles
+1. Preserve convergence under benign concurrent materialization.
+2. Preserve strict bijection invariants at persistence boundaries.
+3. Ensure migration output is self-contained and replay-stable.
+4. Avoid introducing ad-hoc exceptions to core lookup merge rules.
+
+## Strategy for sync collision handling
+- Keep `mergeIdentifierLookups` strict and invariant-focused.
+- At the sync call site, pre-reconcile host lookup against target lookup by semantic key:
+  - For each semantic key already known in target, if host maps same key to a different identifier, rewrite host mapping to target identifier.
+- Then run strict merge on reconciled host map.
+
+This confines policy (“target identifier wins for already-known semantic key”) to sync orchestration, not generic lookup primitives.
+
+## Strategy for legacy migration mapping persistence
+- Replace legacy fixed-array output entry accumulation with a mutable in-memory lookup object.
+- Route all `keyToOutputKey` allocations through `allocateNodeIdentifier` against that mutable lookup.
+- Expose `outputEntries` as a computed serialization of current lookup state (getter), so any migration-created node mapping is included automatically.
+
+## Validation strategy
+- Add regression tests for both cases:
+  - Sync succeeds and converges when host/target use different identifiers for same semantic key.
+  - Legacy migration persists mappings for nodes created during callback.
+- Run focused tests first, then full project checks.

--- a/docs/pr1335-review1.md
+++ b/docs/pr1335-review1.md
@@ -1,0 +1,31 @@
+# PR #1335 review feedback analysis (review set 1)
+
+## Feedback item 1: identifier collision reconciliation during sync
+### Problem
+Current sync merge calls `mergeIdentifierLookups(targetLookup, hostLookup)` directly. That merge enforces strict bijection and throws `IdentifierLookupError` when the same semantic key maps to different identifiers across replicas.
+
+### Why this is a real scenario
+In legitimate distributed behavior, two replicas can independently materialize the same semantic node and allocate different identifiers before synchronization.
+
+### Failure mode
+- Target: `K -> idA`
+- Host: `K -> idB`
+- Direct merge throws on conflict and aborts sync.
+
+### Regression dimension
+Under prior semantic-key persistence this converged naturally by key equality. With identifier-native persistence, failing to normalize key-level equivalence before merge causes a convergence regression.
+
+## Feedback item 2: missing persisted mappings for migration-created nodes (legacy path)
+### Problem
+When source replica lacks existing `identifiers_keys_map`, migration key planning initializes output mappings from only preexisting materialized nodes.
+
+### Failure mode
+Nodes created by `storage.create(...)` during migration receive output identifiers via `keyToOutputKey(...)`, but those mappings were not guaranteed to be appended to persisted output mapping entries in legacy path.
+
+### Consequence
+Migrated data can contain identifier-keyed records whose key↔identifier mapping is not durably stored. On subsequent operations, reallocation can produce different identifiers and orphan previously migrated values.
+
+## Severity rationale
+Both issues are P1:
+- Sync can hard-fail in normal concurrent workflows.
+- Migration can silently produce unreachable persisted data.

--- a/docs/pr1335.md
+++ b/docs/pr1335.md
@@ -1,0 +1,21 @@
+# PR #1335: Switch IncrementalGraph persistence and migration to node identifiers
+
+## High-level objective
+PR #1335 migrates IncrementalGraph persistence from semantic node-key storage to opaque node-identifier storage. The goal is to decouple durable storage keys from semantic node shape so internal representation can evolve while preserving stable persisted references.
+
+## Conceptual architecture shift
+- Introduces a persistent `identifiers_keys_map` global mapping to maintain a bijection between opaque identifiers and semantic keys.
+- Refactors storage/unification layers to treat node identifiers as the primary persisted key.
+- Adds migration-time translation logic so legacy semantic-key replicas can be upgraded into identifier-native replicas.
+- Extends synchronization paths to merge identifier lookup metadata between host and local replicas.
+
+## Important low-level choices made in the PR
+- Added dedicated identifier utilities and errors (`identifier_lookup.js`, `node_identifier.js`) for validation, deterministic allocation, and merge behavior.
+- Reworked database encoding paths to key most node-scoped sublevels by identifier-native encoded keys.
+- Updated migration runner to compute a key plan that maps decision-time keys to output identifiers and writes `identifiers_keys_map` in migrated output.
+- Changed many incremental graph call paths to operate on identifiers directly or through resolver boundaries.
+- Updated extensive test fixtures/snapshots to reflect identifier-native persisted output.
+
+## Scope and impact
+- 66 files changed, with broad impact across incremental graph runtime, database layer, synchronization, migration, and tests.
+- The risk center is convergence correctness: sync and migration must preserve identifier-key consistency while allowing concurrent host evolution.


### PR DESCRIPTION
### Motivation
- The identifier-native persistence introduced by PR #1335 can cause sync to fail when two replicas independently allocate different identifiers for the same semantic node key, and legacy migrations could omit persisting mappings for nodes created during the migration callback.
- Both of these break convergence or produce unreachable persisted data and must be fixed at the orchestration and migration-plan level while preserving strict bijection invariants in the core lookup primitives.

### Description
- Reconciled host lookup mappings before strict merging by adding `reconcileLookupKeysToBase` and using it at the sync merge site so semantic-key collisions (same key -> different ids) are rewritten to the target identifier prior to `mergeIdentifierLookups` (`backend/src/generators/incremental_graph/database/identifier_lookup.js`, `.../sync_merge.js`).
- Fixed legacy migration key planning so mappings for nodes allocated during the migration callback are recorded and persisted by using a mutable in-memory lookup, routing `keyToOutputKey` through `allocateNodeIdentifier`, and exposing `outputEntries` as a getter that serializes the lookup (`backend/src/generators/incremental_graph/migration_runner.js`).
- Added regression tests covering both scenarios: host/target collision reconciliation (`backend/tests/sync_merge.test.js`) and persistence of mappings for migration-created nodes (`backend/tests/migration_runner.test.js`).
- Added supporting documentation describing PR #1335 and this review-response: `docs/pr1335.md`, `docs/pr1335-review1.md`, `docs/pr1335-review1-strat.md`, and `docs/pr1335-review1-impl.md`.

### Testing
- Focused tests run: `npx jest backend/tests/sync_merge.test.js backend/tests/migration_runner.test.js` — passed.
- Full test suite: `npm test` — all tests passed (241/241 suites; 2682 tests in CI run here) after fixes.
- Static analysis and build: `npm run static-analysis` and `npm run build` — passed (lint/type checks and frontend build completed successfully).
- Development setup: `npm install` was executed prior to tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d1b02e434832eb7b40afb61d94509)