### PR TITLE
Document PR #1335 review and tighten InvalidComputorReturnValue naming

### DIFF
--- a/backend/src/generators/incremental_graph/errors.js
+++ b/backend/src/generators/incremental_graph/errors.js
@@ -286,28 +286,29 @@ function isSchemaOverlap(object) {
  */
 class InvalidComputorReturnValue extends Error {
     /**
-     * @param {NodeIdentifier | import('./types').NodeKeyString} nodeIdentifier
+     * @param {NodeIdentifier | import('./types').NodeKeyString} nodeIdentity
      * @param {unknown} value
      */
-    constructor(nodeIdentifier, value) {
+    constructor(nodeIdentity, value) {
         super(
-            `Computor for node '${nodeIdentifier}' returned an invalid value: ${value}. ` +
+            `Computor for node '${nodeIdentity}' returned an invalid value: ${value}. ` +
                 `Computors must return a valid ComputedValue or Unchanged, not null or undefined.`
         );
         this.name = "InvalidComputorReturnValueError";
-        this.nodeKey = nodeIdentifier;
+        this.nodeIdentifier = nodeIdentity;
+        this.nodeKey = nodeIdentity;
         this.value = value;
     }
 }
 
 /**
  * Constructs an InvalidComputorReturnValue error.
- * @param {NodeIdentifier | import('./types').NodeKeyString} nodeIdentifier
+ * @param {NodeIdentifier | import('./types').NodeKeyString} nodeIdentity
  * @param {unknown} value
  * @returns {InvalidComputorReturnValue}
  */
-function makeInvalidComputorReturnValueError(nodeIdentifier, value) {
-    return new InvalidComputorReturnValue(nodeIdentifier, value);
+function makeInvalidComputorReturnValueError(nodeIdentity, value) {
+    return new InvalidComputorReturnValue(nodeIdentity, value);
 }
 
 /**

--- a/docs/pr1335-review1-impl.md
+++ b/docs/pr1335-review1-impl.md
@@ -1,0 +1,45 @@
+# Detailed implementation plan for Review #1 follow-up
+
+## Phase 1 — Documentation and boundary tightening (this change set)
+1. Add reviewer-facing docs (this folder) to explain:
+   - high-level architecture shift,
+   - concrete risk points,
+   - principled forward strategy.
+2. Remove ambiguous internal wording where practical in touched code.
+3. Add/adjust small targeted tests if boundary behavior is modified.
+
+## Phase 2 — API boundary hardening
+1. Audit function signatures in incremental graph modules:
+   - mark each parameter as semantic key or persisted identifier.
+2. Replace mixed “stringly” boundary calls with explicit conversion helpers.
+3. Remove permissive conversion patterns where they mask domain confusion.
+
+Acceptance criteria:
+- No public/internal API claims to accept `NodeIdentifier` unless it truly supports persisted IDs.
+- Failures for missing identifier mappings are explicit (not JSON parse side-effects).
+
+## Phase 3 — Lookup mutation authority
+1. Confirm every mutation path (pull/sync/migration) routes through shared invariant helpers.
+2. Prevent direct whole-map replacement in concurrent paths unless merge policy is applied.
+3. Verify transaction rollback cannot leak in-memory uncommitted mappings.
+
+Acceptance criteria:
+- Concurrency tests prove no mapping loss under parallel pulls.
+- Failed transaction leaves in-memory lookup identical to persisted snapshot.
+
+## Phase 4 — Replica cutover + sync/migration durability checks
+1. Validate ordering: writes flush before replica pointer switch.
+2. Validate migration-created nodes always produce persisted mappings.
+3. Validate sync collision reconciliation converges deterministically.
+
+Acceptance criteria:
+- Crash/restart simulation preserves active replica consistency.
+- Merged/migrated nodes remain reachable by semantic resolution.
+
+## Phase 5 — Final verification
+Run full repository checks:
+- `npm test`
+- `npm run static-analysis`
+- `npm run build`
+
+And keep focused tests for touched modules as regression gates.

--- a/docs/pr1335-review1-strat.md
+++ b/docs/pr1335-review1-strat.md
@@ -1,0 +1,45 @@
+# Strategy to address Review #1 feedback for PR #1335
+
+## Guiding principles
+1. **Invariant first, optimization second.**
+2. **Make illegal states unrepresentable at API boundaries.**
+3. **Centralize side-effectful lookup mutations.**
+4. **Fail loudly with precise errors when identity mapping is missing/ambiguous.**
+5. **Test the behavioral contracts, not just happy paths.**
+
+## Target outcome
+A system where a maintainer can quickly answer:
+- “Is this value a semantic key or a persisted identifier?”
+- “Where do mappings get committed?”
+- “What guarantees hold after transaction success/failure?”
+
+## Strategic workstreams
+
+### A) Clarify types and naming semantics
+- Reserve `NodeIdentifier` for persisted opaque IDs only.
+- Use explicit semantic key types (`NodeKeyString`) in runtime graph construction and parsing.
+- Eliminate APIs that silently coerce raw strings between the two domains.
+
+### B) Consolidate lookup mutation authority
+- Route all lookup changes through invariant-checking helpers.
+- Ensure no call site can overwrite full map snapshots without merge/reconcile policy.
+- Keep transactional overlay + commit flow as the only mutation channel.
+
+### C) Strengthen cutover atomicity model
+- Ensure replica pointer changes happen only after all required writes flush.
+- Keep in-memory cached replica state synchronized with persisted pointer updates.
+- Preserve deterministic recovery semantics after crash/restart.
+
+### D) Harden migration/sync completeness guarantees
+- Any newly created or merged node with persisted state must also produce durable identifier mapping.
+- Reconciliation policy for host/target collisions must be explicit and deterministic.
+
+### E) Improve observability and docs
+- Document invariant checklist near critical modules.
+- Tighten error payload names for debug clarity (e.g., `nodeIdentifier` vs `nodeKey`).
+- Add a maintainer-oriented troubleshooting section.
+
+## Non-goals for this cycle
+- Broad performance redesign.
+- External storage format breakage.
+- Ad hoc compatibility hacks that hide invariant violations.

--- a/docs/pr1335-review1.md
+++ b/docs/pr1335-review1.md
@@ -1,0 +1,53 @@
+# PR #1335 Review #1 — Detailed feedback digest
+
+## Friendly intro
+If you just want the short version: this PR is directionally good and ambitious, but it moved a lot of foundational pieces at once. The resulting system is much more powerful, yet easier to accidentally desynchronize.
+
+Think of it as replacing street addresses with internal customer IDs across an entire city map. Great long-term, but every import/export, merge, and migration now depends on that ID directory being perfect.
+
+## What is excellent
+- The architecture now has a clear concept of persisted node identity.
+- Migration and sync are treated as first-class flows, not afterthoughts.
+- Many sharp review comments already identified and fixed truly serious correctness bugs.
+
+## Questionable design choices (and why they matter)
+
+### 1) Semantic key vs persisted identifier boundaries are still cognitively expensive
+Even where code is correct, naming and typing still make it easy for maintainers to feed semantic keys where identifiers are expected (and vice versa).
+
+Impact:
+- harder onboarding,
+- increased chance of subtle bugs in future refactors,
+- confusing error surfaces when data is damaged or partially migrated.
+
+### 2) Lookup correctness relies on discipline across many call sites
+The identifier bijection is global and critical, but updates are spread across pull, sync, migration, and transaction commit paths.
+
+Impact:
+- easy for a future optimization to accidentally bypass invariant-preserving helpers,
+- invariants are not yet enforced by one obvious “single write authority” boundary.
+
+### 3) Replica cutover semantics are still fragile to operation ordering
+Several review findings show how easy it is to switch replica pointers too early/late relative to metadata and lookup persistence.
+
+Impact:
+- stale reads in-process,
+- snapshot/checkpoint mismatch,
+- hard-to-debug state divergence across restarts.
+
+## Core problem statement
+The PR succeeded at introducing identifier-native persistence, but the system still needs a **more explicit invariant-driven contract**:
+
+1. What values are semantic keys?
+2. What values are persisted identifiers?
+3. When (and only when) can conversion happen?
+4. Which operations atomically update both data and lookup?
+5. Which failure paths must preserve rollback safety?
+
+Without those contracts being obvious and hard to violate, every future change will re-open the same risk class.
+
+## Information to steer further development
+- Treat identifier-lookup updates as critical-section logic, not incidental bookkeeping.
+- Prefer APIs that force callers to choose semantic-key or identifier-specific methods explicitly.
+- Add focused regression tests for concurrency + cutover + migration-created-node mapping completeness.
+- Improve developer docs around invariants before further performance work.

--- a/docs/pr1335.md
+++ b/docs/pr1335.md
@@ -1,0 +1,51 @@
+# PR #1335 — Switch IncrementalGraph persistence and migration to node identifiers
+
+## High-level summary
+PR #1335 changes IncrementalGraph persistence from **semantic node-key strings** (serialized `{head,args}` JSON) to **stable node identifiers** (short opaque IDs) as the primary on-disk key for node state.
+
+In practical terms, this means:
+- persisted values/freshness/revdeps are addressed by `NodeIdentifier` instead of raw serialized node-key strings,
+- a global bijection (`identifiers_keys_map`) is persisted to map identifier ↔ semantic key,
+- synchronization and migration flows were redesigned so existing repositories can move to identifier-native storage.
+
+## Conceptual model shift
+Before this PR:
+- Storage keys directly encoded node semantics.
+- Cache invalidation/sync/migration operated mostly on semantic keys.
+
+After this PR:
+- Storage keys are identity-oriented opaque IDs.
+- Semantic meaning is resolved through lookup.
+- Correctness now depends on a strict, durable, bijective identifier lookup.
+
+This is a classic move from “content-address-like” surface keys to “stable surrogate keys.” It simplifies some storage operations, but increases the burden on reconciliation, migration, and transactional consistency.
+
+## Affected areas
+PR #1335 touches broad areas in `backend/src/generators/incremental_graph/`, including:
+- database encoding/typing layers,
+- identifier lookup and reconciliation,
+- root DB replica/sync flows,
+- migration runner and migration persistence,
+- pull/recompute/instantiation paths and related errors.
+
+## Low-level implementation choices
+Key low-level choices in the PR:
+1. **Identifier lookup is globally persisted** under `identifiers_keys_map` and treated as a bijection.
+2. **Replica switching uses pointer metadata** (`_meta/current_replica`) with in-memory cache updates.
+3. **Migration writes identifier-keyed data** and must emit complete lookup mappings for all carried and created nodes.
+4. **Sync merge introduces host/target lookup merging/reconciliation** when replicas diverge.
+5. **Type system introduces NodeIdentifier in many paths**, creating pressure to keep semantic key vs persisted identifier distinctions explicit.
+
+## Risk/complexity hotspots introduced
+1. **Lost updates on concurrent lookup writes** if whole-map snapshots are overwritten instead of merged.
+2. **In-memory vs persisted lookup drift** when mutable lookup objects leak across failed operations.
+3. **Collision/reconciliation semantics** when independent replicas assign different identifiers for same semantic key.
+4. **Migration completeness hazards** when created nodes are persisted without updating lookup map.
+5. **Type ambiguity** between semantic key strings and persisted identifiers causing mis-parsing and misleading errors.
+
+## Why this PR matters
+The PR unlocks a stronger storage identity model and better long-term graph durability ergonomics, but it also centralizes correctness around one delicate invariant:
+
+> identifier-keyed records are only valid if the identifier lookup is always complete, bijective, and transactionally consistent.
+
+Any future work should prioritize preserving that invariant first, then optimize.


### PR DESCRIPTION
### Motivation
- Create a clear, approachable review and follow-up plan for the large identifier-native persistence change introduced by PR #1335. 
- Surface the main risks (lookup invariants, cutover ordering, migration completeness, and type boundaries) so maintainers can prioritize correctness before optimizations.
- Make a small, low-risk internal naming fix to reduce confusion in error payloads related to node identity.

### Description
- Add reviewer and maintainer documentation: `docs/pr1335.md`, `docs/pr1335-review1.md`, `docs/pr1335-review1-strat.md`, and `docs/pr1335-review1-impl.md` which explain the PR, call out questionable choices, and propose a principled remediation strategy and phased implementation plan. 
- Tighten the `InvalidComputorReturnValue` error in `backend/src/generators/incremental_graph/errors.js` by renaming the constructor parameter to `nodeIdentity`, adding a `nodeIdentifier` field to the error instance, and retaining `nodeKey` for compatibility and debugging clarity, while keeping the public constructor helper `makeInvalidComputorReturnValueError` aligned with the new parameter name. 
- Documentation focuses on the conceptual shift to `NodeIdentifier`-based storage, enumerates hotspots (concurrent lookup writes, in-memory vs persisted drift, collision reconciliation, migration mapping completeness, and type ambiguity), and prescribes invariant-first workstreams.

### Testing
- Ran the full test suite with `npm test` and observed all tests pass: `243` test suites and `2711` tests passed. 
- Ran static analysis with `npm run static-analysis` (TypeScript type check and `eslint`) and it completed without errors. 
- Built the frontend with `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14a387e244832eb883fa41a12a9d25)