### PR TITLE
Implement minimal locking: live identifier reservations, per-node pull locks, and narrow commit mutex (PR1335 follow-up)

### DIFF
--- a/backend/src/generators/incremental_graph/database/root_database.js
+++ b/backend/src/generators/incremental_graph/database/root_database.js
@@ -62,6 +62,8 @@ const {
  * @property {GlobalSublevelType} globalSublevel
  * @property {SchemaStorage} schemaStorage
  * @property {IdentifierLookup} identifierLookup
+ * @property {Set<string>} inFlightIdentifiers
+ * @property {Map<string, string>} inFlightIdentifierOwners
  */
 
 /**
@@ -308,6 +310,8 @@ class RootDatabaseClass {
             globalSublevel,
             schemaStorage: buildSchemaStorage(namespaceSublevel, globalSublevel, version),
             identifierLookup: makeEmptyIdentifierLookup(),
+            inFlightIdentifiers: new Set(),
+            inFlightIdentifierOwners: new Map(),
         };
     }
 
@@ -360,6 +364,17 @@ class RootDatabaseClass {
      */
     nodeIdToKey(nodeIdentifier) {
         return nodeIdToKeyFromLookup(this._computed.identifierLookup, nodeIdentifier);
+    }
+
+
+    /**
+     * @returns {{ inFlightIdentifiers: Set<string>, inFlightIdentifierOwners: Map<string, string> }}
+     */
+    getIdentifierReservationState() {
+        return {
+            inFlightIdentifiers: this._computed.inFlightIdentifiers,
+            inFlightIdentifierOwners: this._computed.inFlightIdentifierOwners,
+        };
     }
 
     /**
@@ -422,7 +437,15 @@ class RootDatabaseClass {
             const schemaStorage = buildSchemaStorage(namespaceSublevel, globalSublevel, this.version);
             const identifierLookup = await loadIdentifierLookupFromGlobal(globalSublevel);
             await this._rootMetaSublevel.put('current_replica', name);
-            this._computed = { replicaName: name, namespaceSublevel, globalSublevel, schemaStorage, identifierLookup };
+            this._computed = {
+                replicaName: name,
+                namespaceSublevel,
+                globalSublevel,
+                schemaStorage,
+                identifierLookup,
+                inFlightIdentifiers: new Set(),
+                inFlightIdentifierOwners: new Map(),
+            };
         } catch (err) {
             throw new SwitchReplicaError(name, err);
         }
@@ -492,6 +515,8 @@ class RootDatabaseClass {
                 globalSublevel,
                 schemaStorage: buildSchemaStorage(namespaceSublevel, globalSublevel, this.version),
                 identifierLookup: await loadIdentifierLookupFromGlobal(globalSublevel),
+                inFlightIdentifiers: new Set(),
+                inFlightIdentifierOwners: new Map(),
             };
         }
     }

--- a/backend/src/generators/incremental_graph/graph_state.js
+++ b/backend/src/generators/incremental_graph/graph_state.js
@@ -17,7 +17,6 @@ const {
     nodeIdentifierToString,
     stringToNodeIdentifier,
     makeTransactionIdentifierLookup,
-    txAllocateNodeIdentifier,
     txNodeIdToKey,
     txNodeKeyToId,
     serializeTransactionLookup,
@@ -25,7 +24,12 @@ const {
 } = require('./database');
 const { withComputedStateMutex } = require('./lock');
 
-/** @typedef {import('./database/root_database').RootDatabase} RootDatabase */
+/**
+ * @typedef {import('./database/root_database').RootDatabase & {
+ *     getIdentifierReservationState?: () => { inFlightIdentifiers: Set<string>, inFlightIdentifierOwners: Map<string, string> },
+ *     __graphReservationState?: { inFlightIdentifiers: Set<string>, inFlightIdentifierOwners: Map<string, string> },
+ * }} RootDatabase
+ */
 /** @typedef {import('./database/root_database').SchemaStorage} SchemaStorage */
 /** @typedef {import('./database/root_database').ValuesDatabase} ValuesDatabase */
 /** @typedef {import('./database/root_database').FreshnessDatabase} FreshnessDatabase */
@@ -73,8 +77,10 @@ const { withComputedStateMutex } = require('./lock');
  *   successful disk flush (disk-first invariant).
  *
  * @typedef {object} Transaction
+ * @property {string} id - Diagnostic transaction identifier.
  * @property {BatchBuilder} batch - LevelDB batch accumulator with read-your-writes.
  * @property {TransactionIdentifierLookup} identifierLookup - Overlay-based identifier lookup.
+ * @property {Set<string>} reservedIdentifiers - Identifier strings reserved by this live transaction.
  * @property {Map<import('./types').NodeKeyString, Promise<import('./types').RecomputeResult>>} inFlight - Per-key in-flight pull promises for deduplication of concurrent nested pulls.
  */
 
@@ -87,7 +93,7 @@ const { withComputedStateMutex } = require('./lock');
  * @property {CountersDatabase} counters - Identifier-keyed counters.
  * @property {TimestampsDatabase} timestamps - Identifier-keyed timestamps.
  * @property {<T>(fn: (batch: BatchBuilder) => Promise<T>) => Promise<T>} withBatch - Run atomically against all graph sublevels (no identifier tracking).
- * @property {<T>(fn: (tx: Transaction) => Promise<T>) => Promise<T>} withTransaction - Run atomically: creates transaction inside computed-state mutex, commits node writes and identifier map.
+ * @property {<T>(fn: (tx: Transaction) => Promise<T>) => Promise<T>} withTransaction - Run a transaction body concurrently and serialize only commit/publish.
  * @property {(node: NodeIdentifier, inputs: NodeIdentifier[], inputCounters: number[], batch: BatchBuilder) => Promise<void>} ensureMaterialized - Persist the current inputs record for a node.
  * @property {(node: NodeIdentifier, inputs: NodeIdentifier[], batch: BatchBuilder) => Promise<void>} ensureReverseDepsIndexed - Add a node to each input's reverse-dependency list.
  * @property {(input: NodeIdentifier, batch: BatchBuilder) => Promise<NodeIdentifier[]>} listDependents - Read a node's dependents inside the current batch.
@@ -186,13 +192,117 @@ function createBatch(schemaStorage) {
     return { batch, operations };
 }
 
+let nextTransactionCounter = 0;
+
+/**
+ * @returns {string}
+ */
+function makeTransactionId() {
+    nextTransactionCounter += 1;
+    return `tx-${String(nextTransactionCounter)}`;
+}
+
+/**
+ * Ensure the active root computed state contains live identifier-reservation
+ * diagnostics used by concurrent transactions.
+ * @param {RootDatabase} rootDatabase
+ * @returns {{ inFlightIdentifiers: Set<string>, inFlightIdentifierOwners: Map<string, string> }}
+ */
+function ensureIdentifierReservationState(rootDatabase) {
+    if (rootDatabase.getIdentifierReservationState !== undefined) {
+        return rootDatabase.getIdentifierReservationState();
+    }
+    if (rootDatabase.__graphReservationState === undefined) {
+        rootDatabase.__graphReservationState = {
+            inFlightIdentifiers: new Set(),
+            inFlightIdentifierOwners: new Map(),
+        };
+    }
+    return rootDatabase.__graphReservationState;
+}
+
+/**
+ * Clear this transaction's live identifier reservations from the active root
+ * computed state. The volatile committed lookup is intentionally untouched.
+ * @param {Transaction} tx
+ * @param {RootDatabase} rootDatabase
+ * @returns {void}
+ */
+function clearIdentifierReservations(tx, rootDatabase) {
+    const { inFlightIdentifiers, inFlightIdentifierOwners } =
+        ensureIdentifierReservationState(rootDatabase);
+    for (const identifierString of tx.reservedIdentifiers) {
+        inFlightIdentifiers.delete(identifierString);
+        const owner = inFlightIdentifierOwners.get(identifierString);
+        if (owner === tx.id) {
+            inFlightIdentifierOwners.delete(identifierString);
+        }
+    }
+    tx.reservedIdentifiers.clear();
+}
+
+/**
+ * Synchronously reserve a fresh node identifier for a transaction overlay.
+ * The check/generate/reserve/update-overlay sequence never awaits and never
+ * calls user code, so it is atomic within one Node.js event loop.
+ * @param {Transaction} tx
+ * @param {RootDatabase} rootDatabase
+ * @param {NodeKeyString} nodeKey
+ * @param {number} [maxAttempts=64]
+ * @returns {NodeIdentifier}
+ */
+function reserveNodeIdentifier(tx, rootDatabase, nodeKey, maxAttempts = 64) {
+    const existing = txNodeKeyToId(tx.identifierLookup, nodeKey);
+    if (existing !== undefined) {
+        return existing;
+    }
+
+    const { inFlightIdentifiers, inFlightIdentifierOwners } =
+        ensureIdentifierReservationState(rootDatabase);
+    const keyString = String(nodeKey);
+    for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+        const candidate = rootDatabase.generateNodeIdentifier();
+        const candidateString = nodeIdentifierToString(candidate);
+        if (txNodeIdToKey(tx.identifierLookup, candidate) !== undefined) {
+            continue;
+        }
+        if (inFlightIdentifiers.has(candidateString)) {
+            continue;
+        }
+
+        inFlightIdentifiers.add(candidateString);
+        inFlightIdentifierOwners.set(candidateString, tx.id);
+        tx.identifierLookup.keyToId.set(keyString, candidate);
+        tx.identifierLookup.idToKey.set(candidateString, nodeKey);
+        tx.reservedIdentifiers.add(candidateString);
+        return candidate;
+    }
+
+    throw new Error(`Failed to reserve a unique node identifier for ${keyString}`);
+}
+
 /**
  * Create the identifier-native graph storage facade for one schema namespace.
  * @param {RootDatabase} rootDatabase
- * @param {SleepCapability} sleeper
+ * @param {SleepCapability} [sleeper]
  * @returns {GraphStorage}
  */
 function makeGraphStorage(rootDatabase, sleeper) {
+    /**
+     * @template T
+     * @param {() => Promise<T>} procedure
+     * @returns {Promise<T>}
+     */
+    const withCommitMutex = async (procedure) => {
+        if (sleeper === undefined) {
+            return await procedure();
+        }
+        return await withComputedStateMutex(
+            sleeper,
+            rootDatabase.currentReplicaName(),
+            procedure
+        );
+    };
     /**
      * @param {NodeIdentifier} node
      * @param {NodeIdentifier[]} inputs
@@ -285,84 +395,74 @@ function makeGraphStorage(rootDatabase, sleeper) {
             return result;
         },
         /**
-         * Run a batch that atomically commits node writes together with any new
-         * identifier allocations made during the operation.
+         * Run a transaction body concurrently and serialize only the commit.
          *
-         * This implements the transaction model from the volatile-consistency spec:
-         * - createTransaction(): creates an overlay-based TransactionIdentifierLookup
-         *   backed by a direct (non-cloned) reference to the committed lookup, then
-         *   creates a fresh batch accumulator. No full-copy clone is performed.
-         * - operation runs with the transaction.
-         * - commitTransaction(): serialize (base + overlay) for disk, flush the batch,
-         *   then apply the overlay to the base in-place (disk-first ordering).
-         *
-         * Using an overlay instead of a full clone eliminates the O(n log n) copy at
-         * transaction start and the second O(n log n) copy at commit time. Only new
-         * allocations (typically very few per transaction) are tracked in the overlay.
-         *
-         * The entire operation happens inside withComputedStateMutex, serializing all
-         * concurrent callers end-to-end and eliminating identifier allocation races.
-         *
-         * Callers that are already inside the mutex (nested dependency pulls) must
-         * NOT call this method again; they must receive the outer transaction via
-         * explicit argument passing and operate on it directly.
+         * Identifier allocation uses synchronous live reservations during the
+         * transaction body. Node writes are queued in a private read-your-writes
+         * batch. The commit mutex covers only durable batch flush, volatile
+         * identifier publication, and reservation cleanup, preserving disk-first
+         * volatile consistency without serializing computor execution.
          *
          * @template T
          * @param {(tx: Transaction) => Promise<T>} fn
          * @returns {Promise<T>}
          */
         async withTransaction(fn) {
-            return await withComputedStateMutex(sleeper, rootDatabase.currentReplicaName(), async () => {
-                // createTransaction(): get a direct reference to _computed.identifierLookup
-                // (no clone), create an empty overlay for this transaction's allocations.
-                const activeSchemaStorage = rootDatabase.getSchemaStorage();
-                const txLookup = makeTransactionIdentifierLookup(rootDatabase.getActiveIdentifierLookup());
-                const { batch, operations } = createBatch(activeSchemaStorage);
+            const activeSchemaStorage = rootDatabase.getSchemaStorage();
+            const txLookup = makeTransactionIdentifierLookup(rootDatabase.getActiveIdentifierLookup());
+            const { batch, operations } = createBatch(activeSchemaStorage);
 
-                /** @type {Transaction} */
-                const tx = { batch, identifierLookup: txLookup, inFlight: new Map() };
+            /** @type {Transaction} */
+            const tx = {
+                id: makeTransactionId(),
+                batch,
+                identifierLookup: txLookup,
+                reservedIdentifiers: new Set(),
+                inFlight: new Map(),
+            };
 
-                // Run the operation (identifier allocation + node-data writes).
+            try {
                 const value = await fn(tx);
 
-                // commitTransaction(): disk-first — flush batch, then update volatile layer.
-                // txLookup.keyToId contains only the new allocations from this transaction.
-                const hasPendingOperations = operations.length > 0;
-                const hasPendingAllocations = tx.identifierLookup.keyToId.size > 0;
-                const hasPersistentDelta = hasPendingOperations || hasPendingAllocations;
+                return await withCommitMutex(async () => {
+                    const hasPendingOperations = operations.length > 0;
+                    const hasPendingAllocations = tx.identifierLookup.keyToId.size > 0;
+                    const hasPersistentDelta = hasPendingOperations || hasPendingAllocations;
 
-                // No-op transaction: no node writes and no new identifier allocations.
-                // Skip persistence work entirely.
-                if (!hasPersistentDelta) {
-                    return value;
-                }
+                    if (!hasPersistentDelta) {
+                        clearIdentifierReservations(tx, rootDatabase);
+                        return value;
+                    }
 
-                if (hasPendingAllocations) {
-                    if (activeSchemaStorage.global === undefined) {
-                        throw new Error(
-                            "Cannot commit identifier allocations: activeSchemaStorage.global is undefined. " +
-                            "The volatile state cannot be synchronized with disk, which would violate " +
-                            "the disk-first ordering invariant (volatile must not advance ahead of disk)."
+                    if (hasPendingAllocations) {
+                        if (activeSchemaStorage.global === undefined) {
+                            throw new Error(
+                                "Cannot commit identifier allocations: activeSchemaStorage.global is undefined. " +
+                                "The volatile state cannot be synchronized with disk, which would violate " +
+                                "the disk-first ordering invariant (volatile must not advance ahead of disk)."
+                            );
+                        }
+                        operations.push(
+                            activeSchemaStorage.global.rawPutOp(
+                                IDENTIFIERS_KEY,
+                                serializeTransactionLookup(tx.identifierLookup)
+                            )
                         );
                     }
-                    operations.push(
-                        activeSchemaStorage.global.rawPutOp(
-                            IDENTIFIERS_KEY,
-                            serializeTransactionLookup(tx.identifierLookup)
-                        )
-                    );
-                }
 
-                await activeSchemaStorage.batch(operations);
+                    await activeSchemaStorage.batch(operations);
 
-                if (hasPendingAllocations) {
-                    // Disk flush succeeded: apply overlay to base in-place.
-                    // This is the only mutation of _computed.identifierLookup.
-                    commitTransactionLookup(tx.identifierLookup);
-                }
+                    if (hasPendingAllocations) {
+                        commitTransactionLookup(tx.identifierLookup);
+                    }
+                    clearIdentifierReservations(tx, rootDatabase);
 
-                return value;
-            });
+                    return value;
+                });
+            } catch (error) {
+                clearIdentifierReservations(tx, rootDatabase);
+                throw error;
+            }
         },
         ensureMaterialized,
         ensureReverseDepsIndexed,
@@ -395,11 +495,7 @@ function lookupNodeIdentifier(tx, nodeKey) {
  * @returns {NodeIdentifier}
  */
 function getOrAllocateNodeIdentifier(tx, rootDatabase, nodeKey) {
-    return txAllocateNodeIdentifier(
-        tx.identifierLookup,
-        nodeKey,
-        () => rootDatabase.generateNodeIdentifier()
-    );
+    return reserveNodeIdentifier(tx, rootDatabase, nodeKey);
 }
 
 /**

--- a/backend/src/generators/incremental_graph/lock.js
+++ b/backend/src/generators/incremental_graph/lock.js
@@ -15,6 +15,7 @@ const { makeUniqueFunctor } = require("../../unique_functor");
 const MUTEX_KEY = makeUniqueFunctor("incremental-graph-operations").instantiate([]);
 const GRAPH_ACTIVITY_KEY = makeUniqueFunctor("incremental-graph-activity").instantiate([]);
 const COMPUTED_STATE_KEY = makeUniqueFunctor("incremental-graph-computed-state");
+const PULL_NODE_KEY = makeUniqueFunctor("incremental-graph-pull-node");
 
 /** @typedef {import('../../sleeper').SleepCapability} SleepCapability */
 
@@ -80,6 +81,22 @@ function withComputedStateMutex(sleeper, computedStateIdentifier, procedure) {
 }
 
 /**
+ * Serialize execution of a concrete node pull body across transactions.
+ *
+ * @template T
+ * @param {SleepCapability} sleeper
+ * @param {string} nodeKeyString
+ * @param {() => Promise<T>} procedure
+ * @returns {Promise<T>}
+ */
+function withPullNodeMutex(sleeper, nodeKeyString, procedure) {
+    return sleeper.withMutex(
+        PULL_NODE_KEY.instantiate([nodeKeyString]),
+        procedure
+    );
+}
+
+/**
  * Acquires an exclusive lock that prevents all concurrent graph activity:
  * pulls, observes, and other exclusive operations (database opens, migrations).
  *
@@ -109,4 +126,5 @@ module.exports = {
     withObserveMode,
     withPullMode,
     withComputedStateMutex,
+    withPullNodeMutex,
 };

--- a/backend/src/generators/incremental_graph/pull.js
+++ b/backend/src/generators/incremental_graph/pull.js
@@ -34,9 +34,44 @@
 const { stringToNodeName } = require("./database");
 const { stringToNodeKeyString } = require("./database");
 const { makeInvalidNodeError } = require("./errors");
-const { withPullMode } = require("./lock");
+const { withPullMode, withPullNodeMutex } = require("./lock");
 const { deserializeNodeKey, serializeNodeKey } = require("./database");
 const { checkArity, ensureNodeNameIsHead } = require("./shared");
+
+/**
+ * Run a transaction while holding locks for the requested concrete node and
+ * its static concrete inputs. This intentionally covers known shared
+ * dependencies before either transaction starts executing so concurrent pulls
+ * that share a static dependency serialize on that dependency, while disjoint
+ * pulls can still overlap.
+ * @template T
+ * @param {IncrementalGraphPullAccess} graph
+ * @param {import('./types').ConcreteNode} concreteNode
+ * @param {() => Promise<T>} procedure
+ * @returns {Promise<T>}
+ */
+function withTopLevelPullLocks(graph, concreteNode, procedure) {
+    const lockKeys = [concreteNode.output, ...concreteNode.inputs]
+        .map(String)
+        .sort();
+    const uniqueLockKeys = lockKeys.filter((lockKey, index) =>
+        index === 0 || lockKey !== lockKeys[index - 1]
+    );
+
+    /**
+     * @param {number} index
+     * @returns {Promise<T>}
+     */
+    const acquireFrom = (index) => {
+        const lockKey = uniqueLockKeys[index];
+        if (lockKey === undefined) {
+            return procedure();
+        }
+        return withPullNodeMutex(graph.sleeper, lockKey, () => acquireFrom(index + 1));
+    };
+
+    return acquireFrom(0);
+}
 
 /**
  * Core pull implementation for a node by its serialized key.
@@ -98,13 +133,17 @@ async function pullNode(graph, nodeKeyStr, tx) {
     };
 
     if (tx !== null) {
-        // Nested call: outer pull already holds the computed-state mutex.
-        // Share the outer transaction directly to avoid deadlock.
+        // Nested call: share the outer transaction directly. Per-transaction
+        // deduplication prevents duplicate dependency pulls in one pull DAG.
         return runDeduplicatedInTransaction(tx);
     }
 
-    // Top-level pull: acquire the computed-state lock and create a fresh transaction.
-    return graph.withTransaction(async (activeTx) => runDeduplicatedInTransaction(activeTx));
+    // Top-level pull: serialize this concrete node and its known static inputs
+    // across transactions. Disjoint lock sets may execute concurrently; shared
+    // dependencies serialize before duplicate dependency computation can begin.
+    return withTopLevelPullLocks(graph, concreteNode, () =>
+        graph.withTransaction(async (activeTx) => runDeduplicatedInTransaction(activeTx))
+    );
 }
 
 /**

--- a/backend/tests/incremental_graph_concurrency.test.js
+++ b/backend/tests/incremental_graph_concurrency.test.js
@@ -733,6 +733,62 @@ describe("IncrementalGraph concurrency", () => {
             await inspectPromise;
         });
 
+        test("duplicate generated identifiers are retried against live reservations", async () => {
+            const capabilities = getMockedRootCapabilities();
+            const db = new InMemoryDatabase();
+            const generated = [
+                nodeIdentifierFromString("aaaaaaaaa"),
+                nodeIdentifierFromString("aaaaaaaaa"),
+                nodeIdentifierFromString("bbbbbbbbb"),
+            ];
+            db.generateNodeIdentifier = () => {
+                const next = generated.shift();
+                if (next === undefined) {
+                    throw new Error("test exhausted deterministic identifiers");
+                }
+                return next;
+            };
+            const releaseBoth = makeDeferred();
+            const started = [];
+
+            const graph = makeIncrementalGraph(capabilities, db, [
+                {
+                    output: "source1",
+                    inputs: [],
+                    computor: async () => {
+                        started.push("source1");
+                        await releaseBoth.promise;
+                        return { type: "test", value: 1 };
+                    },
+                    isDeterministic: true,
+                    hasSideEffects: false,
+                },
+                {
+                    output: "source2",
+                    inputs: [],
+                    computor: async () => {
+                        started.push("source2");
+                        await releaseBoth.promise;
+                        return { type: "test", value: 2 };
+                    },
+                    isDeterministic: true,
+                    hasSideEffects: false,
+                },
+            ]);
+
+            const pull1 = graph.pull("source1");
+            const pull2 = graph.pull("source2");
+            await new Promise((resolve) => setTimeout(resolve, 20));
+            expect(started.sort()).toEqual(["source1", "source2"]);
+
+            releaseBoth.resolve(undefined);
+            await Promise.all([pull1, pull2]);
+
+            const lookup = db.cloneActiveIdentifierLookup();
+            const identifiers = new Set([...lookup.keyToId.values()].map(String));
+            expect(identifiers).toEqual(new Set(["aaaaaaaaa", "bbbbbbbbb"]));
+        });
+
         test("concurrent pulls on the same node are serialized", async () => {
             const capabilities = getMockedRootCapabilities();
             const db = new InMemoryDatabase();
@@ -768,7 +824,7 @@ describe("IncrementalGraph concurrency", () => {
             expect(maxActiveComputations).toBe(1);
         });
 
-        test("concurrent pulls on different nodes are serialized", async () => {
+        test("concurrent pulls on different nodes can overlap", async () => {
             const capabilities = getMockedRootCapabilities();
             const db = new InMemoryDatabase();
             const source1Cell = { value: { type: "test", value: 1 } };
@@ -804,13 +860,12 @@ describe("IncrementalGraph concurrency", () => {
             const pull1 = graph.pull("source1");
             const pull2 = graph.pull("source2");
             await new Promise((resolve) => setTimeout(resolve, 20));
-            // Pulls on different nodes are now serialized by withComputedStateMutex:
-            // source1 holds the mutex (awaiting releaseBoth), source2 has not started yet.
-            expect(started).toEqual(["source1"]);
+            // Disjoint concrete node locks let both top-level computors run before
+            // either transaction commits.
+            expect(started.sort()).toEqual(["source1", "source2"]);
 
             releaseBoth.resolve(undefined);
             await Promise.all([pull1, pull2]);
-            // After both complete (sequentially), both have been computed.
             expect(started.sort()).toEqual(["source1", "source2"]);
         });
 

--- a/backend/tests/incremental_graph_volatile_consistency.test.js
+++ b/backend/tests/incremental_graph_volatile_consistency.test.js
@@ -764,11 +764,11 @@ describe("Supplemental scenario — Read-only lookups do not interfere with allo
 });
 
 // ---------------------------------------------------------------------------
-// Invariant 3 — Serialisation: all mutations are serialized by the mutex
+// Invariant 3 — Disjoint pull concurrency: independent pull bodies can overlap
 // ---------------------------------------------------------------------------
 
-describe("Invariant 3 — Serialisation of concurrent mutations", () => {
-    test("pulls on different independent nodes are serialized (not concurrent)", async () => {
+describe("Invariant 3 — Disjoint pull concurrency", () => {
+    test("pulls on different independent nodes can overlap", async () => {
         const capabilities = getTestCapabilities();
         const db = await getRootDatabase(capabilities);
         const released = makeDeferredPromise();
@@ -808,15 +808,13 @@ describe("Invariant 3 — Serialisation of concurrent mutations", () => {
             await new Promise((resolve) => setTimeout(resolve, 10));
         }
 
-        // While the first pull is blocked in its computor, the second pull must not
-        // enter its own computor yet.
-        expect(started.length).toBe(1);
+        // Disjoint pull lock sets let both computors start before either commits.
+        expect(started.sort()).toEqual(["n1", "n2"]);
 
-        // Release n1's computor; n1 commits, then n2 acquires the mutex and starts.
+        // Release both computors and allow their short commit sections to serialize.
         released.resolve(undefined);
         await Promise.all([p1, p2]);
 
-        // After both complete, both were computed (sequentially).
         expect(started.sort()).toEqual(["n1", "n2"]);
 
         await db.close();

--- a/docs/pr1335-review1-impl.md
+++ b/docs/pr1335-review1-impl.md
@@ -1,0 +1,57 @@
+# PR #1335 Review 1 Implementation Plan
+
+## 1. Root computed reservation state
+
+- Add `inFlightIdentifiers: Set<string>` and `inFlightIdentifierOwners: Map<string, string>` to active root computed state.
+- Reinitialize those sets/maps when the active replica is switched or cleared.
+- For tests with minimal root database stubs, lazily attach equivalent reservation state when `_computed` is not present.
+
+## 2. Transaction shape
+
+- Add transaction IDs from a monotonic in-process counter.
+- Add `reservedIdentifiers: Set<string>` to every transaction.
+- Keep `identifierLookup` as an overlay backed by the committed lookup.
+- Keep `inFlight` for transaction-local nested pull deduplication.
+
+## 3. Synchronous identifier reservation
+
+Implement `reserveNodeIdentifier(tx, rootDatabase, nodeKey)`:
+
+1. Return an existing transaction/base lookup mapping if present.
+2. Generate candidates synchronously through `rootDatabase.generateNodeIdentifier()`.
+3. Reject candidates already present in the transaction/base lookup.
+4. Reject candidates present in live `inFlightIdentifiers`.
+5. Insert the candidate string into live reservations and diagnostics.
+6. Insert the node-key mapping into the transaction overlay.
+7. Insert the candidate string into `tx.reservedIdentifiers`.
+8. Return the candidate.
+
+Cleanup helper:
+
+- Remove every `tx.reservedIdentifiers` entry from live reservation sets/maps.
+- Clear `tx.reservedIdentifiers`.
+- Never mutate committed lookup during cleanup.
+
+## 4. Narrow transaction mutex
+
+Change `withTransaction(fn)` so that it:
+
+1. Creates transaction state without acquiring the computed-state mutex.
+2. Awaits `fn(tx)` outside the commit mutex.
+3. Acquires `withComputedStateMutex(...)` only after the body succeeds.
+4. Under the mutex, appends `identifiers_keys_map` when allocations exist, awaits the durable batch, publishes overlay to the committed lookup, and clears reservations.
+5. On any throw before or during commit, clears reservations and rethrows.
+
+## 5. Concrete pull locking
+
+- Add a `withPullNodeMutex(...)` helper in `lock.js` keyed by serialized concrete node key strings.
+- For top-level pulls, acquire locks for the concrete output and its static concrete inputs in sorted de-duplicated order.
+- Hold those locks until the transaction commits or aborts by wrapping the entire `graph.withTransaction(...)` call.
+- Preserve nested pulls as transaction-local operations; `tx.inFlight` deduplicates repeated nested pulls in one transaction.
+
+## 6. Tests
+
+- Update concurrency tests so disjoint top-level pulls are expected to overlap.
+- Add a deterministic duplicate-candidate test where two live transactions receive the same generated identifier and the second retries.
+- Keep existing same-node serialization, mode-lock, volatile consistency, and batch-failure tests.
+- Run focused suites first, then full test/static-analysis/build checks.

--- a/docs/pr1335-review1-strat.md
+++ b/docs/pr1335-review1-strat.md
@@ -1,0 +1,43 @@
+# PR #1335 Review 1 Strategy
+
+## Design standard
+
+The strategy follows `docs/design.md`: correctness must be deterministic, auditable, and recoverable. We should not rely on random identifier collision probabilities or broad serialization that hides races by preventing all useful concurrency. We should make each shared-state mutation explicit and keep each lock scoped to the invariant it protects.
+
+## Principles
+
+1. **Preserve disk-first volatile consistency.**
+   The in-memory committed identifier lookup may never include an allocation that was not durably written in the same batch as its node-state writes.
+
+2. **Do not serialize computor execution with the commit mutex.**
+   Computors and dependency traversal are user/application work. The commit lock should protect only durable/publish shared state.
+
+3. **Reserve identifiers synchronously, not probabilistically.**
+   A live transaction must reserve candidate identifiers in an in-memory set before returning to the event loop. Candidate generation must retry against both committed lookup and live reservations.
+
+4. **Use locks for ownership, not as a substitute for validation.**
+   Pull-mode activity remains separated from observe/exclusive activity by the existing mode lock. Concrete pull locks protect same-node and known shared dependency execution. The commit mutex protects final merge/publish.
+
+5. **Clean up on every abort path.**
+   Any transaction that throws before durable commit must clear its reserved identifiers without mutating committed lookup.
+
+6. **Update tests to express target semantics.**
+   Tests that previously asserted broad transaction serialization should instead assert disjoint-pull overlap, same-node serialization, shared dependency serialization, duplicate-candidate retry, and batch-failure cleanup.
+
+## Strategy
+
+1. Keep PR #1335's identifier-native storage and disk-first transaction overlay model as the base.
+2. Add live reservation state to root computed state: `inFlightIdentifiers` and `inFlightIdentifierOwners`.
+3. Extend transactions with diagnostic IDs and `reservedIdentifiers`.
+4. Replace `txAllocateNodeIdentifier(...)` use in graph transaction allocation with a synchronous reservation helper.
+5. Move `withComputedStateMutex(...)` from whole transaction body to the commit section.
+6. Add concrete pull locks. At minimum, top-level pulls must lock their output and static input keys in canonical order so disjoint pulls can overlap and shared static dependencies serialize before duplicate computation.
+7. Preserve transaction-local nested pull deduplication through `tx.inFlight`.
+8. Add focused tests first, then iterate with the existing volatile consistency and concurrency suites.
+9. Defer full logical-intent rebasing of every graph write to a later, larger change unless tests expose lost updates; this pass should make no regression in current persisted state and should not introduce partial durable/volatile publication.
+
+## Non-goals for this pass
+
+- Multi-process writer support. The synchronous reservation guarantee is explicitly in-process.
+- A durable reservation table.
+- Replacing every eager raw batch operation with logical intents in one step.

--- a/docs/pr1335.md
+++ b/docs/pr1335.md
@@ -1,0 +1,51 @@
+# PR #1335 Analysis: Identifier-Native Incremental Graph Storage
+
+## High-level purpose
+
+PR #1335 converts the incremental graph from semantic node keys as persistent storage keys to opaque, stable node identifiers. The conceptual target is a graph database where semantic node keys remain the public/query language, while durable graph records (`values`, `freshness`, `inputs`, `revdeps`, `counters`, `timestamps`) are keyed by compact node identifiers. A global persisted `identifiers_keys_map` records the bijection between node identifiers and semantic node keys.
+
+The PR also introduces a transaction model intended to preserve volatile↔persistent consistency: newly allocated identifiers are visible to the in-memory lookup only after the same durable batch has written both graph records and the updated identifier map.
+
+## Major conceptual changes
+
+1. **Opaque node identifiers become the storage identity.**
+   Node records are addressed by 9-letter identifiers rather than serialized semantic keys. This makes rendered database paths shorter and decouples storage identity from the shape of node-key JSON.
+
+2. **A global identifier lookup becomes part of graph state.**
+   The persisted `identifiers_keys_map` is the authoritative durable bijection. The root database keeps an active in-memory mirror for fast lookup by key or identifier.
+
+3. **Graph storage moves behind identifier-native facades.**
+   The old `graph_storage.js` semantic-key layer is replaced by `graph_state.js`, which exposes graph sublevels keyed by `NodeIdentifier` and supplies transaction/batch helpers.
+
+4. **Transactions combine node writes with identifier-map persistence.**
+   PR #1335's current transaction path creates a private identifier overlay, queues LevelDB operations in a read-your-writes batch, writes the serialized combined identifier lookup in the same batch when allocations exist, then publishes the overlay to memory after the durable batch succeeds.
+
+5. **Migration and synchronization become identifier-aware.**
+   Migration code can parse legacy semantic-key records, allocate/reconcile identifiers, and render or synchronize databases with the identifier map included.
+
+6. **Tests and fixtures are updated to identifier-keyed layout.**
+   Rendered mock database fixtures move from semantic filenames such as `all_events` to identifier filenames such as `athsapppb`, with `rendered/r/global/identifiers_keys_map` linking those names back to semantic graph nodes.
+
+## Low-level choices observed
+
+- Node identifiers are validated as exactly nine lowercase ASCII letters.
+- The identifier lookup keeps two maps, `keyToId` and `idToKey`, and validation requires a bijection.
+- Transaction identifier lookup is an overlay: new allocations live in transaction maps backed by the committed lookup.
+- `serializeTransactionLookup(...)` renders base plus overlay sorted by identifier for durable storage.
+- `commitTransactionLookup(...)` mutates the active committed lookup only after durable batch success.
+- The transaction batch wrapper implements read-your-writes by checking queued `put`/`del` overlays before reading LevelDB.
+- Reverse dependencies are stored as sorted identifier arrays.
+- The global schema storage must expose `global.rawPutOp(...)` so `identifiers_keys_map` can be included in the same batch as node writes.
+- Existing mode locks separate `pull`, `observe`, and `exclusive` graph activity, but the current PR serializes every transaction body with `withComputedStateMutex(...)`.
+
+## Affected paths
+
+- Core graph runtime: `backend/src/generators/incremental_graph/class.js`, `pull.js`, `invalidate.js`, `recompute.js`, `inspection.js`, `instantiation.js`, `graph_state.js`, and `lock.js`.
+- Database and identity layer: `backend/src/generators/incremental_graph/database/identifier_lookup.js`, `node_identifier.js`, `root_database.js`, `typed_database.js`, `types.js`, and reconciliation/migration helpers.
+- Migration/sync/rendering: `migration_runner.js`, `migration_storage.js`, `sync_merge.js`, `synchronize*.js`, unification adapters, and render tests.
+- Tests: identifier lookup tests, volatile consistency tests, concurrency tests, migration tests, and rendered fixtures.
+- Documentation: `docs/design.md` and `docs/specs/incremental-graph-volatile-consistency.md`.
+
+## Gap relative to `docs/design.md`
+
+The PR establishes the identifier-native and disk-first foundation, but its implemented transaction lock is intentionally broad: `withTransaction(...)` holds `withComputedStateMutex(...)` while computors execute, dependencies are traversed, identifiers are allocated, and the batch commits. The target design requires narrowing that mutex to only commit/publish work, adding live identifier reservations, and using per-node pull locks so independent pulls can run concurrently while same-node/shared-dependency pulls remain deterministic.


### PR DESCRIPTION
### Motivation

- Narrow the broad transaction mutex in the identifier-native incremental graph so computor execution and dependency traversal can run concurrently while preserving the disk-first volatile→persistent invariant from `docs/design.md`.
- Guarantee in-process uniqueness of generated node identifiers by adding synchronous live reservations rather than relying on end-to-end serialization or probabilistic collision avoidance.
- Allow disjoint top-level pulls to overlap while ensuring same-node and shared-dependency pulls serialize deterministically.

### Description

- Added documentation files `docs/pr1335.md`, `docs/pr1335-review1-strat.md`, and `docs/pr1335-review1-impl.md` describing analysis, design strategy, and implementation plan for PR #1335.
- Root computed state: added live reservation fields `inFlightIdentifiers` and `inFlightIdentifierOwners` and a typed accessor `getIdentifierReservationState()` in `backend/src/generators/incremental_graph/database/root_database.js` and reinitialized them on replica changes.
- Transaction/state changes: transactions now carry a diagnostic `id` and a `reservedIdentifiers` set; implemented `reserveNodeIdentifier(...)` and `clearIdentifierReservations(...)` helpers in `backend/src/generators/incremental_graph/graph_state.js` to perform synchronous check/generate/reserve/update-overlay without yielding to the event loop.
- Commit mutex narrowing: `withTransaction(fn)` was reworked so `fn(tx)` runs outside the computed-state mutex and only the commit/publish/cleanup section is executed under the computed-state mutex, preserving the disk-first ordering while reducing serialized work.
- Per-node pull locking: added `withPullNodeMutex(...)` in `backend/src/generators/incremental_graph/lock.js` and `withTopLevelPullLocks(...)` in `backend/src/generators/incremental_graph/pull.js` so top-level pulls acquire canonicalized locks for the output and static inputs (sorted, deduplicated) and hold them until commit/abort; nested pulls still reuse the outer transaction and `tx.inFlight` deduplication.
- Identifier allocation: replaced the old `txAllocateNodeIdentifier(...)` usage with the synchronous reservation-based `reserveNodeIdentifier(...)` via `getOrAllocateNodeIdentifier(...)` so live reservations block duplicate transient allocations in-process.
- Tests: updated and added tests to exercise new behavior (duplicate generated-identifier retry and disjoint top-level pull overlap) in `backend/tests/incremental_graph_concurrency.test.js` and `backend/tests/incremental_graph_volatile_consistency.test.js`.

### Testing

- Installed dependencies: ran `npm install` successfully.
- Focused test suites executed and passed: `npx jest backend/tests/incremental_graph_concurrency.test.js backend/tests/incremental_graph_volatile_consistency.test.js --runInBand` (passed).
- Additional focused suites passed: `npx jest backend/tests/incremental_graph_batch_consistency.test.js backend/tests/migration_revdeps_ordering.test.js backend/tests/identifiers_keys_map_correctness.test.js --runInBand` (passed).
- Static analysis and build: `npm run static-analysis` (TypeScript + ESLint) passed after type/JSDoc adjustments, and `npm run build` (frontend) completed successfully.
- Note: a full repository `npm test` run was attempted but the all-suite Jest run in this environment stalled; verification was performed by running the affected backend test suites, static analysis, and build, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b8bc6f6a4832e8df044688e2722ce)