### PR TITLE
Implement fine-grained IncrementalGraph locking (per-node locks + short commit mutex)

### DIFF
--- a/backend/src/generators/incremental_graph/class.js
+++ b/backend/src/generators/incremental_graph/class.js
@@ -36,7 +36,11 @@ const {
     validateNoOverlap,
     validateSingleArityPerHead,
 } = require("./compiled_node");
-const { makeGraphStorage, getOrAllocateNodeIdentifier } = require("./graph_state");
+const {
+    makeGraphStorage,
+    getOrAllocateNodeIdentifier,
+    lookupNodeIdentifier,
+} = require("./graph_state");
 const {
     internalGetDbVersion,
     internalGetFreshness,
@@ -61,6 +65,7 @@ const {
     internalUnsafePull,
 } = require("./pull");
 const { internalMaybeRecalculate } = require("./recompute");
+const { acquireTransactionNodeLock } = require("./lock");
 
 class IncrementalGraphClass {
     /** @type {Map<import('./types').NodeName, CompiledNode>} */
@@ -193,9 +198,23 @@ class IncrementalGraphClass {
     /**
      * @param {ConcreteNode} concreteNode
      * @param {Transaction} tx
-     * @returns {ResolvedConcreteNode}
+     * @returns {Promise<ResolvedConcreteNode>}
      */
-    resolveConcreteNode(concreteNode, tx) {
+    async resolveConcreteNode(concreteNode, tx) {
+        await acquireTransactionNodeLock(tx, concreteNode.output);
+        const inputIdentifiers = [];
+        for (const inputKey of concreteNode.inputs) {
+            const existingIdentifier = lookupNodeIdentifier(tx, inputKey);
+            if (existingIdentifier !== undefined) {
+                inputIdentifiers.push(existingIdentifier);
+                continue;
+            }
+            await acquireTransactionNodeLock(tx, inputKey);
+            inputIdentifiers.push(
+                getOrAllocateNodeIdentifier(tx, this.rootDatabase, inputKey)
+            );
+        }
+
         return {
             outputKey: concreteNode.output,
             inputKeys: concreteNode.inputs,
@@ -204,9 +223,7 @@ class IncrementalGraphClass {
                 this.rootDatabase,
                 concreteNode.output
             ),
-            inputIdentifiers: concreteNode.inputs.map((inputKey) =>
-                getOrAllocateNodeIdentifier(tx, this.rootDatabase, inputKey)
-            ),
+            inputIdentifiers,
             computor: concreteNode.computor,
         };
     }

--- a/backend/src/generators/incremental_graph/database/identifier_lookup.js
+++ b/backend/src/generators/incremental_graph/database/identifier_lookup.js
@@ -370,10 +370,24 @@ function txNodeIdToKey(txLookup, nodeIdentifier) {
  * @param {TransactionIdentifierLookup} txLookup
  * @param {NodeKeyString} nodeKey
  * @param {(attempt: number) => NodeIdentifier} makeIdentifier
+ * @param {Set<string> | number} [inFlightIdentifiers]
+ * @param {Set<string>} [reservedIdentifiers]
  * @param {number} [maxAttempts=64]
  * @returns {NodeIdentifier}
  */
-function txAllocateNodeIdentifier(txLookup, nodeKey, makeIdentifier, maxAttempts = 64) {
+function txAllocateNodeIdentifier(
+    txLookup,
+    nodeKey,
+    makeIdentifier,
+    inFlightIdentifiers = new Set(),
+    reservedIdentifiers = new Set(),
+    maxAttempts = 64
+) {
+    if (typeof inFlightIdentifiers === "number") {
+        maxAttempts = inFlightIdentifiers;
+        inFlightIdentifiers = new Set();
+    }
+
     const existing = txNodeKeyToId(txLookup, nodeKey);
     if (existing !== undefined) {
         return existing;
@@ -382,12 +396,18 @@ function txAllocateNodeIdentifier(txLookup, nodeKey, makeIdentifier, maxAttempts
     const keyString = nodeKeyStringToString(nodeKey);
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
         const candidate = makeIdentifier(attempt);
-        // Collision-check against both overlay and base.
-        if (txNodeIdToKey(txLookup, candidate) === undefined) {
-            txLookup.keyToId.set(keyString, candidate);
-            txLookup.idToKey.set(nodeIdentifierToString(candidate), nodeKey);
-            return candidate;
+        const candidateString = nodeIdentifierToString(candidate);
+        if (txNodeIdToKey(txLookup, candidate) !== undefined) {
+            continue;
         }
+        if (inFlightIdentifiers.has(candidateString)) {
+            continue;
+        }
+        inFlightIdentifiers.add(candidateString);
+        reservedIdentifiers.add(candidateString);
+        txLookup.keyToId.set(keyString, candidate);
+        txLookup.idToKey.set(candidateString, nodeKey);
+        return candidate;
     }
 
     throw new IdentifierAllocationError(keyString);

--- a/backend/src/generators/incremental_graph/database/root_database.js
+++ b/backend/src/generators/incremental_graph/database/root_database.js
@@ -62,6 +62,7 @@ const {
  * @property {GlobalSublevelType} globalSublevel
  * @property {SchemaStorage} schemaStorage
  * @property {IdentifierLookup} identifierLookup
+ * @property {Set<string>} inFlightIdentifiers
  */
 
 /**
@@ -308,6 +309,7 @@ class RootDatabaseClass {
             globalSublevel,
             schemaStorage: buildSchemaStorage(namespaceSublevel, globalSublevel, version),
             identifierLookup: makeEmptyIdentifierLookup(),
+            inFlightIdentifiers: new Set(),
         };
     }
 
@@ -336,6 +338,21 @@ class RootDatabaseClass {
      */
     getActiveIdentifierLookup() {
         return this._computed.identifierLookup;
+    }
+
+    /**
+     * @returns {Set<string>}
+     */
+    getInFlightIdentifiers() {
+        return this._computed.inFlightIdentifiers;
+    }
+
+    /**
+     * @param {string} identifier
+     * @returns {void}
+     */
+    releaseInFlightIdentifier(identifier) {
+        this._computed.inFlightIdentifiers.delete(identifier);
     }
 
     /**
@@ -422,7 +439,14 @@ class RootDatabaseClass {
             const schemaStorage = buildSchemaStorage(namespaceSublevel, globalSublevel, this.version);
             const identifierLookup = await loadIdentifierLookupFromGlobal(globalSublevel);
             await this._rootMetaSublevel.put('current_replica', name);
-            this._computed = { replicaName: name, namespaceSublevel, globalSublevel, schemaStorage, identifierLookup };
+            this._computed = {
+                replicaName: name,
+                namespaceSublevel,
+                globalSublevel,
+                schemaStorage,
+                identifierLookup,
+                inFlightIdentifiers: new Set(),
+            };
         } catch (err) {
             throw new SwitchReplicaError(name, err);
         }
@@ -492,6 +516,7 @@ class RootDatabaseClass {
                 globalSublevel,
                 schemaStorage: buildSchemaStorage(namespaceSublevel, globalSublevel, this.version),
                 identifierLookup: await loadIdentifierLookupFromGlobal(globalSublevel),
+                inFlightIdentifiers: new Set(),
             };
         }
     }

--- a/backend/src/generators/incremental_graph/graph_state.js
+++ b/backend/src/generators/incremental_graph/graph_state.js
@@ -16,6 +16,7 @@ const {
     IDENTIFIERS_KEY,
     nodeIdentifierToString,
     stringToNodeIdentifier,
+    stringToNodeKeyString,
     makeTransactionIdentifierLookup,
     txAllocateNodeIdentifier,
     txNodeIdToKey,
@@ -23,7 +24,11 @@ const {
     serializeTransactionLookup,
     commitTransactionLookup,
 } = require('./database');
-const { withComputedStateMutex } = require('./lock');
+const {
+    withCommitMutex,
+    releaseConcreteNodeLocks,
+    transactionHoldsNodeLock,
+} = require('./lock');
 
 /** @typedef {import('./database/root_database').RootDatabase} RootDatabase */
 /** @typedef {import('./database/root_database').SchemaStorage} SchemaStorage */
@@ -75,6 +80,9 @@ const { withComputedStateMutex } = require('./lock');
  * @typedef {object} Transaction
  * @property {BatchBuilder} batch - LevelDB batch accumulator with read-your-writes.
  * @property {TransactionIdentifierLookup} identifierLookup - Overlay-based identifier lookup.
+ * @property {Set<string>} reservedIdentifiers - Generated identifiers reserved by this transaction.
+ * @property {Set<string>} heldNodeLocks - Concrete semantic node locks held until transaction finish.
+ * @property {Map<string, () => void>} nodeLockReleases - Release callbacks for held node locks.
  * @property {Map<import('./types').NodeKeyString, Promise<import('./types').RecomputeResult>>} inFlight - Per-key in-flight pull promises for deduplication of concurrent nested pulls.
  */
 
@@ -93,6 +101,7 @@ const { withComputedStateMutex } = require('./lock');
  * @property {(input: NodeIdentifier, batch: BatchBuilder) => Promise<NodeIdentifier[]>} listDependents - Read a node's dependents inside the current batch.
  * @property {(node: NodeIdentifier, batch: BatchBuilder) => Promise<NodeIdentifier[] | null>} getInputs - Read a node's inputs inside the current batch.
  * @property {() => Promise<NodeIdentifier[]>} listMaterializedNodes - List all materialized node identifiers.
+ * @property {<T>(procedure: () => Promise<T>) => Promise<T>} withCommitSnapshot - Run a read while commit publication is paused.
  */
 
 /**
@@ -300,10 +309,11 @@ function makeGraphStorage(rootDatabase, sleeper) {
          * transaction start and the second O(n log n) copy at commit time. Only new
          * allocations (typically very few per transaction) are tracked in the overlay.
          *
-         * The entire operation happens inside withComputedStateMutex, serializing all
-         * concurrent callers end-to-end and eliminating identifier allocation races.
+         * The operation body runs without the commit mutex. Concrete node locks
+         * protect node-owned records, and the commit mutex is held only while
+         * durable writes and volatile identifier publication are finalized.
          *
-         * Callers that are already inside the mutex (nested dependency pulls) must
+         * Callers that are already inside a transaction (nested dependency pulls) must
          * NOT call this method again; they must receive the outer transaction via
          * explicit argument passing and operate on it directly.
          *
@@ -312,63 +322,94 @@ function makeGraphStorage(rootDatabase, sleeper) {
          * @returns {Promise<T>}
          */
         async withTransaction(fn) {
-            return await withComputedStateMutex(sleeper, rootDatabase.currentReplicaName(), async () => {
-                // createTransaction(): get a direct reference to _computed.identifierLookup
-                // (no clone), create an empty overlay for this transaction's allocations.
-                const activeSchemaStorage = rootDatabase.getSchemaStorage();
-                const txLookup = makeTransactionIdentifierLookup(rootDatabase.getActiveIdentifierLookup());
-                const { batch, operations } = createBatch(activeSchemaStorage);
+            const activeSchemaStorage = rootDatabase.getSchemaStorage();
+            const txLookup = makeTransactionIdentifierLookup(rootDatabase.getActiveIdentifierLookup());
+            const { batch, operations } = createBatch(activeSchemaStorage);
 
-                /** @type {Transaction} */
-                const tx = { batch, identifierLookup: txLookup, inFlight: new Map() };
+            /** @type {Transaction} */
+            const tx = {
+                batch,
+                identifierLookup: txLookup,
+                reservedIdentifiers: new Set(),
+                heldNodeLocks: new Set(),
+                nodeLockReleases: new Map(),
+                inFlight: new Map(),
+            };
 
-                // Run the operation (identifier allocation + node-data writes).
+            let transactionCommitted = false;
+            try {
                 const value = await fn(tx);
 
-                // commitTransaction(): disk-first — flush batch, then update volatile layer.
-                // txLookup.keyToId contains only the new allocations from this transaction.
-                const hasPendingOperations = operations.length > 0;
-                const hasPendingAllocations = tx.identifierLookup.keyToId.size > 0;
-                const hasPersistentDelta = hasPendingOperations || hasPendingAllocations;
+                await withCommitMutex(sleeper, rootDatabase.currentReplicaName(), async () => {
+                    const hasPendingOperations = operations.length > 0;
+                    const hasPendingAllocations = tx.identifierLookup.keyToId.size > 0;
+                    const hasPersistentDelta = hasPendingOperations || hasPendingAllocations;
 
-                // No-op transaction: no node writes and no new identifier allocations.
-                // Skip persistence work entirely.
-                if (!hasPersistentDelta) {
-                    return value;
-                }
+                    if (!hasPersistentDelta) {
+                        transactionCommitted = true;
+                        return;
+                    }
 
-                if (hasPendingAllocations) {
-                    if (activeSchemaStorage.global === undefined) {
-                        throw new Error(
-                            "Cannot commit identifier allocations: activeSchemaStorage.global is undefined. " +
-                            "The volatile state cannot be synchronized with disk, which would violate " +
-                            "the disk-first ordering invariant (volatile must not advance ahead of disk)."
+                    if (hasPendingAllocations) {
+                        if (activeSchemaStorage.global === undefined) {
+                            throw new Error(
+                                "Cannot commit identifier allocations: activeSchemaStorage.global is undefined. " +
+                                "The volatile state cannot be synchronized with disk, which would violate " +
+                                "the disk-first ordering invariant (volatile must not advance ahead of disk)."
+                            );
+                        }
+                        for (const [keyString, identifier] of tx.identifierLookup.keyToId.entries()) {
+                            const committedIdentifier = rootDatabase.nodeKeyToId(stringToNodeKeyString(keyString));
+                            if (committedIdentifier !== undefined && committedIdentifier !== identifier) {
+                                throw new Error(
+                                    `Identifier lookup conflict: node key ${keyString} is already mapped to ${nodeIdentifierToString(committedIdentifier)}`
+                                );
+                            }
+                        }
+                        for (const [identifierString, nodeKey] of tx.identifierLookup.idToKey.entries()) {
+                            const committedNodeKey = rootDatabase.nodeIdToKey(stringToNodeIdentifier(identifierString));
+                            if (committedNodeKey !== undefined && committedNodeKey !== nodeKey) {
+                                throw new Error(
+                                    `Identifier lookup conflict: identifier ${identifierString} is already mapped to ${String(committedNodeKey)}`
+                                );
+                            }
+                        }
+                        operations.push(
+                            activeSchemaStorage.global.rawPutOp(
+                                IDENTIFIERS_KEY,
+                                serializeTransactionLookup(tx.identifierLookup)
+                            )
                         );
                     }
-                    operations.push(
-                        activeSchemaStorage.global.rawPutOp(
-                            IDENTIFIERS_KEY,
-                            serializeTransactionLookup(tx.identifierLookup)
-                        )
-                    );
-                }
 
-                await activeSchemaStorage.batch(operations);
+                    await activeSchemaStorage.batch(operations);
 
-                if (hasPendingAllocations) {
-                    // Disk flush succeeded: apply overlay to base in-place.
-                    // This is the only mutation of _computed.identifierLookup.
-                    commitTransactionLookup(tx.identifierLookup);
-                }
+                    if (hasPendingAllocations) {
+                        commitTransactionLookup(tx.identifierLookup);
+                    }
+                    transactionCommitted = true;
+                });
 
                 return value;
-            });
+            } finally {
+                for (const identifier of tx.reservedIdentifiers) {
+                    rootDatabase.releaseInFlightIdentifier(identifier);
+                }
+                tx.reservedIdentifiers.clear();
+                releaseConcreteNodeLocks(tx);
+                if (!transactionCommitted) {
+                    tx.inFlight.clear();
+                }
+            }
         },
         ensureMaterialized,
         ensureReverseDepsIndexed,
         listDependents,
         getInputs,
         listMaterializedNodes,
+        withCommitSnapshot(procedure) {
+            return withCommitMutex(sleeper, rootDatabase.currentReplicaName(), procedure);
+        },
     };
 }
 
@@ -395,10 +436,19 @@ function lookupNodeIdentifier(tx, nodeKey) {
  * @returns {NodeIdentifier}
  */
 function getOrAllocateNodeIdentifier(tx, rootDatabase, nodeKey) {
+    const existing = lookupNodeIdentifier(tx, nodeKey);
+    if (existing !== undefined) {
+        return existing;
+    }
+    if (!transactionHoldsNodeLock(tx, nodeKey)) {
+        throw new Error(`Cannot allocate node identifier without holding node lock for ${String(nodeKey)}`);
+    }
     return txAllocateNodeIdentifier(
         tx.identifierLookup,
         nodeKey,
-        () => rootDatabase.generateNodeIdentifier()
+        () => rootDatabase.generateNodeIdentifier(),
+        rootDatabase.getInFlightIdentifiers(),
+        tx.reservedIdentifiers
     );
 }
 

--- a/backend/src/generators/incremental_graph/inspection.js
+++ b/backend/src/generators/incremental_graph/inspection.js
@@ -110,19 +110,21 @@ function internalGetSchemaByHead(incrementalGraph, head) {
  * @returns {Promise<Array<[string, Array<ConstValue>]>>}
  */
 async function internalListMaterializedNodes(incrementalGraph) {
-    return withObserveMode(incrementalGraph.sleeper, async () => {
-        const materializedNodes = await incrementalGraph.storage.listMaterializedNodes();
-        return materializedNodes.map((nodeIdentifier) => {
-            const nodeKey = incrementalGraph.lookupNodeKey(nodeIdentifier);
-            if (nodeKey === undefined) {
-                throw new Error(
-                    `Missing semantic node key for materialized identifier ${String(nodeIdentifier)}: cannot list nodes`
-                );
-            }
-            const parsed = deserializeNodeKey(stringToNodeKeyString(String(nodeKey)));
-            return [nodeNameToString(parsed.head), parsed.args];
-        });
-    });
+    return withObserveMode(incrementalGraph.sleeper, async () =>
+        incrementalGraph.storage.withCommitSnapshot(async () => {
+            const materializedNodes = await incrementalGraph.storage.listMaterializedNodes();
+            return materializedNodes.map((nodeIdentifier) => {
+                const nodeKey = incrementalGraph.lookupNodeKey(nodeIdentifier);
+                if (nodeKey === undefined) {
+                    throw new Error(
+                        `Missing semantic node key for materialized identifier ${String(nodeIdentifier)}: cannot list nodes`
+                    );
+                }
+                const parsed = deserializeNodeKey(stringToNodeKeyString(String(nodeKey)));
+                return [nodeNameToString(parsed.head), parsed.args];
+            });
+        })
+    );
 }
 
 /**

--- a/backend/src/generators/incremental_graph/invalidate.js
+++ b/backend/src/generators/incremental_graph/invalidate.js
@@ -16,7 +16,7 @@
  * @property {import('../../sleeper').SleepCapability} sleeper
  * @property {import('./graph_state').GraphStorage} storage
  * @property {<T>(procedure: (tx: Transaction) => Promise<T>) => Promise<T>} withTransaction
- * @property {(nodeDefinition: import('./types').ConcreteNode, tx: Transaction) => import('./types').ResolvedConcreteNode} resolveConcreteNode
+ * @property {(nodeDefinition: import('./types').ConcreteNode, tx: Transaction) => Promise<import('./types').ResolvedConcreteNode>} resolveConcreteNode
  * @property {(nodeKeyStr: NodeKeyString, compiledNode: import('./types').CompiledNode, bindings: Array<ConstValue>) => import('./types').ConcreteNode} getOrCreateConcreteNode
  */
 
@@ -110,7 +110,7 @@ async function internalUnsafeInvalidate(
      * @returns {Promise<void>}
      */
     const run = async (tx) => {
-        const nodeDefinition = incrementalGraph.resolveConcreteNode(
+        const nodeDefinition = await incrementalGraph.resolveConcreteNode(
             concreteNode,
             tx
         );

--- a/backend/src/generators/incremental_graph/lock.js
+++ b/backend/src/generators/incremental_graph/lock.js
@@ -15,6 +15,93 @@ const { makeUniqueFunctor } = require("../../unique_functor");
 const MUTEX_KEY = makeUniqueFunctor("incremental-graph-operations").instantiate([]);
 const GRAPH_ACTIVITY_KEY = makeUniqueFunctor("incremental-graph-activity").instantiate([]);
 const COMPUTED_STATE_KEY = makeUniqueFunctor("incremental-graph-computed-state");
+const COMMIT_KEY = makeUniqueFunctor("incremental-graph-commit");
+
+
+/**
+ * @typedef {{ promise: Promise<void>, release: () => void }} ManualLockEntry
+ */
+
+/** @type {Map<string, ManualLockEntry>} */
+const concreteNodeLocks = new Map();
+
+/**
+ * Acquire a process-local concrete node lock and return a release callback.
+ * @param {import('./types').NodeKeyString} nodeKey
+ * @returns {Promise<() => void>}
+ */
+async function acquireConcreteNodeLock(nodeKey) {
+    const stringKey = String(nodeKey);
+    for (;;) {
+        const existing = concreteNodeLocks.get(stringKey);
+        if (existing === undefined) {
+            break;
+        }
+        await existing.promise;
+    }
+
+    /** @type {() => void} */
+    let releasePromise = () => undefined;
+    const promise = new Promise((resolve) => {
+        releasePromise = () => resolve(undefined);
+    });
+    let released = false;
+    concreteNodeLocks.set(stringKey, {
+        promise,
+        release() {
+            if (released) {
+                return;
+            }
+            released = true;
+            concreteNodeLocks.delete(stringKey);
+            releasePromise();
+        },
+    });
+    return () => {
+        const entry = concreteNodeLocks.get(stringKey);
+        if (entry !== undefined) {
+            entry.release();
+        }
+    };
+}
+
+/**
+ * Release concrete node locks held by a transaction.
+ * @param {{ heldNodeLocks: Set<string>, nodeLockReleases: Map<string, () => void> }} tx
+ * @returns {void}
+ */
+function releaseConcreteNodeLocks(tx) {
+    const releases = Array.from(tx.nodeLockReleases.values()).reverse();
+    tx.nodeLockReleases.clear();
+    tx.heldNodeLocks.clear();
+    for (const release of releases) {
+        release();
+    }
+}
+
+/**
+ * @param {{ heldNodeLocks: Set<string>, nodeLockReleases: Map<string, () => void> }} tx
+ * @param {import('./types').NodeKeyString} nodeKey
+ * @returns {Promise<void>}
+ */
+async function acquireTransactionNodeLock(tx, nodeKey) {
+    const stringKey = String(nodeKey);
+    if (tx.heldNodeLocks.has(stringKey)) {
+        return;
+    }
+    const release = await acquireConcreteNodeLock(nodeKey);
+    tx.heldNodeLocks.add(stringKey);
+    tx.nodeLockReleases.set(stringKey, release);
+}
+
+/**
+ * @param {{ heldNodeLocks: Set<string> }} tx
+ * @param {import('./types').NodeKeyString} nodeKey
+ * @returns {boolean}
+ */
+function transactionHoldsNodeLock(tx, nodeKey) {
+    return tx.heldNodeLocks.has(String(nodeKey));
+}
 
 /** @typedef {import('../../sleeper').SleepCapability} SleepCapability */
 
@@ -80,6 +167,17 @@ function withComputedStateMutex(sleeper, computedStateIdentifier, procedure) {
 }
 
 /**
+ * @template T
+ * @param {SleepCapability} sleeper
+ * @param {string} replicaName
+ * @param {() => Promise<T>} procedure
+ * @returns {Promise<T>}
+ */
+function withCommitMutex(sleeper, replicaName, procedure) {
+    return sleeper.withMutex(COMMIT_KEY.instantiate([replicaName]), procedure);
+}
+
+/**
  * Acquires an exclusive lock that prevents all concurrent graph activity:
  * pulls, observes, and other exclusive operations (database opens, migrations).
  *
@@ -109,4 +207,8 @@ module.exports = {
     withObserveMode,
     withPullMode,
     withComputedStateMutex,
+    withCommitMutex,
+    acquireTransactionNodeLock,
+    releaseConcreteNodeLocks,
+    transactionHoldsNodeLock,
 };

--- a/backend/src/generators/incremental_graph/pull.js
+++ b/backend/src/generators/incremental_graph/pull.js
@@ -26,7 +26,7 @@
  * @property {import('../../sleeper').SleepCapability} sleeper
  * @property {import('./graph_state').GraphStorage} storage
  * @property {<T>(procedure: (tx: Transaction) => Promise<T>) => Promise<T>} withTransaction
- * @property {(nodeDefinition: import('./types').ConcreteNode, tx: Transaction) => import('./types').ResolvedConcreteNode} resolveConcreteNode
+ * @property {(nodeDefinition: import('./types').ConcreteNode, tx: Transaction) => Promise<import('./types').ResolvedConcreteNode>} resolveConcreteNode
  * @property {(nodeKeyStr: NodeKeyString, compiledNode: import('./types').CompiledNode, bindings: Array<ConstValue>) => import('./types').ConcreteNode} getOrCreateConcreteNode
  * @property {(nodeDefinition: import('./types').ResolvedConcreteNode, tx: Transaction) => Promise<RecomputeResult>} maybeRecalculate
  */
@@ -64,7 +64,7 @@ async function pullNode(graph, nodeKeyStr, tx) {
      * @returns {Promise<RecomputeResult>}
      */
     const runWithTransaction = async (activeTx) => {
-        const nodeDefinition = graph.resolveConcreteNode(concreteNode, activeTx);
+        const nodeDefinition = await graph.resolveConcreteNode(concreteNode, activeTx);
         const nodeFreshness = await activeTx.batch.freshness.get(nodeDefinition.outputIdentifier);
 
         if (nodeFreshness === "up-to-date") {

--- a/backend/tests/identifier_resolver.test.js
+++ b/backend/tests/identifier_resolver.test.js
@@ -23,7 +23,11 @@ const {
 function makeRootDatabase() {
     const generated = ["allocaaaa", "allocaaab", "allocaaac", "allocaaad"];
     let counter = 0;
+    const inFlightIdentifiers = new Set();
     return {
+        getInFlightIdentifiers() {
+            return inFlightIdentifiers;
+        },
         generateNodeIdentifier() {
             const value = generated[counter] ?? "allocaaaz";
             counter += 1;
@@ -42,7 +46,21 @@ function makeTransaction(initialLookupEntries) {
     return {
         batch: {},
         identifierLookup: makeTransactionIdentifierLookup(baseLookup),
+        reservedIdentifiers: new Set(),
+        heldNodeLocks: new Set(),
+        nodeLockReleases: new Map(),
+        inFlight: new Map(),
     };
+}
+
+/**
+ * Mark a test transaction as holding the concrete lock for a key.
+ * @param {ReturnType<typeof makeTransaction>} tx
+ * @param {import('../src/generators/incremental_graph/database').NodeKeyString} key
+ * @returns {void}
+ */
+function holdNodeLock(tx, key) {
+    tx.heldNodeLocks.add(String(key));
 }
 
 describe("Transaction-based identifier operations", () => {
@@ -76,6 +94,7 @@ describe("Transaction-based identifier operations", () => {
         const tx = makeTransaction([]);
         const db = makeRootDatabase();
         const key = stringToNodeKeyString('{"head":"node","args":[]}');
+        holdNodeLock(tx, key);
         
         const allocated = getOrAllocateNodeIdentifier(tx, db, key);
         expect(allocated).toBeDefined();
@@ -87,6 +106,7 @@ describe("Transaction-based identifier operations", () => {
         const tx = makeTransaction([]);
         const db = makeRootDatabase();
         const key = stringToNodeKeyString('{"head":"node","args":[]}');
+        holdNodeLock(tx, key);
         
         const first = getOrAllocateNodeIdentifier(tx, db, key);
         const second = getOrAllocateNodeIdentifier(tx, db, key);
@@ -111,6 +131,7 @@ describe("Transaction-based identifier operations", () => {
         const tx = makeTransaction([]);
         const db = makeRootDatabase();
         const key = stringToNodeKeyString('{"head":"node","args":[]}');
+        holdNodeLock(tx, key);
         
         const allocated = getOrAllocateNodeIdentifier(tx, db, key);
         const found = lookupNodeIdentifier(tx, key);
@@ -121,6 +142,7 @@ describe("Transaction-based identifier operations", () => {
         const tx = makeTransaction([]);
         const db = makeRootDatabase();
         const key = stringToNodeKeyString('{"head":"node","args":[]}');
+        holdNodeLock(tx, key);
         
         const allocated = getOrAllocateNodeIdentifier(tx, db, key);
         const found = requireNodeKey(tx, allocated);
@@ -132,6 +154,8 @@ describe("Transaction-based identifier operations", () => {
         const db = makeRootDatabase();
         const keyA = stringToNodeKeyString('{"head":"a","args":[]}');
         const keyB = stringToNodeKeyString('{"head":"b","args":[]}');
+        holdNodeLock(tx, keyA);
+        holdNodeLock(tx, keyB);
         
         const idA = getOrAllocateNodeIdentifier(tx, db, keyA);
         const idB = getOrAllocateNodeIdentifier(tx, db, keyB);
@@ -148,6 +172,7 @@ describe("Transaction-based identifier operations", () => {
         const db = makeRootDatabase();
         
         const newKey = stringToNodeKeyString('{"head":"new","args":[]}');
+        holdNodeLock(tx, newKey);
         const newId = getOrAllocateNodeIdentifier(tx, db, newKey);
         
         // Both the pre-existing entry and the new allocation are in the lookup.

--- a/backend/tests/incremental_graph_concurrency.test.js
+++ b/backend/tests/incremental_graph_concurrency.test.js
@@ -42,6 +42,7 @@ class InMemoryDatabase {
         /** @type {string} */
         this.version = 'test-version';
         this._identifierLookup = makeEmptyIdentifierLookup();
+        this._inFlightIdentifiers = new Set();
         this._identifierCounter = 0;
     }
 
@@ -53,6 +54,14 @@ class InMemoryDatabase {
 
     getActiveIdentifierLookup() {
         return this._identifierLookup;
+    }
+
+    getInFlightIdentifiers() {
+        return this._inFlightIdentifiers;
+    }
+
+    releaseInFlightIdentifier(identifier) {
+        this._inFlightIdentifiers.delete(identifier);
     }
 
     replaceActiveIdentifierLookup(lookup) {
@@ -768,7 +777,7 @@ describe("IncrementalGraph concurrency", () => {
             expect(maxActiveComputations).toBe(1);
         });
 
-        test("concurrent pulls on different nodes are serialized", async () => {
+        test("concurrent pulls on different nodes overlap", async () => {
             const capabilities = getMockedRootCapabilities();
             const db = new InMemoryDatabase();
             const source1Cell = { value: { type: "test", value: 1 } };
@@ -804,13 +813,12 @@ describe("IncrementalGraph concurrency", () => {
             const pull1 = graph.pull("source1");
             const pull2 = graph.pull("source2");
             await new Promise((resolve) => setTimeout(resolve, 20));
-            // Pulls on different nodes are now serialized by withComputedStateMutex:
-            // source1 holds the mutex (awaiting releaseBoth), source2 has not started yet.
-            expect(started).toEqual(["source1"]);
+            // Pulls on different concrete nodes overlap: both computors enter
+            // before either one finishes.
+            expect(started.sort()).toEqual(["source1", "source2"]);
 
             releaseBoth.resolve(undefined);
             await Promise.all([pull1, pull2]);
-            // After both complete (sequentially), both have been computed.
             expect(started.sort()).toEqual(["source1", "source2"]);
         });
 

--- a/backend/tests/incremental_graph_spec.test.js
+++ b/backend/tests/incremental_graph_spec.test.js
@@ -53,6 +53,7 @@ class InMemoryDatabase {
         /** @type {string} */
         this.version = 'test-version';
         this._identifierLookup = makeEmptyIdentifierLookup();
+        this._inFlightIdentifiers = new Set();
         this._identifierCounter = 0;
     }
 
@@ -64,6 +65,14 @@ class InMemoryDatabase {
 
     getActiveIdentifierLookup() {
         return this._identifierLookup;
+    }
+
+    getInFlightIdentifiers() {
+        return this._inFlightIdentifiers;
+    }
+
+    releaseInFlightIdentifier(identifier) {
+        this._inFlightIdentifiers.delete(identifier);
     }
 
     replaceActiveIdentifierLookup(lookup) {

--- a/backend/tests/incremental_graph_volatile_consistency.test.js
+++ b/backend/tests/incremental_graph_volatile_consistency.test.js
@@ -764,11 +764,11 @@ describe("Supplemental scenario — Read-only lookups do not interfere with allo
 });
 
 // ---------------------------------------------------------------------------
-// Invariant 3 — Serialisation: all mutations are serialized by the mutex
+// Invariant 3 — Independent pull concurrency
 // ---------------------------------------------------------------------------
 
-describe("Invariant 3 — Serialisation of concurrent mutations", () => {
-    test("pulls on different independent nodes are serialized (not concurrent)", async () => {
+describe("Invariant 3 — Independent pull concurrency", () => {
+    test("pulls on different independent nodes can run concurrently", async () => {
         const capabilities = getTestCapabilities();
         const db = await getRootDatabase(capabilities);
         const released = makeDeferredPromise();
@@ -808,15 +808,14 @@ describe("Invariant 3 — Serialisation of concurrent mutations", () => {
             await new Promise((resolve) => setTimeout(resolve, 10));
         }
 
-        // While the first pull is blocked in its computor, the second pull must not
-        // enter its own computor yet.
-        expect(started.length).toBe(1);
+        // Independent concrete nodes are protected by different node locks, so both
+        // computors may enter before either finishes.
+        expect(started.sort()).toEqual(["n1", "n2"]);
 
-        // Release n1's computor; n1 commits, then n2 acquires the mutex and starts.
+        // Release both computors and allow both transactions to commit.
         released.resolve(undefined);
         await Promise.all([p1, p2]);
 
-        // After both complete, both were computed (sequentially).
         expect(started.sort()).toEqual(["n1", "n2"]);
 
         await db.close();

--- a/backend/tests/test_database_helper.js
+++ b/backend/tests/test_database_helper.js
@@ -34,6 +34,18 @@ const {
  * @param {string} key
  * @returns {string}
  */
+/**
+ * Allocate an identifier in a test transaction after marking the semantic lock held.
+ * @param {import('../src/generators/incremental_graph/graph_state').Transaction} tx
+ * @param {import('../src/generators/incremental_graph/database/root_database').RootDatabase} rootDatabase
+ * @param {string} jsonKey
+ * @returns {import('../src/generators/incremental_graph/database').NodeIdentifier}
+ */
+function getOrAllocateNodeIdentifierForTest(tx, rootDatabase, jsonKey) {
+    tx.heldNodeLocks.add(String(jsonKey));
+    return getOrAllocateNodeIdentifier(tx, rootDatabase, jsonKey);
+}
+
 function toJsonKey(key) {
     // If already a valid JSON key, return as-is
     if (isJsonKey(key)) {
@@ -124,7 +136,7 @@ function makeSemanticStorage(graph) {
             async put(key, value) {
                 const jsonKey = toJsonKey(key);
                 await graph.withTransaction(async (tx) => {
-                    const nodeIdentifier = getOrAllocateNodeIdentifier(
+                    const nodeIdentifier = getOrAllocateNodeIdentifierForTest(
                         tx,
                         graph.rootDatabase,
                         jsonKey
@@ -133,7 +145,7 @@ function makeSemanticStorage(graph) {
                         tx.batch.inputs.put(nodeIdentifier, {
                             inputs: value.inputs.map((inputKey) =>
                                 nodeIdentifierToString(
-                                    getOrAllocateNodeIdentifier(
+                                    getOrAllocateNodeIdentifierForTest(
                                         tx,
                                         graph.rootDatabase,
                                         toJsonKey(inputKey)
@@ -148,7 +160,7 @@ function makeSemanticStorage(graph) {
                         tx.batch.revdeps.put(
                             nodeIdentifier,
                             value.map((dependentKey) =>
-                                getOrAllocateNodeIdentifier(
+                                getOrAllocateNodeIdentifierForTest(
                                     tx,
                                     graph.rootDatabase,
                                     toJsonKey(dependentKey)
@@ -214,12 +226,12 @@ function makeSemanticStorage(graph) {
                         put(key, value) {
                             const jsonKey = toJsonKey(key);
                             const nodeIdentifier =
-                                getOrAllocateNodeIdentifier(tx, graph.rootDatabase, jsonKey);
+                                getOrAllocateNodeIdentifierForTest(tx, graph.rootDatabase, jsonKey);
                             if (databaseName === "inputs") {
                                 tx.batch.inputs.put(nodeIdentifier, {
                                     inputs: value.inputs.map((inputKey) =>
                                         nodeIdentifierToString(
-                                            getOrAllocateNodeIdentifier(
+                                            getOrAllocateNodeIdentifierForTest(
                                                 tx,
                                                 graph.rootDatabase,
                                                 toJsonKey(inputKey)
@@ -234,7 +246,7 @@ function makeSemanticStorage(graph) {
                                 tx.batch.revdeps.put(
                                     nodeIdentifier,
                                     value.map((dependentKey) =>
-                                        getOrAllocateNodeIdentifier(
+                                        getOrAllocateNodeIdentifierForTest(
                                             tx,
                                             graph.rootDatabase,
                                             toJsonKey(dependentKey)


### PR DESCRIPTION
### Motivation
- Implement the locking model from `docs/design.md` so independent `pull()` work can overlap while preserving durable/volatile identifier lookup consistency. 
- Remove the previous broad transaction serialization so user computors and dependency traversal do not run under the durable commit/publish lock. 
- Ensure identifier allocation is synchronous, reserved while in-flight, and remains a bijection across commits.

### Description
- Add per-semantic-node concrete locks and transaction-held lock tracking with helpers in `backend/src/generators/incremental_graph/lock.js` (`acquireTransactionNodeLock`, `releaseConcreteNodeLocks`, `transactionHoldsNodeLock`, `withCommitMutex`).
- Change transaction lifecycle in `backend/src/generators/incremental_graph/graph_state.js` so user computors run outside the short commit mutex and commit-time work (durable batch + volatile `identifierLookup` publication) runs under `withCommitMutex`; transactions now track `reservedIdentifiers`, `heldNodeLocks`, and `nodeLockReleases` and clean them up on commit/abort.
- Extend identifier allocation to use an in-process reservation set and record reservations on allocation in `backend/src/generators/incremental_graph/database/identifier_lookup.js` (`txAllocateNodeIdentifier` now accepts `inFlightIdentifiers` and `reservedIdentifiers`).
- Add `inFlightIdentifiers` to active replica state and accessors in `backend/src/generators/incremental_graph/database/root_database.js` so allocations are checked against live reservations.
- Make concrete-node resolution asynchronous and acquire concrete node locks before allocating identifiers in `backend/src/generators/incremental_graph/class.js` (`resolveConcreteNode` now awaits locks and avoids locking already-identified inputs).
- Protect multi-record inspection scans by taking a short commit snapshot via `withCommitSnapshot` on `GraphStorage` and update `inspection.js` to use it to avoid mixed volatile/durable snapshots.
- Update tests/helpers to reflect the new locking and in-flight reservation semantics (concurrency tests now assert that independent pulls may overlap), including edits to `backend/tests/*` and `backend/tests/test_database_helper.js`.

### Testing
- Ran focused unit tests: `npx jest backend/tests/identifier_resolver.test.js backend/tests/incremental_graph.test.js backend/tests/incremental_graph_concurrency.test.js` and `npx jest backend/tests/incremental_graph_volatile_consistency.test.js` with `--runInBand`; all passed.
- Ran static analysis and build: `npm run static-analysis` and `npm run build`; both succeeded with no errors.
- Ran full test suite: `npm test -- --maxWorkers=2`; result: all test suites passed (`244` suites, `2732` tests) and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c7d667944832eb5d7b1964c494994)