### PR TITLE
Reconcile host identifiers during sync merge

### DIFF
--- a/backend/src/generators/incremental_graph/database/sync_merge.js
+++ b/backend/src/generators/incremental_graph/database/sync_merge.js
@@ -45,18 +45,17 @@
  */
 
 const { topologicalSortFromMap, isTopologicalSortCycleError } = require('./topo_sort');
+const { compareIsoTimestamps } = require('./sync_merge_timestamps');
 const { stringToNodeIdentifier, versionToString } = require('./types');
-const { compareNodeIdentifier } = require('./node_identifier');
+const { compareNodeIdentifier, nodeIdentifierToString } = require('./node_identifier');
 const { RAW_BATCH_CHUNK_SIZE } = require('./constants');
 const { makeDbToDbAdapter, unifyStores } = require('./unification');
 const {
-    makeEmptyIdentifierLookup,
-    makeIdentifierLookup,
     mergeIdentifierLookups,
     serializeIdentifierLookup,
 } = require('./identifier_lookup');
 const { reconcileHostLookupWithTargetLookup } = require('./reconcile_identifier_lookup');
-const { MalformedIdentifierLookupError } = require('./replica_errors');
+const { makeHostIdentifierTranslation, parseIdentifierLookup } = require('./sync_merge_identifier_translation');
 
 /** @typedef {import('./root_database').RootDatabase} RootDatabase */
 /** @typedef {import('./root_database').SchemaStorage} SchemaStorage */
@@ -127,27 +126,6 @@ function isSyncMergeAggregateError(object) {
 // ─── Internal helpers ─────────────────────────────────────────────────────────
 
 /**
- * Compare two ISO-8601 date strings.
- * Returns negative if a < b, 0 if equal, positive if a > b.
- * `undefined` is treated as the oldest possible value (before any real timestamp).
- *
- * ISO 8601 UTC timestamps (ending in 'Z') are lexicographically ordered,
- * so plain string comparison produces the correct temporal ordering.
- *
- * @param {string | undefined} a
- * @param {string | undefined} b
- * @returns {number}
- */
-function compareIsoTimestamps(a, b) {
-    if (a === undefined && b === undefined) return 0;
-    if (a === undefined) return -1;
-    if (b === undefined) return 1;
-    if (a < b) return -1;
-    if (a > b) return 1;
-    return 0;
-}
-
-/**
  * Gently unify the entire contents of replica `from` into replica `to`.
  * Only keys whose value differs are written; keys absent from the source
  * are deleted from the target.  This replaces the previous clear-then-copy
@@ -182,46 +160,52 @@ async function copyReplicaGently(rootDatabase, from, to) {
  *
  * @param {SchemaStorage} T - Target (inactive) replica storage.
  * @param {SchemaStorage} H - Hostname staging storage.
- * @param {NodeIdentifier} key
+ * @param {NodeIdentifier} targetKey - Identifier to write in the target replica.
+ * @param {NodeIdentifier} hostKey - Identifier to read from the host staging storage.
+ * @param {(hostIdentifier: NodeIdentifier) => NodeIdentifier} targetIdentifierForHostIdentifier
  * @returns {Promise<Array<*>>}
  */
-async function buildTakeOps(T, H, key) {
+async function buildTakeOps(T, H, targetKey, hostKey, targetIdentifierForHostIdentifier) {
     /** @type {Array<*>} */
     const ops = [];
 
-    const hValue = await H.values.get(key);
+    const hValue = await H.values.get(hostKey);
     if (hValue !== undefined) {
-        ops.push(T.values.putOp(key, hValue));
+        ops.push(T.values.putOp(targetKey, hValue));
     } else {
-        ops.push(T.values.delOp(key));
+        ops.push(T.values.delOp(targetKey));
     }
 
-    const hFreshness = await H.freshness.get(key);
-    ops.push(T.freshness.putOp(key, hFreshness !== undefined ? hFreshness : 'potentially-outdated'));
+    const hFreshness = await H.freshness.get(hostKey);
+    ops.push(T.freshness.putOp(targetKey, hFreshness !== undefined ? hFreshness : 'potentially-outdated'));
 
-    const hTimestamps = await H.timestamps.get(key);
+    const hTimestamps = await H.timestamps.get(hostKey);
     if (hTimestamps !== undefined) {
-        ops.push(T.timestamps.putOp(key, hTimestamps));
+        ops.push(T.timestamps.putOp(targetKey, hTimestamps));
     } else {
-        ops.push(T.timestamps.delOp(key));
+        ops.push(T.timestamps.delOp(targetKey));
     }
 
-    const hInputs = await H.inputs.get(key);
+    const hInputs = await H.inputs.get(hostKey);
     if (hInputs !== undefined) {
-        ops.push(T.inputs.putOp(key, hInputs));
+        ops.push(T.inputs.putOp(targetKey, {
+            inputs: hInputs.inputs.map(input => nodeIdentifierToString(targetIdentifierForHostIdentifier(stringToNodeIdentifier(input)))),
+            inputCounters: hInputs.inputCounters,
+        }));
     } else {
-        ops.push(T.inputs.delOp(key));
+        ops.push(T.inputs.delOp(targetKey));
     }
 
-    const hCounter = await H.counters.get(key);
+    const hCounter = await H.counters.get(hostKey);
     if (hCounter !== undefined) {
-        ops.push(T.counters.putOp(key, hCounter));
+        ops.push(T.counters.putOp(targetKey, hCounter));
     } else {
-        ops.push(T.counters.delOp(key));
+        ops.push(T.counters.delOp(targetKey));
     }
 
     return ops;
 }
+
 
 /**
  * Gently update the revdeps index in `T` to match the desired state derived
@@ -357,6 +341,37 @@ async function mergeHostIntoReplica(logger, rootDatabase, hostname) {
     const T = rootDatabase.schemaStorageForReplica(toReplica);
     const H = rootDatabase.hostnameSchemaStorage(hostname);
 
+    const hostLookup = parseIdentifierLookup(await H.global.get('identifiers_keys_map'));
+    const targetLookup = parseIdentifierLookup(await T.global.get('identifiers_keys_map'));
+    const reconciledHostLookup = reconcileHostLookupWithTargetLookup(targetLookup, hostLookup);
+    const { hostToTarget, targetToHost } = makeHostIdentifierTranslation(hostLookup, reconciledHostLookup);
+
+    /**
+     * @param {NodeIdentifier} hostIdentifier
+     * @returns {NodeIdentifier}
+     */
+    function targetIdentifierForHostIdentifier(hostIdentifier) {
+        return hostToTarget.get(nodeIdentifierToString(hostIdentifier)) ?? hostIdentifier;
+    }
+
+    /**
+     * @param {NodeIdentifier} targetIdentifier
+     * @returns {NodeIdentifier}
+     */
+    function hostIdentifierForTargetIdentifier(targetIdentifier) {
+        return targetToHost.get(nodeIdentifierToString(targetIdentifier)) ?? targetIdentifier;
+    }
+
+    /**
+     * @param {import('./root_database').InputsRecord | undefined} record
+     * @returns {NodeIdentifier[]}
+     */
+    function translatedHostInputs(record) {
+        return record
+            ? record.inputs.map(input => targetIdentifierForHostIdentifier(stringToNodeIdentifier(input)))
+            : [];
+    }
+
     // ── Step 2: Collect nodes and build merged dependency map ────────────────
     //
     // Initial timestamp decisions are computed for all T nodes.  Then the
@@ -380,7 +395,7 @@ async function mergeHostIntoReplica(logger, rootDatabase, hostname) {
 
     for await (const node of T.inputs.keys()) {
         const tTimestamps = await T.timestamps.get(node);
-        const hTimestamps = await H.timestamps.get(node);
+        const hTimestamps = await H.timestamps.get(hostIdentifierForTargetIdentifier(node));
 
         const cmp = compareIsoTimestamps(tTimestamps?.modifiedAt, hTimestamps?.modifiedAt);
 
@@ -398,9 +413,10 @@ async function mergeHostIntoReplica(logger, rootDatabase, hostname) {
     // ── 2b: Discover H-only nodes ─────────────────────────────────────────────
     /** @type {Set<NodeIdentifier>} */
     const hOnlyNodes = new Set();
-    for await (const key of H.inputs.keys()) {
-        if (!initialDecisions.has(key)) {
-            hOnlyNodes.add(key);
+    for await (const hostKey of H.inputs.keys()) {
+        const targetKey = targetIdentifierForHostIdentifier(hostKey);
+        if (!initialDecisions.has(targetKey)) {
+            hOnlyNodes.add(targetKey);
         }
     }
 
@@ -420,22 +436,20 @@ async function mergeHostIntoReplica(logger, rootDatabase, hostname) {
             // merged graph (empty list).  Falling back to T.inputs here would
             // make mergedInputsMap inconsistent with the actual DB state after
             // the merge, leaving revdeps pointing to inputs that no longer exist.
-            record = await H.inputs.get(node);
+            record = await H.inputs.get(hostIdentifierForTargetIdentifier(node));
+            mergedInputsMap.set(node, translatedHostInputs(record));
         } else {
             record = await T.inputs.get(node);
+            const inputKeys = record
+                ? record.inputs.map(input => stringToNodeIdentifier(input))
+                : [];
+            mergedInputsMap.set(node, inputKeys);
         }
-        const inputKeys = record
-            ? record.inputs.map(s => stringToNodeIdentifier(s))
-            : [];
-        mergedInputsMap.set(node, inputKeys);
     }
 
     for (const key of hOnlyNodes) {
-        const record = await H.inputs.get(key);
-        const inputKeys = record
-            ? record.inputs.map(s => stringToNodeIdentifier(s))
-            : [];
-        mergedInputsMap.set(key, inputKeys);
+        const record = await H.inputs.get(hostIdentifierForTargetIdentifier(key));
+        mergedInputsMap.set(key, translatedHostInputs(record));
     }
 
     // ── Step 3: Stable topological sort of the merged graph ──────────────────
@@ -512,7 +526,7 @@ async function mergeHostIntoReplica(logger, rootDatabase, hostname) {
 
     for (const [node, decision] of decisions) {
         if (decision === 'take') {
-            const takeOps = await buildTakeOps(T, H, node);
+            const takeOps = await buildTakeOps(T, H, node, hostIdentifierForTargetIdentifier(node), targetIdentifierForHostIdentifier);
             pendingOps.push(...takeOps);
             // H-only nodes whose ancestors include a locally-kept (T-newer) node
             // were computed on the remote with stale inputs.  Copy the structural
@@ -528,7 +542,7 @@ async function mergeHostIntoReplica(logger, rootDatabase, hostname) {
             // mergedInputsMap and rebuilt revdeps. We then force freshness to
             // potentially-outdated to trigger recomputation.
             if (initialDecisions.get(node) === 'take') {
-                const takeOps = await buildTakeOps(T, H, node);
+                const takeOps = await buildTakeOps(T, H, node, hostIdentifierForTargetIdentifier(node), targetIdentifierForHostIdentifier);
                 pendingOps.push(...takeOps);
             }
             pendingOps.push(T.freshness.putOp(node, 'potentially-outdated'));
@@ -546,7 +560,7 @@ async function mergeHostIntoReplica(logger, rootDatabase, hostname) {
             // an ancestor, T.modifiedAt >= H.modifiedAt already — overwriting would
             // regress the timestamp.
             if (initialDecisions.get(node) === 'take') {
-                const hTimestamps = await H.timestamps.get(node);
+                const hTimestamps = await H.timestamps.get(hostIdentifierForTargetIdentifier(node));
                 if (hTimestamps !== undefined) {
                     const tTimestamps = await T.timestamps.get(node);
                     // Preserve T's createdAt; advance only modifiedAt to H's value.
@@ -578,17 +592,6 @@ async function mergeHostIntoReplica(logger, rootDatabase, hostname) {
     const hasChanges = taken + invalidated > 0;
 
     if (hasChanges) {
-        const hostIdentifierValue = await H.global.get('identifiers_keys_map');
-        const targetIdentifierValue = await T.global.get('identifiers_keys_map');
-        /** @param {unknown} rawEntries */
-        const parseIdentifierLookup = (rawEntries) => {
-            if (rawEntries === undefined) return makeEmptyIdentifierLookup();
-            if (!Array.isArray(rawEntries)) throw new MalformedIdentifierLookupError(rawEntries);
-            return makeIdentifierLookup(rawEntries);
-        };
-        const hostLookup = parseIdentifierLookup(hostIdentifierValue);
-        const targetLookup = parseIdentifierLookup(targetIdentifierValue);
-        const reconciledHostLookup = reconcileHostLookupWithTargetLookup(targetLookup, hostLookup);
         const mergedLookup = mergeIdentifierLookups(targetLookup, reconciledHostLookup);
 
         pendingOps.push(T.global.putOp('identifiers_keys_map', serializeIdentifierLookup(mergedLookup)));

--- a/backend/src/generators/incremental_graph/database/sync_merge_identifier_translation.js
+++ b/backend/src/generators/incremental_graph/database/sync_merge_identifier_translation.js
@@ -1,0 +1,60 @@
+const { nodeIdentifierFromString, nodeIdentifierToString } = require('./node_identifier');
+const {
+    makeEmptyIdentifierLookup,
+    makeIdentifierLookup,
+    nodeKeyToIdFromLookup,
+} = require('./identifier_lookup');
+const { MalformedIdentifierLookupError } = require('./replica_errors');
+
+/** @typedef {import('./types').NodeIdentifier} NodeIdentifier */
+/** @typedef {import('./identifier_lookup').IdentifierLookup} IdentifierLookup */
+
+/**
+ * Parse a persisted identifier lookup value from replica global metadata.
+ * Missing metadata is treated as an empty lookup so legacy/unit-test fixtures
+ * that write identifier-addressed nodes directly can still merge by identity.
+ *
+ * @param {unknown} rawEntries
+ * @returns {IdentifierLookup}
+ */
+function parseIdentifierLookup(rawEntries) {
+    if (rawEntries === undefined) return makeEmptyIdentifierLookup();
+    if (!Array.isArray(rawEntries)) throw new MalformedIdentifierLookupError(rawEntries);
+    return makeIdentifierLookup(rawEntries);
+}
+
+/**
+ * Build identifier translation tables from host identifiers into the target
+ * replica's reconciled identifier namespace.
+ *
+ * The host and target may independently allocate different identifiers for the
+ * same semantic node key. Decisions must be made in the target namespace, while
+ * host data still has to be read from the original host namespace. These maps
+ * keep that distinction explicit.
+ *
+ * @param {IdentifierLookup} hostLookup
+ * @param {IdentifierLookup} reconciledHostLookup
+ * @returns {{ hostToTarget: Map<string, NodeIdentifier>, targetToHost: Map<string, NodeIdentifier> }}
+ */
+function makeHostIdentifierTranslation(hostLookup, reconciledHostLookup) {
+    /** @type {Map<string, NodeIdentifier>} */
+    const hostToTarget = new Map();
+    /** @type {Map<string, NodeIdentifier>} */
+    const targetToHost = new Map();
+
+    for (const [hostIdentifierString, nodeKey] of hostLookup.idToKey.entries()) {
+        const hostIdentifier = nodeIdentifierFromString(hostIdentifierString);
+        const targetIdentifier = nodeKeyToIdFromLookup(reconciledHostLookup, nodeKey);
+        if (targetIdentifier !== undefined) {
+            hostToTarget.set(hostIdentifierString, targetIdentifier);
+            targetToHost.set(nodeIdentifierToString(targetIdentifier), hostIdentifier);
+        }
+    }
+
+    return { hostToTarget, targetToHost };
+}
+
+module.exports = {
+    makeHostIdentifierTranslation,
+    parseIdentifierLookup,
+};

--- a/backend/src/generators/incremental_graph/database/sync_merge_timestamps.js
+++ b/backend/src/generators/incremental_graph/database/sync_merge_timestamps.js
@@ -1,0 +1,22 @@
+/**
+ * Compare two ISO-8601 date strings.
+ * Returns negative if a < b, 0 if equal, positive if a > b.
+ * `undefined` is treated as the oldest possible value (before any real timestamp).
+ *
+ * ISO 8601 UTC timestamps (ending in 'Z') are lexicographically ordered,
+ * so plain string comparison produces the correct temporal ordering.
+ *
+ * @param {string | undefined} a
+ * @param {string | undefined} b
+ * @returns {number}
+ */
+function compareIsoTimestamps(a, b) {
+    if (a === undefined && b === undefined) return 0;
+    if (a === undefined) return -1;
+    if (b === undefined) return 1;
+    if (a < b) return -1;
+    if (a > b) return 1;
+    return 0;
+}
+
+module.exports = { compareIsoTimestamps };

--- a/backend/tests/sync_merge.test.js
+++ b/backend/tests/sync_merge.test.js
@@ -16,7 +16,10 @@
 const {
     getRootDatabase,
     isMalformedIdentifierLookupError,
+    makeIdentifierLookup,
     nodeIdentifierFromString,
+    serializeIdentifierLookup,
+    stringToNodeKeyString,
 } = require('../src/generators/incremental_graph/database');
 const {
     mergeHostIntoReplica,
@@ -177,6 +180,65 @@ describe('mergeHostIntoReplica', () => {
             const T = db.schemaStorageForReplica(newActive);
             const merged = await T.values.get(nodeA);
             expect(merged).toEqual(remoteValue);
+        } finally {
+            if (db) await db.close();
+        }
+    });
+
+    test('reconciles host identifiers before timestamp decisions and copied inputs', async () => {
+        const capabilities = getTestCapabilities();
+        let db;
+        try {
+            db = await getRootDatabase(capabilities);
+            const logger = makeLogger();
+            const hostname = 'peer';
+            const appVersionStr = db.version;
+            await db.setGlobalVersion(appVersionStr);
+            await db.setHostnameGlobal(hostname, 'version', appVersionStr);
+
+            const targetParent = nodeIdentifierFromString('parentaaa');
+            const targetChild = nodeIdentifierFromString('childaaaa');
+            const hostParent = nodeIdentifierFromString('parentbbb');
+            const hostChild = nodeIdentifierFromString('childbbbb');
+            const parentKey = stringToNodeKeyString('{"head":"parent","args":[]}');
+            const childKey = stringToNodeKeyString('{"head":"child","args":[]}');
+            const localChildValue = { value: { id: 'child-local', type: 'test', description: 'local child' }, isDirty: false };
+            const remoteChildValue = { value: { id: 'child-remote', type: 'test', description: 'remote child' }, isDirty: false };
+
+            const L = db.schemaStorageForReplica('x');
+            await writeNode(L, targetParent, TS1, [], undefined);
+            await writeNode(L, targetChild, TS1, [targetParent], localChildValue);
+            await L.global.put('identifiers_keys_map', serializeIdentifierLookup(makeIdentifierLookup([
+                [targetParent, parentKey],
+                [targetChild, childKey],
+            ])));
+
+            const H = db.hostnameSchemaStorage(hostname);
+            await writeNode(H, hostParent, TS1, [], undefined);
+            await writeNode(H, hostChild, TS2, [hostParent], remoteChildValue);
+            await H.global.put('identifiers_keys_map', serializeIdentifierLookup(makeIdentifierLookup([
+                [hostParent, parentKey],
+                [hostChild, childKey],
+            ])));
+
+            db = await mergeAndReopenIfSwitched(capabilities, logger, db, hostname);
+
+            const T = db.schemaStorageForReplica(db.currentReplicaName());
+            expect(db.currentReplicaName()).toBe('y');
+            expect(await T.values.get(targetChild)).toEqual(remoteChildValue);
+            expect(await T.values.get(hostChild)).toBeUndefined();
+            expect(await T.timestamps.get(targetChild)).toEqual({ createdAt: TS2, modifiedAt: TS2 });
+            expect(await T.timestamps.get(hostChild)).toBeUndefined();
+            expect(await T.inputs.get(targetChild)).toEqual({
+                inputs: [targetParent],
+                inputCounters: [],
+            });
+            expect(await T.revdeps.get(targetParent)).toEqual([targetChild]);
+            expect(await T.revdeps.get(hostParent)).toBeUndefined();
+            expect(await T.global.get('identifiers_keys_map')).toEqual(serializeIdentifierLookup(makeIdentifierLookup([
+                [targetParent, parentKey],
+                [targetChild, childKey],
+            ])));
         } finally {
             if (db) await db.close();
         }

--- a/docs/pr1335.md
+++ b/docs/pr1335.md
@@ -1,0 +1,117 @@
+# PR #1335: IncrementalGraph persistence by node identifier
+
+## What PR #1335 changes at a high level
+
+PR #1335 changes the IncrementalGraph database from a model where persisted graph records could be addressed by semantic node keys into a model where persisted graph records are addressed by opaque `NodeIdentifier` values. The semantic meaning of a node is no longer encoded in the storage key for values, freshness, inputs, reverse dependencies, counters, or timestamps. Instead, semantic identity is carried by the replica-global `identifiers_keys_map` bijection.
+
+The conceptual split is now:
+
+- **Semantic API boundary**: callers still describe graph nodes by semantic keys: a head plus arguments, serialized as `NodeKeyString` when necessary.
+- **Materialized storage boundary**: database sublevels store concrete node state by `NodeIdentifier`.
+- **Translation boundary**: IncrementalGraph resolves a semantic key to an identifier once, then passes identifiers through the lower storage layers.
+- **Inspection/migration boundary**: tooling that must explain or migrate graph contents reads `identifiers_keys_map` explicitly instead of rediscovering meaning from storage-key shapes.
+
+This is a correctness-oriented refactor. Its goal is not just shorter keys; it makes identity explicit. A materialized node can be renamed, migrated, synchronized, or moved between replicas without assuming that the storage key itself describes the node's semantics.
+
+## Core data model
+
+### `NodeIdentifier`
+
+A `NodeIdentifier` is an opaque persisted identifier. Current runtime parsing accepts only nine lowercase ASCII letters. That strict shape is intentionally enforced in normal runtime paths so identifier-addressed stores cannot silently accept legacy semantic-key strings or malformed data.
+
+### `NodeKeyString`
+
+A `NodeKeyString` is the serialized semantic key: it encodes what the node means. It remains necessary for public graph operations, schema matching, diagnostics, migration, and the lookup table, but it should not be used as the physical key for node state sublevels.
+
+### `identifiers_keys_map`
+
+`identifiers_keys_map` is a replica-global persisted record containing sorted `[NodeIdentifier, NodeKeyString]` entries. In memory it is represented as a bijection with:
+
+- `keyToId`: semantic key string → node identifier.
+- `idToKey`: node identifier string → semantic key.
+
+The bijection invariant matters more than either direction alone. A node key must not map to two identifiers, and an identifier must not map to two node keys. Merge, migration, and runtime allocation all depend on this being true.
+
+## Low-level implementation choices
+
+### Identifier-native sublevels
+
+The graph state sublevels now use `NodeIdentifier` for concrete graph records:
+
+- `values`
+- `freshness`
+- `inputs`
+- `revdeps`
+- `counters`
+- `timestamps`
+
+`inputs` records still contain ordered input references and matching counters, but the input references are persisted identifiers rather than semantic keys.
+
+### Lookup allocation and persistence
+
+Identifier allocation is centralized in the lookup helpers. Allocating a node identifier must update both lookup directions, and the serialized lookup must be written with graph mutations that make those identifiers observable. This prevents graph records from referencing identifiers that the lookup cannot explain.
+
+### Graph storage is intended to remain identifier-native
+
+A major design constraint introduced through PR #1335 review is that low-level graph storage should not know about semantic node keys, node heads, or node arguments. Storage receives identifiers. Semantic-to-identifier resolution belongs at IncrementalGraph operation boundaries and in explicit migration/inspection code.
+
+### Migration handles legacy key-addressed state
+
+Migration code has to bridge older snapshots that stored semantic keys in places now expected to contain identifiers. The important low-level choice is that legacy parsing belongs in migration-specific modules, while current runtime parsing stays strict. That keeps old data readable without weakening runtime invariants.
+
+### Sync merge works at the replica level
+
+Host synchronization stages each remote host into hostname storage and then merges that host into the inactive local replica. The merge copies the active local replica into the inactive target, makes decisions against target and host records, rebuilds reverse dependencies from the merged input graph, writes the merged lookup, and switches the active replica pointer only when graph changes were produced.
+
+## The reviewed bug: raw host identifiers were used too long
+
+The review feedback identifies a subtle distributed-identity bug:
+
+1. Replica T and host H independently materialize the same semantic node.
+2. Because identifiers are random, T may assign identifier `targetId` while H assigns identifier `hostId`.
+3. H's `identifiers_keys_map` correctly says `hostId` means the same semantic key that T maps to `targetId`.
+4. The old merge reconciled the lookup only after making timestamp decisions and copying records.
+5. Timestamp comparison looked for `H.timestamps.get(targetId)`, found nothing, and incorrectly kept T's node.
+6. H's record under `hostId` was then treated as H-only and copied under `hostId`.
+7. The reconciled lookup pointed the semantic key at `targetId`, so the copied `hostId` data was unreachable and the actual remote update was lost.
+
+The underlying mistake was comparing and copying graph records before translating host identifiers into the target replica's reconciled identifier namespace.
+
+## Resolution plan
+
+The correct plan is to make merge decisions in exactly one namespace: the target replica namespace.
+
+1. **Parse both lookups before graph decisions.** Load T's `identifiers_keys_map` and H's `identifiers_keys_map` immediately after preparing the inactive target replica.
+2. **Reconcile H's lookup against T's lookup before timestamp comparison.** If both replicas have the same semantic key under different identifiers, prefer T's identifier for the merged replica.
+3. **Build explicit host↔target translation maps.** Keep two maps because decisions are written in target identifiers while source data is still read from host identifiers.
+4. **Translate H keys during H-only discovery.** A host node is H-only only if its translated target identifier is absent from T's initial decision set.
+5. **Translate H timestamp reads during decision building.** For a target node, read H timestamps from the host identifier that maps to that target identifier.
+6. **Translate H inputs before topological sorting and taint propagation.** The merged dependency graph must be entirely target-identifier-addressed.
+7. **Copy H records from host identifiers into target identifiers.** `take` operations should read values/freshness/timestamps/inputs/counters from the original host key but write them to the reconciled target key.
+8. **Translate copied input records.** Inputs copied from H must be rewritten through the same host→target translation before being stored in T.
+9. **Rebuild revdeps from the translated merged input map.** This keeps reverse dependencies reachable through target identifiers and avoids stale host-only revdep edges.
+10. **Persist the merged lookup after graph decisions.** The lookup should describe the target-addressed graph state that was actually written.
+
+## Implemented fix
+
+The implemented change follows that plan inside `sync_merge.js`:
+
+- Lookup parsing and reconciliation now happen before Step 2 decisions.
+- The merge constructs `hostToTarget` and `targetToHost` translation maps from the original host lookup and reconciled host lookup.
+- Timestamp reads for T nodes use `hostIdentifierForTargetIdentifier(node)`.
+- H-only discovery translates each H key to its target key before deciding whether it is truly absent.
+- H input records are translated into target identifiers before entering `mergedInputsMap`.
+- `buildTakeOps` now reads from a host key, writes to a target key, and rewrites copied `inputs` through the host→target translation.
+- The final `identifiers_keys_map` merge reuses the already reconciled lookup so decision logic and lookup persistence agree.
+
+## Regression scenario covered by tests
+
+The new regression test creates two semantic nodes where the local target replica and remote host use different identifiers for the same parent and child semantic keys. The remote child is newer and depends on the remote parent identifier. The expected merged result is:
+
+- The remote child value is written under the target child identifier.
+- No unreachable record is written under the host child identifier.
+- The copied child input is rewritten to the target parent identifier.
+- Revdeps are rebuilt from target parent to target child.
+- The persisted lookup keeps the target identifiers for the shared semantic keys.
+
+That scenario would have failed before this fix because the newer host child timestamp was invisible under the raw target child identifier.


### PR DESCRIPTION
### Motivation

- Prevent lost or unreachable H-side updates when two replicas independently allocate different `NodeIdentifier`s for the same semantic node by ensuring decisions and copies are made in a single, reconciled identifier namespace. 

### Description

- Parse and reconcile both replica `identifiers_keys_map` records before any merge decisions, and build explicit host↔target translation maps used throughout the merge. 
- Translate host identifiers into the target namespace for timestamp comparisons, H-only discovery, merged inputs construction, topological sorting, and taint propagation so the merged dependency graph is fully target-identifier addressed. 
- Change `buildTakeOps` so it reads H records by the original host identifier, writes them under the reconciled target identifier, and rewrites copied `inputs` through the host→target translation. 
- Split small helpers into `sync_merge_identifier_translation.js` and `sync_merge_timestamps.js`, add a regression test exercising the host/target-identifier scenario in `backend/tests/sync_merge.test.js`, and add `docs/pr1335.md` documenting the rationale and plan. 

### Testing

- Ran `npx jest backend/tests/sync_merge.test.js --runInBand` which passed and includes the new regression (`reconciles host identifiers before timestamp decisions and copied inputs`). 
- Ran `npm run static-analysis` (TypeScript + ESLint) which passed after modularizing helpers. 
- Ran the full test suite with `npm test`; an earlier parallel-run transient timeout in unrelated `from_input` tests was observed during iteration, but a rerun (and targeted runs) completed successfully and all test suites passed. 
- Ran `npm run build` for the frontend which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ca4f4d4ec832eb54ca134d3d782df)