### PR TITLE
Document alternative IncrementalGraph locking design

### DIFF
--- a/docs/new-locking-implementation.md
+++ b/docs/new-locking-implementation.md
@@ -1,0 +1,402 @@
+# Alternative locking implementation for IncrementalGraph
+
+## Context
+
+Pull request [#1335](https://github.com/ottojung/volodyslav/pull/1335) changes
+`IncrementalGraph` from semantic `NodeKey`-addressed persistence to opaque
+`NodeIdentifier`-addressed persistence. The intent is good: translate a user-supplied semantic key to
+an identifier once, then keep graph storage identifier-native. The PR discussion repeatedly pushed in
+that direction: graph storage must not understand `NodeKey`, and non-migration code should not accept
+legacy/malformed graph data.
+
+The difficult part is no longer only the identifier mapping. It is the synchronization boundary around
+all mutable graph state:
+
+- the LevelDB sublevels (`values`, `freshness`, `inputs`, `revdeps`, `counters`, `timestamps`),
+- the persisted `global/identifiers_keys_map`,
+- the volatile identifier lookup inside `RootDatabase`,
+- the set of in-flight generated identifiers,
+- per-node recomputation/invalidation state, and
+- replica pointer swaps during migration or synchronization.
+
+The current PR solves this with several explicit lock classes. A simpler alternative is a single
+logical graph worker (an actor/serializer) that owns the graph state and accepts messages such as
+`pull`, `invalidate`, `allocateIdentifier`, `commitBatch`, `checkpoint`, `migrate`, and `sync`.
+This report evaluates that approach.
+
+## Current locking shape in the PR
+
+The current implementation uses multiple process-local synchronization mechanisms:
+
+1. **Activity modes** in `lock.js`:
+   - `observe` for ordinary inspections/invalidations,
+   - `pull` for pull operations, and
+   - `exclusive` for migrations and other operations that must exclude all graph activity.
+2. **An exclusive-operation mutex** (`MUTEX_KEY`) to serialize exclusive callers before they acquire
+   the graph activity lock.
+3. **A commit mutex** keyed by replica name. It serializes durable batch flushes and the publication
+   of the volatile identifier lookup.
+4. **Concrete node locks** keyed by semantic node key strings. Transactions acquire the output node
+   first and then inputs in canonical order so that two concurrent pulls sharing nodes do not allocate
+   or rewrite the same node state at the same time.
+5. **Transaction-local state** containing a batch, an overlay identifier lookup, reserved identifiers,
+   held node-lock releases, and in-flight nested pull promises.
+
+This is a reasonable lock-based design, but the important observation is that the invariants are not
+local to one lock. Correctness depends on the composition of several locks, acquisition-order rules,
+and transaction rules:
+
+- node locks protect semantic-node ownership during transaction execution,
+- the commit mutex protects disk flush + volatile lookup publication,
+- the graph activity mode lock protects migrations and read snapshots from incompatible operations,
+- the transaction overlay protects read-your-writes behavior for identifier allocation, and
+- nested pulls must reuse the outer transaction rather than reacquiring the graph-level transaction
+  boundary.
+
+The result is powerful but fragile. The implementation has to document and test many negative rules:
+"do not reacquire this non-reentrant mutex", "do not allocate without holding the node lock", "do not
+translate keys in storage", "do not update volatile state before disk", "do not run migration while
+pulls observe the old replica", and so on.
+
+## Theoretical model: a logical worker / actor / serializer
+
+A logical worker is a single owner of a mutable state machine. Other code cannot mutate that state
+directly; it submits messages to the worker. The worker processes messages one at a time, updates its
+private state, performs side effects, and sends a result back to the caller.
+
+This is the same core idea as the actor model. Akka describes actors as independent entities that
+react to incoming messages sequentially, one at a time, and says that internal state can be modified
+only through messages, eliminating races on actor-owned invariants:
+<https://doc.akka.io/docs/akka/current/typed/guide/actors-intro.html>. Microsoft Orleans documents a
+similar turn-based model for grains: a scheduler ensures that a grain activation executes on only one
+thread at a time, giving the grain single-threaded execution semantics:
+<https://learn.microsoft.com/en-us/dotnet/orleans/implementation/scheduler>.
+
+In Node.js this does **not** require a physical `worker_threads` worker. It can be a promise queue in
+the same event loop. Node worker threads communicate through message passing and are primarily useful
+for CPU-intensive JavaScript, while Node's normal asynchronous I/O is already efficient without worker
+threads: <https://nodejs.org/api/worker_threads.html>. MDN's worker docs also emphasize the important
+conceptual boundary: messages are copied/transferred rather than direct shared-variable access:
+<https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers>.
+
+For this project, "separate logical worker" should therefore mean **a graph-owned serialized command
+queue**, not necessarily a separate OS thread. A physical worker thread would add cloning/transfer
+costs, complicate capabilities and LevelDB handles, and provide little benefit for an I/O-heavy graph.
+
+## Why this helps
+
+### Centralized synchronization
+
+A worker turns implicit locking into explicit ownership. If the graph worker is the only code allowed
+to mutate the identifier lookup, replica pointer, graph sublevels, and graph caches, then ordinary code
+no longer needs to coordinate multiple independent locks. There is exactly one serialization point for
+state transitions.
+
+Instead of this shape:
+
+```text
+public pull
+  -> acquire activity mode lock
+  -> create transaction
+  -> acquire several node locks
+  -> compute
+  -> acquire commit mutex
+  -> flush batch
+  -> publish volatile lookup
+  -> release all locks in the right order
+```
+
+we get this shape:
+
+```text
+public pull
+  -> send Pull(nodeName, bindings) to graph worker
+
+graph worker loop
+  -> dequeue Pull
+  -> create transaction from worker-owned committed state
+  -> compute using worker-owned transaction context
+  -> flush batch
+  -> publish worker-owned volatile lookup
+  -> resolve caller promise
+```
+
+The invariants become state-machine rules instead of lock-order rules.
+
+### Single owner for identifier allocation
+
+Identifier allocation is a natural worker responsibility. The worker can keep the committed lookup,
+transaction overlay, and in-flight generated identifiers in one place. `allocateIdentifier(nodeKey)`
+can be an internal operation that is called only by the currently executing graph command. That makes
+it impossible for two top-level operations to allocate competing identifiers for the same key unless
+we intentionally introduce parallel subworkers.
+
+This matches the PR's desired boundary: translate from semantic key to identifier at the graph edge,
+then pass identifiers through storage.
+
+### Cleaner disk-before-memory protocol
+
+The worker can enforce one commit sequence for every mutating message:
+
+1. build a batch and identifier-map delta,
+2. flush the LevelDB batch,
+3. update the worker's committed volatile state,
+4. resolve the caller.
+
+If the flush fails, the worker discards the transaction and leaves its committed volatile state
+unchanged. Because no other command runs concurrently, there is no observable interleaving between
+"disk succeeded" and "memory published".
+
+### Easier replica cutover
+
+Migration and sync pointer swaps are also worker messages. When the worker is executing `Migrate` or
+`Sync`, no `Pull`, `Invalidate`, or inspection command can observe the half-swapped state. This removes
+the need for a separate exclusive mode lock for graph activity.
+
+### More inspectable concurrency behavior
+
+A message protocol is easier to audit than scattered lock calls. A future reader can inspect the
+worker's command union and know every operation that can affect graph state. This fits the project's
+preference for explicitness and type-checked JSDoc typedefs.
+
+## Downsides and risks
+
+### Less parallelism
+
+A single worker serializes all graph commands. The current lock-based design tries to allow some
+parallelism: multiple pulls can run at the same time if they do not collide on concrete node locks,
+and inspections can run in compatible modes. A worker would initially give that up.
+
+For this application that may be acceptable. The graph is part of a personal tool, and correctness and
+maintainability are likely more valuable than maximizing parallel graph throughput. Still, if a node
+computor performs a long AI call or long filesystem/network operation while the worker is occupied,
+every other graph command waits.
+
+This is the biggest design issue. The worker should not blindly hold the queue while doing arbitrary
+long external work unless we deliberately accept that latency.
+
+### Reentrancy and nested pulls need careful design
+
+Computors can call `pull` dynamically. If a worker command calls a computor and that computor sends a
+new message to the same worker and waits for it, the system deadlocks: the worker cannot process the
+nested message until the current message finishes, and the current message cannot finish until the
+nested message resolves.
+
+The solution is to make nested pulls **not** enqueue new top-level messages. During a `Pull` command,
+the worker should provide the computor with an internal `pullInTransaction` callback bound to the
+current transaction. That preserves the existing explicit-context idea and avoids actor self-deadlock.
+Public graph APIs enqueue messages; worker-internal nested operations call worker-private functions.
+
+### Long-running command fairness
+
+A large migration or a deep recomputation can monopolize the queue. This is not a data race, but it is
+a usability concern. We can address it later with explicit yield points or phased commands, but every
+yield point is a place where invariants must be clearly defined. The simplest first implementation
+should prefer correctness over cooperative interleaving.
+
+### Back-pressure and cancellation are explicit design work
+
+A queue can grow. In an adversarial web service this would raise rate-limit/back-pressure concerns,
+but this project explicitly assumes a non-adversarial client and bans DoS-oriented complexity. Still,
+for developer experience, the worker should expose debugging/inspection metrics such as current
+command name and queue length. It should not add caps.
+
+Cancellation is also non-trivial. If a caller abandons a promise while a command is running, the
+worker must still either finish the commit protocol or discard the transaction safely. The initial
+implementation can avoid cancellation support.
+
+### Error handling moves to the protocol boundary
+
+Errors from a worker command resolve/reject the caller promise. The worker must continue processing
+subsequent messages after failed commands. This needs explicit error classes close to their sources,
+plus a small command-wrapper guarantee: failed command transactions are discarded; the worker loop
+itself remains alive.
+
+### Physical worker threads are probably the wrong first step
+
+A real `worker_threads` implementation would force message serialization of command arguments and
+results, make capabilities harder to pass, and may not share LevelDB handles safely or pleasantly. It
+would also blur project encapsulation by introducing a separate module entry point. Start with an
+in-process logical worker. If CPU-bound graph work later blocks the event loop, split specific CPU
+computors into physical workers independently of graph-state ownership.
+
+## Suitability for IncrementalGraph
+
+The approach is well-suited to the identifier/persistence problem because the graph already behaves
+like a transactional state machine:
+
+- It has a small set of top-level operations (`pull`, `invalidate`, inspect, migrate, sync).
+- Correctness depends on ordering disk writes and volatile publication.
+- Identifier allocation is stateful and should be centralized.
+- Replica swaps are global state transitions.
+- Storage should remain identifier-native and not participate in semantic translation.
+- Nested pulls already need explicit transaction propagation.
+
+The worker is especially attractive because it can remove the most delicate part of the current PR:
+interactions between concrete node locks and commit-time identifier publication. If no two top-level
+transactions run at the same time, we do not need per-node allocation locks to avoid same-key races.
+The worker can still deduplicate in-flight work within the active command via transaction-local
+promises, but it does not need a process-global manual lock map keyed by semantic node strings.
+
+However, the worker is not a free win for recomputation latency. Some computors may perform slow AI or
+I/O work. Fully serializing those slow operations means one slow node can delay unrelated graph
+queries. There are three possible responses:
+
+1. **Accept full serialization first.** This is simplest and likely correct enough for a personal
+   graph. It is the recommended first implementation.
+2. **Split compute from commit.** The worker can prepare a transaction, call slow pure/external work
+   outside the worker, then send `CommitPreparedTransaction` back. This regains concurrency but brings
+   back stale-read/conflict questions. It should be avoided until we have evidence that full
+   serialization is too slow.
+3. **Shard workers.** One worker per independent graph or per replica/node partition. This restores
+   some parallelism but reintroduces cross-worker synchronization for shared identifiers, revdeps, and
+   replica swaps. It is not suitable as the first design for PR #1335.
+
+## Recommended design
+
+Implement an in-process `IncrementalGraphWorker` that owns the graph's mutable state and command
+queue. It should be a small serializer, not a physical thread.
+
+### Command protocol
+
+A possible command union:
+
+```javascript
+/**
+ * @typedef {object} PullCommand
+ * @property {'pull'} type
+ * @property {import('./types').NodeName} nodeName
+ * @property {Array<import('./types').ConstValue>} bindings
+ */
+
+/**
+ * @typedef {object} InvalidateCommand
+ * @property {'invalidate'} type
+ * @property {import('./types').NodeName} nodeName
+ * @property {Array<import('./types').ConstValue>} bindings
+ */
+
+/**
+ * @typedef {object} InspectCommand
+ * @property {'inspect'} type
+ * @property {'value' | 'freshness' | 'schemas' | 'materializedNodes'} target
+ * @property {unknown} payload
+ */
+
+/**
+ * @typedef {object} MigrateCommand
+ * @property {'migrate'} type
+ * @property {Array<import('./types').NodeDef>} nodeDefs
+ * @property {(storage: import('./migration_storage').MigrationStorage) => Promise<void>} callback
+ */
+
+/**
+ * @typedef {PullCommand | InvalidateCommand | InspectCommand | MigrateCommand} GraphCommand
+ */
+```
+
+The public `IncrementalGraph` methods become thin wrappers that validate public arguments and call
+`worker.submit(command)`. The worker loop is the only place that calls mutation internals.
+
+### Worker-owned state
+
+The worker should own or have exclusive access to:
+
+- `RootDatabase`'s active computed replica state,
+- committed identifier lookup,
+- in-flight generated identifiers,
+- concrete instantiation cache, or at least all mutations to it,
+- active transaction object while a command runs,
+- LevelDB batch commit protocol, and
+- migration/sync cutover procedures.
+
+A key design decision: move volatile graph state out of ambient `RootDatabase` mutation methods where
+possible. `RootDatabase` can still provide typed database accessors and primitive persistence helpers,
+but publication of new volatile state should happen through worker-owned commit functions.
+
+### Nested pull rule
+
+Public `graph.pull(...)` enqueues a `PullCommand`.
+
+Computor-provided `pull(...)` does **not** enqueue. It calls worker-private
+`pullInCurrentTransaction(nodeName, bindings, tx)`. If there is no active transaction, it should fail
+with a specific internal misuse error. This keeps nested dependency discovery atomic and avoids
+self-deadlock.
+
+### Commit rule
+
+Every mutating command should use the same worker-private helper:
+
+```text
+runTransaction(commandName, body):
+  create tx from committed worker state
+  run body(tx)
+  if tx has no durable delta: return result
+  append identifier map if needed
+  flush LevelDB batch
+  publish volatile lookup / replica state
+  return result
+```
+
+No other module should write `identifiers_keys_map` or replace the active lookup.
+
+### Read/inspect rule
+
+There are two acceptable options:
+
+1. Enqueue inspections behind mutations. This gives simple linearizable reads.
+2. Allow lock-free reads from an immutable snapshot published by the worker.
+
+For the first implementation, prefer queued inspections. They are simpler, and this application does
+not need high-throughput reads.
+
+## What can be deleted or simplified
+
+If the worker fully serializes top-level graph commands, these mechanisms can be removed or reduced:
+
+- concrete node lock map,
+- transaction-held node-lock release bookkeeping,
+- commit mutex,
+- graph activity mode lock for pull/observe/exclusive,
+- non-reentrant computed-state mutex warnings, and
+- many lock-order tests.
+
+Some external locks may remain outside the graph worker:
+
+- gitstore/checkpoint mutexes, because they protect working-tree state outside IncrementalGraph,
+- cross-process synchronization, if added later, because an in-process worker does not serialize other
+  Node processes, and
+- low-level LevelDB atomic batch behavior, because the worker serializes logical transactions but the
+  database still provides durable atomicity.
+
+## Implementation plan
+
+1. **Introduce the serializer without changing semantics.** Add a small queue abstraction with tests:
+   FIFO order, rejection propagation, worker survival after a failed command, and no reentrant public
+   enqueue from inside a command.
+2. **Wrap public graph methods.** Route public `pull`, `invalidate`, migration, sync, and inspection
+   through the worker, while leaving existing internals mostly intact.
+3. **Move transaction creation/commit into the worker.** Make one helper responsible for identifier
+   overlay creation, batch flush, and volatile publication.
+4. **Convert nested pulls to worker-private calls.** Ensure computor `pull` callbacks reuse the active
+   transaction and never enqueue.
+5. **Remove redundant locks gradually.** First remove the commit mutex, then activity-mode locks, then
+   concrete node locks after tests prove same-key concurrent pulls share one committed identifier.
+6. **Update specs and tests.** Replace lock-order tests with worker-order tests and invariant tests:
+   disk-before-memory, exact lookup persistence, migration cutover isolation, failed-command recovery,
+   and concurrent public calls producing serializable results.
+
+## Recommendation
+
+Use the logical worker approach as the next design direction for IncrementalGraph, but implement it as
+an in-process serialized command queue rather than a physical worker thread.
+
+This approach fits the PR's core goal: keep storage identifier-native and centralize semantic-key to
+identifier translation at the IncrementalGraph boundary. It should make the identifier and replica
+invariants easier to reason about, reduce lock composition bugs, and align with actor-model theory:
+state is owned by one entity and modified only through sequentially processed messages.
+
+The main cost is reduced parallelism, especially if computors perform slow external work. Given the
+project's personal-tool context and the complexity already visible in PR #1335, that is an acceptable
+first trade-off. If performance becomes a real problem, optimize later from a correct serialized core
+rather than trying to preserve parallelism with several interacting locks from the beginning.

--- a/docs/petri.md
+++ b/docs/petri.md
@@ -1,0 +1,395 @@
+# Petri-net model for IncrementalGraph synchronization
+
+## Context and goal
+
+`docs/specs/incremental-graph-locking-design.md` asks for a locking model with five concurrency
+properties:
+
+1. `invalidate()` is exclusive with every `pull()`, but compatible with other invalidations.
+2. Inspection reads are compatible with invalidations.
+3. `pull()` is exclusive with inspection reads.
+4. `pull()` is exclusive with other pulls of the same concrete node.
+5. Pulls of different concrete nodes may proceed concurrently.
+
+The same document proposes a concrete lock protocol: a global mode lock with compatible `observe` and
+`pull` groups, plus one exclusive per-node pull mutex. It also requires a fixed acquisition discipline:
+global activity mode first, then node-level locks, and never acquire `observe` while holding node locks.
+
+This report considers a different model: represent graph synchronization as a Petri network, and ask
+whether that model can provide correctness, at least the same fine-grained concurrency as the locking
+spec, and simple implementation.
+
+## What a Petri network would mean here
+
+A Petri net is a state-machine model with:
+
+- **places**: resource or state buckets;
+- **tokens**: current availability or current state;
+- **transitions**: atomic moves that consume tokens from input places and produce tokens into output
+  places; and
+- **marking**: the whole current token distribution.
+
+For IncrementalGraph, the places would represent graph activity phases and node ownership. A transition
+fires when all required tokens are available. While a token is consumed, no incompatible transition can
+fire. When the operation finishes, completion transitions restore the tokens.
+
+This is not the same as the previously proposed single logical worker. A single worker serializes all
+top-level commands. A Petri-net scheduler can allow independent transitions to fire concurrently when
+their input tokens do not conflict. It is closer to a generalized lock manager whose locking policy is
+declared as a net.
+
+## Minimal Petri-net encoding of the existing locking spec
+
+The locking spec can be encoded directly.
+
+### Places
+
+```text
+place ObservePhaseFree        // no pull phase is active or queued-as-current phase
+place PullPhaseFree           // no observe phase is active or queued-as-current phase
+place PullSlot                // optional counting place for active pull-mode compatibility
+place ObserveSlot             // optional counting place for active observe-mode compatibility
+place NodePullFree(nodeKey)   // one token per concrete node
+```
+
+A simpler implementation can avoid explicit `PullSlot` and `ObserveSlot` places by treating a graph
+phase as a reader-group with a fairness queue. But if the goal is an actual Petri network, the net
+needs either colored/counting places or a small amount of scheduler metadata to represent "many holders
+of the same phase are compatible, but a conflicting phase waits for the group to drain."
+
+### Transitions
+
+```text
+StartObserve(op):
+  requires graph phase is not Pull
+  records one active observe holder
+
+FinishObserve(op):
+  releases one active observe holder
+
+StartPull(nodeKey):
+  requires graph phase is not Observe
+  consumes NodePullFree(nodeKey)
+  records one active pull holder
+
+FinishPull(nodeKey):
+  produces NodePullFree(nodeKey)
+  releases one active pull holder
+```
+
+This encodes the five demanded properties:
+
+- `invalidate()` and inspections are both observe operations, so they can overlap.
+- Any observe holder prevents new pull holders in the conflicting phase.
+- Any pull holder prevents new observe holders in the conflicting phase.
+- Same-node pulls contend on the same `NodePullFree(nodeKey)` token.
+- Different-node pulls consume different node tokens and can run concurrently.
+
+So, at the level of **safety**, a Petri net can express the current design exactly.
+
+## A more graph-native Petri-net encoding
+
+The above net is only a reformulation of the existing lock protocol. Petri nets become more interesting
+if we model graph work more finely.
+
+A graph-native net could add places such as:
+
+```text
+NodeStable(nodeId)            // node value/freshness/inputs are not being rewritten
+NodeComputing(nodeId)         // one recomputation owns the node output
+NodeDependenciesReading(nodeId)
+IdentifierMapFree            // identifier lookup may be extended
+CommitLogFree(replica)        // durable batch publication may run
+ReplicaPointerStable          // no migration/sync cutover is in progress
+```
+
+Then a `pull(A)` transition sequence could be decomposed:
+
+1. enter pull phase;
+2. consume `NodeStable(A)`, produce `NodeComputing(A)`;
+3. recursively fire dependency pull/read transitions;
+4. consume `IdentifierMapFree` only if a new identifier must be allocated;
+5. consume `CommitLogFree(activeReplica)` only for the commit transition;
+6. produce `NodeStable(A)` and release phase/node tokens.
+
+This is more expressive than the current locking spec. It could, for example, serialize identifier-map
+extension while allowing already-identified node computations to proceed, or serialize commits while
+allowing computations to prepare batches concurrently.
+
+However, that extra precision comes with a major cost: operations become multi-transition workflows,
+and correctness now depends on many intermediate markings. This shifts complexity from lock ordering to
+net design, transition atomicity, and scheduler fairness.
+
+## Correctness analysis
+
+### Safety
+
+A Petri-net scheduler can provide safety if all shared mutable invariants are represented by tokens
+and every operation consumes the right tokens before touching the protected state.
+
+For the incremental graph, the safety invariants are roughly:
+
+- no pull overlaps an observe operation;
+- no two pulls rewrite the same concrete node concurrently;
+- identifier allocation is collision-safe and publishes atomically with the batch that introduced the
+  identifier;
+- volatile lookup publication happens only after durable batch success;
+- migration/sync replica cutover is not observed halfway through; and
+- nested pulls do not create a dependency-cycle deadlock.
+
+A Petri net can encode these as resource places:
+
+| Invariant | Petri-net resource |
+|-----------|--------------------|
+| pull vs observe exclusion | global phase places |
+| same-node pull exclusion | `NodePullFree(node)` token |
+| identifier allocation serialization | `IdentifierMapFree` token, or one owner token per active lookup |
+| disk-before-memory commit | commit transition consumes prepared transaction and produces committed volatile state only after durable write succeeds |
+| replica cutover isolation | `ReplicaPointerStable` / `CutoverFree` token |
+| nested dependency ownership | ordered dependency transitions over DAG nodes |
+
+For safety, Petri nets are strong: the token discipline makes incompatible states unrepresentable if
+all state access goes through transitions. In particular, a net can make "allocate identifier without
+identifier-map ownership" or "commit while cutover is active" structurally impossible.
+
+The safety weak point is not the model; it is the implementation boundary. If ordinary modules can
+still mutate `RootDatabase`, write `identifiers_keys_map`, or update node sublevels outside the net,
+the Petri model becomes documentation rather than enforcement. To get real safety, the net scheduler
+must be the only entry point for graph-state mutation, just like a lock manager or worker would be.
+
+### Liveness
+
+Liveness is harder. A transition being enabled does not guarantee it will eventually fire unless the
+scheduler has fairness rules. A Petri net can prove some deadlock-freedom properties on a finite static
+net, but IncrementalGraph is dynamic:
+
+- node places are created lazily for concrete nodes;
+- dependencies can be dynamic because computors can call `pull`;
+- commits and identifier allocations are conditional;
+- operations contain asynchronous effects; and
+- the graph may be large enough that full state-space exploration is impractical.
+
+The current locking spec uses a simpler liveness argument:
+
+- the graph phase lock has FIFO mode-group fairness;
+- per-node locks are FIFO;
+- acquisition order is global phase first, then node locks; and
+- recursive pulls follow graph dependencies, which are a DAG.
+
+A Petri-net implementation would need equivalent explicit scheduling rules:
+
+1. **FIFO fairness for conflicting modes.** A stream of observe transitions must not starve a waiting
+   pull transition, and a stream of pull transitions must not starve a waiting observe transition.
+2. **FIFO fairness per node.** Same-node pulls should not starve behind later same-node work.
+3. **No hold-and-wait cycles outside the graph DAG.** If a workflow holds node `A` and waits for node
+   `B`, this must correspond to a valid dependency edge `A -> B`. Otherwise the net can create cycles
+   that the graph constructor cannot reject.
+4. **Failure transitions.** Every started operation must have a completion or rollback path that
+   returns consumed tokens even if computation, LevelDB batch write, migration, or sync fails.
+5. **Async boundary discipline.** Awaiting arbitrary external work while holding scarce tokens can
+   preserve safety but harm liveness and latency.
+
+Thus a Petri-net model can achieve liveness, but not automatically. The implementation still needs a
+fair scheduler and very careful rollback paths. Without those, a Petri net can be just as deadlock- or
+starvation-prone as a lock system.
+
+## Fine-grained concurrency
+
+### Matching the locking spec
+
+A Petri-net scheduler can match the requested granularity exactly:
+
+| Requested behavior | Petri-net expression |
+|--------------------|----------------------|
+| invalidates overlap invalidates | compatible observe transitions |
+| inspections overlap invalidates | compatible observe transitions |
+| pulls exclude observe reads/invalidations | conflicting graph phase places |
+| same-node pulls serialize | one `NodePullFree(node)` token |
+| different-node pulls overlap | separate node tokens |
+
+So the answer to "can it meet the demanded fine-grainedness?" is yes.
+
+### Going beyond the locking spec
+
+A Petri net can go finer than the spec, but the benefit is questionable.
+
+Possible refinements:
+
+- Only take `IdentifierMapFree` when a transaction actually allocates a new identifier.
+- Only take `CommitLogFree(replica)` for the final batch flush/publication step.
+- Distinguish read-only dependency inspection from node output mutation.
+- Permit multiple prepared computations to run concurrently and serialize only their commit
+  transitions.
+- Represent migration cutover as a short exclusive transition instead of excluding the whole migration
+  callback.
+
+These refinements might improve concurrency, but they introduce conflict detection. For example, if two
+prepared computations started from the same freshness/counter snapshot and then commit in a different
+order, the second commit may be stale. At that point the design begins to resemble optimistic
+transactions with validation, not just Petri-net scheduling.
+
+For this project, "higher than the spec" should probably mean one modest improvement: keep the same
+phase/node granularity, but make identifier allocation and commit publication explicit transitions in
+the model. Avoid splitting slow computation from commit until there is real performance evidence.
+
+## Simplicity analysis
+
+There are three possible implementation styles.
+
+### Option A: Petri net as documentation/specification only
+
+This is simple to write and useful for reasoning, but it does not enforce correctness. The code would
+still use `withModeMutex` and `withMutex` exactly as described in the existing locking spec.
+
+Verdict: good supplement, not a new implementation model.
+
+### Option B: Restricted Petri-net scheduler compiled to existing locks
+
+Define a small resource DSL:
+
+```javascript
+startObserve(op)
+startPull(nodeKey)
+withIdentifierMap(op)
+withCommit(replica, op)
+withCutover(op)
+```
+
+Internally, this compiles to the existing sleeper primitives and a few ordinary mutexes. The "Petri"
+part is the declared resource graph and transition protocol, not a general-purpose Petri-net engine.
+
+Verdict: probably the best practical variant if we want Petri-net thinking. It can keep the current
+fine-grained behavior and make the resource protocol more explicit without inventing a large runtime.
+It is still basically a lock manager.
+
+### Option C: General Petri-net runtime
+
+Build a generic scheduler with dynamic places, colored tokens, transition guards, fairness queues,
+rollback transitions, and async transition execution.
+
+Verdict: not simple. It would be more abstract than the current design, harder to type with JSDoc,
+harder to debug, and likely overkill for the graph. The model might be elegant, but the implementation
+would have many new failure modes.
+
+## Recommended Petri-inspired design
+
+If we pursue this direction, use a **restricted Petri-net lock manager**, not a full Petri-net runtime.
+
+The implementation should expose graph-specific transitions:
+
+```text
+observe(op)
+  acquires GraphPhase(observe)
+
+pull(nodeKey, op)
+  acquires GraphPhase(pull)
+  acquires NodePull(nodeKey)
+
+allocateIdentifier(op)
+  requires active transaction
+  acquires IdentifierMap
+
+commit(replica, op)
+  requires prepared transaction
+  acquires Commit(replica)
+
+cutover(op)
+  acquires GraphPhase(exclusive) or Cutover
+```
+
+This gives the main benefit of the Petri model: every protected invariant is represented as an explicit
+place/token. But each transition remains graph-specific and small enough to understand.
+
+### Suggested resource places
+
+```text
+GraphPhase              // observe vs pull vs exclusive/cutover
+NodePull(nodeKey)       // one token per concrete node
+IdentifierMap(replica)  // one token for lookup extension/publication
+Commit(replica)         // one token for durable batch + volatile publication
+Cutover                 // one token for replica pointer replacement
+```
+
+### Suggested transition rules
+
+1. Public invalidation and inspection use `GraphPhase(observe)`.
+2. Public pull uses `GraphPhase(pull)` plus `NodePull(nodeKey)` for the node currently being pulled.
+3. Nested pulls reuse the active pull workflow and acquire dependency `NodePull(dependencyKey)` only in
+   graph dependency order.
+4. Identifier allocation is allowed only inside an active transaction and consumes `IdentifierMap`.
+5. Commit consumes `Commit(replica)` and performs disk-before-memory publication.
+6. Migration/sync cutover consumes `Cutover` and a graph-exclusive phase token.
+7. Every transition has a `finally` rollback/release path.
+8. The scheduler uses FIFO fairness for conflicting phase groups and per-node queues.
+
+This is essentially the existing locking spec plus two improvements:
+
+- identifier-map and commit publication become named resources rather than ad hoc implementation
+  details; and
+- the resource model can be documented and tested as a transition system.
+
+## Tests and verification strategy
+
+A Petri-inspired implementation should be tested at two levels.
+
+### Scheduler/resource tests
+
+- observe operations overlap;
+- pull operations for different nodes overlap;
+- pull operations for the same node serialize;
+- observe and pull operations exclude each other;
+- FIFO mode-group fairness prevents starvation;
+- tokens are released on failure;
+- nested dependency acquisition cannot violate the DAG order; and
+- cutover excludes all incompatible graph activity.
+
+### Graph invariant tests
+
+- concurrent same-node pulls allocate one identifier;
+- concurrent different-node pulls do not block unless they share dependencies;
+- failed batch writes do not publish volatile identifier state;
+- migration cutover never exposes mixed-replica lookup state;
+- inspection reads never overlap pull writes; and
+- invalidation never overlaps pull recomputation.
+
+A small finite model test may also be worthwhile. For example, model two nodes, one dependency edge,
+one observe operation, one same-node pull pair, and one migration. Exhaustively enumerate transition
+orders and assert safety properties. This would give confidence without requiring a general verifier.
+
+## Final evaluation
+
+### Correctness: possible, but scheduler-dependent
+
+A Petri-net model is a good fit for safety because shared graph invariants can be represented by
+resource tokens. Liveness is possible only if the implementation includes fairness, rollback, and
+acyclic nested-acquisition rules. Petri nets do not remove the need to design those rules.
+
+### Fine-grainedness: yes
+
+The model can exactly match the existing locking-design document: observe operations overlap, pull
+operations overlap by node, and conflicting observe/pull phases exclude each other. It can also express
+finer resources such as identifier-map ownership and commit publication.
+
+### Simplicity: only if restricted
+
+A full Petri-net runtime would not be simple. It would likely be more complex than the current lock
+protocol and harder to maintain. A restricted Petri-inspired resource scheduler, compiled to the
+existing sleeper primitives, could be simple enough and would make the synchronization model more
+explicit.
+
+## Recommendation
+
+Do not replace the incremental graph locking model with a general Petri-net engine.
+
+Instead, if Petri-net structure is desired, use it as a **design language and small resource DSL** over
+the existing primitives:
+
+- keep the global observe/pull phase from `docs/specs/incremental-graph-locking-design.md`;
+- keep per-node pull exclusion;
+- add explicit named resources for identifier-map mutation, commit publication, and replica cutover;
+- document each operation as a transition sequence;
+- test token release, fairness, and invariant preservation directly.
+
+This achieves the requested safety and fine-grainedness while preserving implementation simplicity. A
+general Petri-net scheduler would be theoretically expressive, but it would not satisfy the simplicity
+goal.


### PR DESCRIPTION
### Motivation
- The incremental-graph identifier migration in PR #1335 centralizes persistent keys but exposes a complex, multi-lock synchronization surface that is fragile to composition errors. 
- Provide an alternative design that centralizes graph-state synchronization to reduce lock-order complexity and make identifier allocation, commit ordering, and replica cutover easier to reason about. 
- Propose a pragmatic variant (in-process logical worker / serialized command queue) that preserves correctness while keeping implementation and testing simpler.

### Description
- Add `docs/new-locking-implementation.md`, a 400-line technical report that analyzes the PR's current lock-based approach and proposes a logical worker (actor/serializer) alternative. 
- The document summarizes the existing locks (`activity` modes, `MUTEX_KEY`, commit mutex, per-node concrete locks, and transaction overlays) and explains why their composition is error-prone. 
- It specifies the worker-based command protocol, worker-owned state (identifier lookup, in-flight ids, transaction lifecycle), nested-pull rules (no enqueue from inside a transaction), commit ordering (disk-before-memory), and a staged migration plan to adopt the worker. 
- The report evaluates advantages, downsides (reduced parallelism, nested-pull reentrancy concerns, long-running commands), and practical implementation guidance (in-process queue preferred over `worker_threads`).

### Testing
- Ran `npm install` successfully. 
- Ran static analysis with `npm run static-analysis` which completed without errors. 
- Ran `npm run build` which completed successfully. 
- Attempted to run the full test suite with `npm test` (and `timeout 300 npm test -- --runInBand`) but the Jest run produced no progress and was manually terminated / timed out; test run did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e547448cc832e87e4e23dc9b464fc)