### PR TITLE
Validate allocation fingerprints and preserve local sync metadata

### DIFF
--- a/backend/src/generators/incremental_graph/database/fingerprint.js
+++ b/backend/src/generators/incremental_graph/database/fingerprint.js
@@ -1,0 +1,63 @@
+/**
+ * Persisted allocation fingerprints contain only lowercase ASCII letters and
+ * are at least nine characters long.
+ */
+const FINGERPRINT_PATTERN = /^[a-z]{9,}$/;
+
+/**
+ * Thrown when persisted replica or snapshot metadata does not contain a valid
+ * allocation fingerprint.
+ */
+class InvalidFingerprintError extends Error {
+    /**
+     * @param {string} context
+     * @param {unknown} value
+     */
+    constructor(context, value) {
+        super(
+            `Invalid fingerprint in ${context}: expected a string matching ` +
+            `/^[a-z]{9,}$/, got ${JSON.stringify(value)}`
+        );
+        this.name = 'InvalidFingerprintError';
+        this.context = context;
+        this.value = value;
+    }
+}
+
+/**
+ * Check whether a persisted value is a valid allocation fingerprint.
+ * @param {unknown} value
+ * @returns {value is string}
+ */
+function isValidFingerprint(value) {
+    return typeof value === 'string' && FINGERPRINT_PATTERN.test(value);
+}
+
+/**
+ * Validate and return a persisted allocation fingerprint.
+ * @param {unknown} value
+ * @param {string} context
+ * @returns {string}
+ * @throws {InvalidFingerprintError}
+ */
+function requireValidFingerprint(value, context) {
+    if (!isValidFingerprint(value)) {
+        throw new InvalidFingerprintError(context, value);
+    }
+    return value;
+}
+
+/**
+ * @param {unknown} object
+ * @returns {object is InvalidFingerprintError}
+ */
+function isInvalidFingerprintError(object) {
+    return object instanceof InvalidFingerprintError;
+}
+
+module.exports = {
+    FINGERPRINT_PATTERN,
+    isInvalidFingerprintError,
+    isValidFingerprint,
+    requireValidFingerprint,
+};

--- a/backend/src/generators/incremental_graph/database/index.js
+++ b/backend/src/generators/incremental_graph/database/index.js
@@ -17,6 +17,7 @@ const {
 } = require('./types');
 const { makeRootDatabase, isRootDatabase, isInvalidReplicaPointerError, isSwitchReplicaError, isSchemaBatchVersionError, isMalformedIdentifierLookupError, MissingIdentifierLookupError, isMissingIdentifierLookupError, LAST_NODE_INDEX_KEY } = require('./root_database');
 const { makeTypedDatabase, isTypedDatabase } = require('./typed_database');
+const { isInvalidFingerprintError, isValidFingerprint, requireValidFingerprint } = require('./fingerprint');
 const {
     checkpointDatabase,
     checkpointMigration,
@@ -95,6 +96,9 @@ module.exports = {
     isMalformedIdentifierLookupError,
     MissingIdentifierLookupError,
     isMissingIdentifierLookupError,
+    isInvalidFingerprintError,
+    isValidFingerprint,
+    requireValidFingerprint,
     LAST_NODE_INDEX_KEY,
     makeTypedDatabase,
     isTypedDatabase,

--- a/backend/src/generators/incremental_graph/database/root_database.js
+++ b/backend/src/generators/incremental_graph/database/root_database.js
@@ -23,6 +23,7 @@ const {
     nodeKeyToIdFromLookup,
 } = require('./identifier_lookup');
 const { makeNodeIdentifier, nodeIdentifierToString } = require('./node_identifier');
+const { requireValidFingerprint } = require('./fingerprint');
 
 const {
     hostnameSchemaStorage: hostnameSchemaStorageHelper,
@@ -615,13 +616,10 @@ class RootDatabaseClass {
             );
         }
         const storedFingerprint = await this._computed.globalSublevel.get('fingerprint');
-        if (typeof storedFingerprint === 'string' && storedFingerprint.length >= 9) {
-            this._computed.fingerprint = storedFingerprint;
-        } else {
-            throw new MissingIdentifierLookupError(
-                `active replica '${this.currentReplicaName()}' has a version but missing or invalid fingerprint`
-            );
-        }
+        this._computed.fingerprint = requireValidFingerprint(
+            storedFingerprint,
+            `active replica '${this.currentReplicaName()}' global metadata`
+        );
     }
 
     /**
@@ -722,13 +720,10 @@ class RootDatabaseClass {
                     );
                 }
                 const storedFingerprint = await globalSublevel.get('fingerprint');
-                if (typeof storedFingerprint === 'string' && storedFingerprint.length >= 9) {
-                    fingerprint = storedFingerprint;
-                } else {
-                    throw new MissingIdentifierLookupError(
-                        `replica '${name}' has a version but missing or invalid fingerprint`
-                    );
-                }
+                fingerprint = requireValidFingerprint(
+                    storedFingerprint,
+                    `replica '${name}' global metadata`
+                );
             }
             await this._rootMetaSublevel.put('current_replica', name);
             this._computed = {

--- a/backend/src/generators/incremental_graph/database/sync_merge.js
+++ b/backend/src/generators/incremental_graph/database/sync_merge.js
@@ -48,7 +48,6 @@ const {
     serializeIdentifierLookup,
 } = require('./identifier_lookup');
 const { LAST_NODE_INDEX_KEY } = require('./root_database');
-const { MalformedIdentifierLookupError } = require('./replica_errors');
 const { buildMergePlan } = require('./sync_merge_plan');
 const { unifyRevdeps } = require('./sync_merge_revdeps');
 const { buildTakeOps, copyReplicaGently } = require('./sync_merge_transfer');
@@ -418,7 +417,7 @@ function summarizeDecisions(decisions) {
  * @param {IdentifierLookup} targetLookup
  * @param {IdentifierLookup} hostLookup
  * @param {Map<NodeIdentifier, NodeIdentifier[]>} mergedInputsMap
- * @param {number} mergedLastNodeIndex
+ * @param {number} targetLastNodeIndex
  * @returns {Promise<void>}
  */
 async function commitChangedMerge(
@@ -428,7 +427,7 @@ async function commitChangedMerge(
     targetLookup,
     hostLookup,
     mergedInputsMap,
-    mergedLastNodeIndex
+    targetLastNodeIndex
 ) {
     mergeIdentifierLookups(targetLookup, hostLookup);
     const writer = new ReplicaBatchWriter(targetStorage);
@@ -438,32 +437,12 @@ async function commitChangedMerge(
     ));
     await writer.push(targetStorage.global.putOp(
         LAST_NODE_INDEX_KEY,
-        mergedLastNodeIndex
+        targetLastNodeIndex
     ));
     await writer.flush();
 
     await unifyRevdeps(targetStorage, mergedInputsMap);
     await rootDatabase.setCurrentReplicaPointer(targetReplica);
-}
-
-/**
- * Load the last_node_index from a schema storage's global sublevel.
- * Returns 0 if the key is absent (fresh / un-versioned replica).
- * Throws if the key is present but not a non-negative integer.
- * @param {SchemaStorage} storage
- * @returns {Promise<number>}
- */
-async function loadLastNodeIndex(storage) {
-    const value = await storage.global.get(LAST_NODE_INDEX_KEY);
-    if (value === undefined) {
-        return 0;
-    }
-    if (typeof value === 'number' && Number.isInteger(value) && value >= 0) {
-        return value;
-    }
-    throw new MalformedIdentifierLookupError(
-        `last_node_index is not a non-negative integer: ${typeof value}`
-    );
 }
 
 /**
@@ -513,9 +492,7 @@ async function mergeHostIntoReplica(logger, rootDatabase, hostname) {
     const targetLookup = await loadTargetLookup(targetStorage);
     assertNoIdentifierLookupConflicts(targetLookup, hostLookup);
 
-    const targetLastNodeIndex = await loadLastNodeIndex(targetStorage);
-    const hostLastNodeIndex = await loadLastNodeIndex(hostStorage);
-    const mergedLastNodeIndex = Math.max(targetLastNodeIndex, hostLastNodeIndex);
+    const targetLastNodeIndex = rootDatabase.getLastNodeIndex();
 
     const {
         initialDecisions,
@@ -536,8 +513,7 @@ async function mergeHostIntoReplica(logger, rootDatabase, hostname) {
     );
 
     const summary = summarizeDecisions(decisions.values());
-    const metadataChanged = mergedLastNodeIndex !== targetLastNodeIndex;
-    if (summary.hasChanges || metadataChanged) {
+    if (summary.hasChanges) {
         await commitChangedMerge(
             rootDatabase,
             targetStorage,
@@ -545,11 +521,11 @@ async function mergeHostIntoReplica(logger, rootDatabase, hostname) {
             targetLookup,
             hostLookup,
             mergedInputsMap,
-            mergedLastNodeIndex
+            targetLastNodeIndex
         );
     }
 
-    const switchedReplica = summary.hasChanges || metadataChanged;
+    const switchedReplica = summary.hasChanges;
     logger.logInfo(
         {
             hostname,

--- a/backend/src/generators/incremental_graph/database/synchronize_reset_snapshot.js
+++ b/backend/src/generators/incremental_graph/database/synchronize_reset_snapshot.js
@@ -7,6 +7,7 @@ const {
 } = require('./gitstore');
 const { makeRootDatabase } = require('./root_database');
 const { scanFromFilesystem } = require('./render');
+const { requireValidFingerprint } = require('./fingerprint');
 
 /** @typedef {import('./synchronize').Capabilities} Capabilities */
 /** @typedef {import('./root_database').RootDatabase} RootDatabase */
@@ -41,9 +42,19 @@ async function importResetSnapshotIntoDatabase(capabilities, database, workTree,
         nextReplica
     );
 
-    if (isExistingDb && preImportFingerprint) {
-        const targetGlobal = database.replicaGlobalSublevel(nextReplica);
-        await targetGlobal.put('fingerprint', preImportFingerprint);
+    const targetGlobal = database.replicaGlobalSublevel(nextReplica);
+    if (hasSnapshotReplicaDirectory) {
+        requireValidFingerprint(
+            await targetGlobal.get('fingerprint'),
+            'rendered/r/global/fingerprint during reset import'
+        );
+    }
+
+    if (isExistingDb) {
+        await targetGlobal.put(
+            'fingerprint',
+            requireValidFingerprint(preImportFingerprint, 'pre-import live database')
+        );
     }
 
     const previousReplica = database.currentReplicaName();

--- a/backend/tests/database.test.js
+++ b/backend/tests/database.test.js
@@ -602,7 +602,7 @@ describe('generators/database', () => {
 
                 const yStorage = db.schemaStorageForReplica('y');
                 await yStorage.global.put('version', db.version);
-                await yStorage.global.put(IDENTIFIERS_KEY, [['aaaaaaaaa', 'bbbbbbbbb'], ['aaaaaaaaa', 'ccccccccc']]);
+                await yStorage.global.put(IDENTIFIERS_KEY, [['1-abcdefghi', '2-abcdefghi'], ['1-abcdefghi', '3-abcdefghi']]);
 
                 await expect(db.setCurrentReplicaPointer('y')).rejects.toThrow();
                 expect(db.currentReplicaName()).toBe('x');

--- a/backend/tests/database_synchronize.test.js
+++ b/backend/tests/database_synchronize.test.js
@@ -296,7 +296,7 @@ describe("synchronizeNoLock", () => {
                                         ['!x!!global!version', "incompatible-version"],
                     ['!x!!values!{"head":"event","args":["zed"]}', { source: "zed" }],
                     ['!x!!inputs!{"head":"event","args":["zed"]}', { inputs: [], inputCounters: [] }],
-                                        ['!x!!global!identifiers_keys_map', [['zzzzzzzzz', '{"head":"event","args":["zed"]}']]],
+                                        ['!x!!global!identifiers_keys_map', [['z-abcdefghi', '{"head":"event","args":["zed"]}']]],
                 ],
             },
         ]);
@@ -355,6 +355,10 @@ describe("synchronizeNoLock", () => {
         const snapshotKey = '!x!!values!{"head":"event","args":["reset"]}';
         await seedHostnameBranchWithRenderedFiles(capabilities, [
             { path: renderedKeyPath(snapshotKey), content: JSON.stringify("after-reset") },
+            { path: 'r/global/version', content: JSON.stringify('snapshot-version') },
+            { path: 'r/global/identifiers_keys_map', content: JSON.stringify([]) },
+            { path: 'r/global/last_node_index', content: JSON.stringify(0) },
+            { path: 'r/global/fingerprint', content: JSON.stringify('snapshotfingerprint') },
         ]);
         await expect(
             synchronizeNoLock(capabilities, { resetToHostname: "test-host" })

--- a/backend/tests/fingerprint_design.test.js
+++ b/backend/tests/fingerprint_design.test.js
@@ -7,7 +7,7 @@
  *   3. First-boot restore imports snapshot fingerprint.
  *   4. Reset into existing live DB preserves pre-import local fingerprint.
  *   5. Sync merge preserves local fingerprint (host fingerprint not adopted).
- *   6. Metadata-only merge propagates last_node_index but preserves fingerprint.
+ *   6. Metadata-only host allocation metadata is ignored.
  *   7. Restart preserves fingerprint and last_node_index.
  */
 
@@ -23,6 +23,7 @@ const {
     nodeIdentifierFromString,
     makeIdentifierLookup,
     serializeIdentifierLookup,
+    isValidFingerprint,
 } = require('../src/generators/incremental_graph/database');
 const {
     mergeHostIntoReplica,
@@ -67,11 +68,30 @@ function makeLogger() {
     return { logInfo: jest.fn(), logDebug: jest.fn(), logWarning: jest.fn(), logError: jest.fn() };
 }
 
-const NODE_A = nodeIdentifierFromString('aaaaaaaaa');
+const NODE_A = nodeIdentifierFromString('1-abcdefghi');
+const HOST_NODE_A = nodeIdentifierFromString('1-remotehostfingerprint');
 const TS1 = '2024-01-01T00:00:01.000Z';
 
 describe('fingerprint design', () => {
     let db;
+
+    test.each([
+        'abcdefghi',
+        'abcdefghijklmnop',
+    ])('accepts valid fingerprint %s', (fingerprint) => {
+        expect(isValidFingerprint(fingerprint)).toBe(true);
+    });
+
+    test.each([
+        undefined,
+        123,
+        'abcdefgh',
+        'abc123def',
+        'ABCdefghi',
+        'abcdefghi-',
+    ])('rejects malformed fingerprint %p', (fingerprint) => {
+        expect(isValidFingerprint(fingerprint)).toBe(false);
+    });
 
     afterEach(async () => {
         if (db) {
@@ -119,6 +139,60 @@ describe('fingerprint design', () => {
         } finally {
             cleanup(tmpDir);
         }
+    });
+
+    test.each([
+        ['missing', undefined],
+        ['non-string', 123],
+        ['too short', 'abcdefgh'],
+        ['digits', 'abc123def'],
+        ['uppercase', 'ABCdefghi'],
+        ['punctuation', 'abcdefghi-'],
+    ])('opening a versioned active replica fails for %s fingerprint', async (_description, fingerprint) => {
+        const { capabilities, tmpDir } = getTestCapabilities();
+        try {
+            db = await getRootDatabase(capabilities);
+            await db.setGlobalVersion(db.getVersion());
+            const global = db.getSchemaStorage().global;
+            if (fingerprint === undefined) {
+                await global.del('fingerprint');
+            } else {
+                await global.put('fingerprint', fingerprint);
+            }
+            await db.close();
+            db = undefined;
+
+            await expect(getRootDatabase(capabilities)).rejects.toThrow(
+                /Invalid fingerprint in active replica 'x' global metadata/
+            );
+        } finally {
+            cleanup(tmpDir);
+        }
+    });
+
+    test('replica switch rejects a malformed target fingerprint before pointer update', async () => {
+        const { capabilities, tmpDir } = getTestCapabilities();
+        try {
+            db = await getRootDatabase(capabilities);
+            const target = db.schemaStorageForReplica('y');
+            await target.global.put('version', db.getVersion());
+            await target.global.put(IDENTIFIERS_KEY, []);
+            await target.global.put(LAST_NODE_INDEX_KEY, 0);
+            await target.global.put('fingerprint', 'ABCdefghi');
+
+            await expect(db.setCurrentReplicaPointer('y')).rejects.toThrow(
+                /Invalid fingerprint in replica 'y' global metadata/
+            );
+            expect(db.currentReplicaName()).toBe('x');
+        } finally {
+            cleanup(tmpDir);
+        }
+    });
+
+    test('nodeIdentifierFromString remains a nominal conversion without runtime validation', () => {
+        expect(String(nodeIdentifierFromString('not a current-format identifier'))).toBe(
+            'not a current-format identifier'
+        );
     });
 
     // ── 2. Checkpoint / rendered snapshot ─────────────────────────────────
@@ -245,6 +319,29 @@ describe('fingerprint design', () => {
         }
     });
 
+    test('first-boot rendered snapshot import rejects a malformed fingerprint', async () => {
+        const { capabilities, tmpDir } = getTestCapabilities();
+        try {
+            db = await getRootDatabase(capabilities);
+            const rDir = path.join(tmpDir, 'snapshot', 'r');
+            const globalDir = path.join(rDir, 'global');
+            fs.mkdirSync(globalDir, { recursive: true });
+            fs.writeFileSync(path.join(globalDir, 'version'), JSON.stringify(String(db.getVersion())));
+            fs.writeFileSync(path.join(globalDir, IDENTIFIERS_KEY), JSON.stringify([]));
+            fs.writeFileSync(path.join(globalDir, LAST_NODE_INDEX_KEY), JSON.stringify(0));
+            fs.writeFileSync(path.join(globalDir, 'fingerprint'), JSON.stringify('abc123def'));
+
+            const targetReplica = db.otherReplicaName();
+            await scanFromFilesystem(capabilities, db, rDir, targetReplica);
+            await expect(db.setCurrentReplicaPointer(targetReplica)).rejects.toThrow(
+                /Invalid fingerprint in replica 'y' global metadata/
+            );
+            expect(db.currentReplicaName()).toBe('x');
+        } finally {
+            cleanup(tmpDir);
+        }
+    });
+
     // ── 4. Reset / import into existing live DB ───────────────────────────
 
     test('reset into existing DB preserves pre-import local fingerprint', async () => {
@@ -321,7 +418,9 @@ describe('fingerprint design', () => {
 
             // Merge: host has no nodes, so this is a no-op from a graph
             // perspective. But fingerprint should stay local.
-            await mergeHostIntoReplica(logger, db, hostname);
+            const switched = await mergeHostIntoReplica(logger, db, hostname);
+            expect(switched).toBe(false);
+            expect(db.currentReplicaName()).toBe('x');
             expect(db.getFingerprint()).toBe(localFingerprint);
 
             // Also verify via the in-memory computed state.
@@ -345,12 +444,12 @@ describe('fingerprint design', () => {
             await db.setHostnameGlobal(hostname, 'version', appVersionStr);
 
             const H = db.hostnameSchemaStorage(hostname);
-            await H.inputs.put(NODE_A, { inputs: [], inputCounters: [] });
-            await H.timestamps.put(NODE_A, { createdAt: TS1, modifiedAt: TS1 });
-            await H.freshness.put(NODE_A, 'up-to-date');
-            await H.values.put(NODE_A, { value: { id: 'a', type: 'test', description: 'a' }, isDirty: false });
+            await H.inputs.put(HOST_NODE_A, { inputs: [], inputCounters: [] });
+            await H.timestamps.put(HOST_NODE_A, { createdAt: TS1, modifiedAt: TS1 });
+            await H.freshness.put(HOST_NODE_A, 'up-to-date');
+            await H.values.put(HOST_NODE_A, { value: { id: 'a', type: 'test', description: 'a' }, isDirty: false });
             await H.global.put(IDENTIFIERS_KEY, serializeIdentifierLookup(makeIdentifierLookup([
-                [NODE_A, 'aaaaaaaaa'],
+                [HOST_NODE_A, 'node-a'],
             ])));
             await H.global.put(LAST_NODE_INDEX_KEY, 1);
             // Host has a different fingerprint.
@@ -359,6 +458,10 @@ describe('fingerprint design', () => {
             const logger = makeLogger();
             const switched = await mergeHostIntoReplica(logger, db, hostname);
             expect(switched).toBe(true);
+
+            // The host allocation watermark belongs to its fingerprint namespace.
+            expect(db.getLastNodeIndex()).toBe(0);
+            expect(await db.getSchemaStorage().global.get(LAST_NODE_INDEX_KEY)).toBe(0);
 
             // Local fingerprint must be preserved.
             expect(db.getFingerprint()).toBe(localFingerprint);
@@ -375,9 +478,9 @@ describe('fingerprint design', () => {
         }
     });
 
-    // ── 6. Metadata-only merge propagates last_node_index ─────────────────
+    // ── 6. Metadata-only host allocation metadata is ignored ─────────────
 
-    test('metadata-only merge commits when last_node_index differs', async () => {
+    test('metadata-only host fingerprint and last_node_index differences are a no-op', async () => {
         const { capabilities, tmpDir } = getTestCapabilities();
         try {
             db = await getRootDatabase(capabilities);
@@ -404,20 +507,13 @@ describe('fingerprint design', () => {
 
             const logger = makeLogger();
             const switched = await mergeHostIntoReplica(logger, db, hostname);
-            expect(switched).toBe(true);
-
-            // After merge, replica should have switched (metadata change).
-            // last_node_index should be max(0, 5) = 5.
-            // But since the merge might or might not switch the replica
-            // depending on the exact implementation...
-
-            // Fingerprint must remain local.
+            expect(switched).toBe(false);
+            expect(db.currentReplicaName()).toBe('x');
             expect(db.getFingerprint()).toBe(localFingerprint);
 
-            // Verify active replica's global metadata.
             const activeGlobal = db.getSchemaStorage().global;
-            const persistedFingerprint = await activeGlobal.get('fingerprint');
-            expect(persistedFingerprint).toBe(localFingerprint);
+            expect(await activeGlobal.get('fingerprint')).toBe(localFingerprint);
+            expect(await activeGlobal.get(LAST_NODE_INDEX_KEY)).toBe(0);
         } finally {
             cleanup(tmpDir);
         }

--- a/backend/tests/graph_storage_revdeps_ordering.test.js
+++ b/backend/tests/graph_storage_revdeps_ordering.test.js
@@ -115,8 +115,8 @@ describe("ensureReverseDepsIndexed – sorted identifier insertion", () => {
     });
 
     test("insert into empty list produces single-element array", async () => {
-        const input = nid("inputaaaa");
-        const dep = nid("depaaaaaa");
+        const input = nid("1-abcdefghi");
+        const dep = nid("2-abcdefghi");
 
         await storage.withBatch(async (batch) => {
             await storage.ensureReverseDepsIndexed(dep, [input], batch);
@@ -127,9 +127,9 @@ describe("ensureReverseDepsIndexed – sorted identifier insertion", () => {
     });
 
     test("inserts at beginning (new dep sorts before existing)", async () => {
-        const input = nid("inputaaaa");
-        const depB = nid("bbbbbbbbb");
-        const depA = nid("aaaaaaaaa");
+        const input = nid("1-abcdefghi");
+        const depB = nid("2-abcdefghi");
+        const depA = nid("1-abcdefghi");
 
         await storage.withBatch(async (batch) => {
             await storage.ensureReverseDepsIndexed(depB, [input], batch);
@@ -144,9 +144,9 @@ describe("ensureReverseDepsIndexed – sorted identifier insertion", () => {
     });
 
     test("inserts at end (new dep sorts after existing)", async () => {
-        const input = nid("inputaaaa");
-        const depA = nid("aaaaaaaaa");
-        const depB = nid("bbbbbbbbb");
+        const input = nid("1-abcdefghi");
+        const depA = nid("1-abcdefghi");
+        const depB = nid("2-abcdefghi");
 
         await storage.withBatch(async (batch) => {
             await storage.ensureReverseDepsIndexed(depA, [input], batch);
@@ -161,10 +161,10 @@ describe("ensureReverseDepsIndexed – sorted identifier insertion", () => {
     });
 
     test("inserts in the middle", async () => {
-        const input = nid("inputaaaa");
-        const depA = nid("aaaaaaaaa");
-        const depC = nid("ccccccccc");
-        const depB = nid("bbbbbbbbb");
+        const input = nid("1-abcdefghi");
+        const depA = nid("1-abcdefghi");
+        const depC = nid("3-abcdefghi");
+        const depB = nid("2-abcdefghi");
 
         await storage.withBatch(async (batch) => {
             await storage.ensureReverseDepsIndexed(depA, [input], batch);
@@ -182,8 +182,8 @@ describe("ensureReverseDepsIndexed – sorted identifier insertion", () => {
     });
 
     test("duplicate insertion is ignored (idempotent)", async () => {
-        const input = nid("inputaaaa");
-        const dep = nid("depaaaaaa");
+        const input = nid("1-abcdefghi");
+        const dep = nid("2-abcdefghi");
 
         await storage.withBatch(async (batch) => {
             await storage.ensureReverseDepsIndexed(dep, [input], batch);
@@ -200,10 +200,10 @@ describe("ensureReverseDepsIndexed – sorted identifier insertion", () => {
     });
 
     test("multiple inserts in one batch keep sorted invariant", async () => {
-        const input = nid("inputaaaa");
-        const depC = nid("ccccccccc");
-        const depA = nid("aaaaaaaaa");
-        const depB = nid("bbbbbbbbb");
+        const input = nid("1-abcdefghi");
+        const depC = nid("3-abcdefghi");
+        const depA = nid("1-abcdefghi");
+        const depB = nid("2-abcdefghi");
 
         await storage.withBatch(async (batch) => {
             await storage.ensureReverseDepsIndexed(depC, [input], batch);
@@ -217,11 +217,11 @@ describe("ensureReverseDepsIndexed – sorted identifier insertion", () => {
     });
 
     test("same dependents inserted in different orders produce identical stored array", async () => {
-        const input1 = nid("inputaaab");
-        const input2 = nid("inputaaac");
-        const depA = nid("aaaaaaaaa");
-        const depB = nid("bbbbbbbbb");
-        const depC = nid("ccccccccc");
+        const input1 = nid("3-abcdefghi");
+        const input2 = nid("4-abcdefghi");
+        const depA = nid("1-abcdefghi");
+        const depB = nid("2-abcdefghi");
+        const depC = nid("3-abcdefghi");
 
         const schema1 = makeSchemaStorage();
         const storage1 = makeGraphStorage(makeRootDatabase(schema1));
@@ -251,8 +251,8 @@ describe("ensureReverseDepsIndexed – sorted identifier insertion", () => {
     });
 
     test("stored representation uses identifier database keys", async () => {
-        const input = nid("inputaaaa");
-        const dep = nid("depaaaaaa");
+        const input = nid("1-abcdefghi");
+        const dep = nid("2-abcdefghi");
 
         await storage.withBatch(async (batch) => {
             await storage.ensureReverseDepsIndexed(dep, [input], batch);

--- a/backend/tests/identifier_lookup.test.js
+++ b/backend/tests/identifier_lookup.test.js
@@ -50,16 +50,16 @@ function keyStr(k) {
 }
 
 // Pre-built identifiers and keys used across tests.
-const ID_A = id("aaaaaaaaa");
-const ID_B = id("bbbbbbbbb");
-const ID_C = id("ccccccccc");
-const ID_D = id("ddddddddd");
+const ID_A = id("1-abcdefghi");
+const ID_B = id("2-abcdefghi");
+const ID_C = id("3-abcdefghi");
+const ID_D = id("4-abcdefghi");
 const KEY_X = key("key_x");
 const KEY_Y = key("key_y");
 const KEY_Z = key("key_z");
 
 /**
- * Sorted order of identifier strings: aaaaaaaa < bbbbbbbbb < ccccccccc < ddddddddd
+ * Sorted order follows the persisted current-format identifier strings.
  */
 
 // ---------------------------------------------------------------------------
@@ -85,8 +85,8 @@ describe("makeIdentifierLookup", () => {
         const lookup = makeIdentifierLookup(entries);
         expect(keyStr(nodeIdToKeyFromLookup(lookup, ID_A))).toBe("key_x");
         expect(keyStr(nodeIdToKeyFromLookup(lookup, ID_B))).toBe("key_y");
-        expect(nodeIdentifierToString(requireNodeIdentifierForKey(lookup, KEY_X))).toBe("aaaaaaaaa");
-        expect(nodeIdentifierToString(requireNodeIdentifierForKey(lookup, KEY_Y))).toBe("bbbbbbbbb");
+        expect(nodeIdentifierToString(requireNodeIdentifierForKey(lookup, KEY_X))).toBe("1-abcdefghi");
+        expect(nodeIdentifierToString(requireNodeIdentifierForKey(lookup, KEY_Y))).toBe("2-abcdefghi");
     });
 
     test("builds lookup from unsorted entries (serialized cache is sorted)", () => {
@@ -94,8 +94,8 @@ describe("makeIdentifierLookup", () => {
         const lookup = makeIdentifierLookup(entries);
         const serialized = lookup.serialized;
         expect(serialized.length).toBe(2);
-        expect(nodeIdentifierToString(serialized[0][0])).toBe("aaaaaaaaa");
-        expect(nodeIdentifierToString(serialized[1][0])).toBe("bbbbbbbbb");
+        expect(nodeIdentifierToString(serialized[0][0])).toBe("1-abcdefghi");
+        expect(nodeIdentifierToString(serialized[1][0])).toBe("2-abcdefghi");
     });
 
     test("throws on duplicate identifier", () => {
@@ -122,8 +122,8 @@ describe("serializeIdentifierLookup", () => {
     test("returns sorted entries", () => {
         const lookup = makeIdentifierLookup([[ID_B, KEY_Y], [ID_A, KEY_X]]);
         const result = serializeIdentifierLookup(lookup);
-        expect(nodeIdentifierToString(result[0][0])).toBe("aaaaaaaaa");
-        expect(nodeIdentifierToString(result[1][0])).toBe("bbbbbbbbb");
+        expect(nodeIdentifierToString(result[0][0])).toBe("1-abcdefghi");
+        expect(nodeIdentifierToString(result[1][0])).toBe("2-abcdefghi");
         expect(keyStr(result[0][1])).toBe("key_x");
         expect(keyStr(result[1][1])).toBe("key_y");
     });
@@ -156,7 +156,7 @@ describe("setIdentifierMapping", () => {
         const lookup = makeEmptyIdentifierLookup();
         setIdentifierMapping(lookup, ID_A, KEY_X);
         expect(keyStr(requireNodeKeyForIdentifier(lookup, ID_A))).toBe("key_x");
-        expect(nodeIdentifierToString(requireNodeIdentifierForKey(lookup, KEY_X))).toBe("aaaaaaaaa");
+        expect(nodeIdentifierToString(requireNodeIdentifierForKey(lookup, KEY_X))).toBe("1-abcdefghi");
     });
 
     test("re-asserting same mapping is idempotent", () => {
@@ -211,7 +211,7 @@ describe("deleteIdentifierMappingForNodeKey", () => {
         setIdentifierMapping(lookup, ID_B, KEY_Y);
         deleteIdentifierMappingForNodeKey(lookup, KEY_X);
         expect(nodeKeyToIdFromLookup(lookup, KEY_X)).toBeUndefined();
-        expect(nodeIdentifierToString(requireNodeIdentifierForKey(lookup, KEY_Y))).toBe("bbbbbbbbb");
+        expect(nodeIdentifierToString(requireNodeIdentifierForKey(lookup, KEY_Y))).toBe("2-abcdefghi");
     });
 });
 
@@ -222,7 +222,7 @@ describe("deleteIdentifierMappingForNodeKey", () => {
 describe("nodeKeyToIdFromLookup / nodeIdToKeyFromLookup", () => {
     test("returns identifier for existing key", () => {
         const lookup = makeIdentifierLookup([[ID_A, KEY_X]]);
-        expect(nodeIdentifierToString(nodeKeyToIdFromLookup(lookup, KEY_X))).toBe("aaaaaaaaa");
+        expect(nodeIdentifierToString(nodeKeyToIdFromLookup(lookup, KEY_X))).toBe("1-abcdefghi");
     });
 
     test("returns key for existing identifier", () => {
@@ -253,7 +253,7 @@ describe("allocateNodeIdentifier", () => {
             callCount++;
             return ID_A;
         });
-        expect(nodeIdentifierToString(result)).toBe("aaaaaaaaa");
+        expect(nodeIdentifierToString(result)).toBe("1-abcdefghi");
         expect(callCount).toBe(1);
     });
 
@@ -264,7 +264,7 @@ describe("allocateNodeIdentifier", () => {
             callCount++;
             return ID_B;
         });
-        expect(nodeIdentifierToString(result)).toBe("aaaaaaaaa");
+        expect(nodeIdentifierToString(result)).toBe("1-abcdefghi");
         expect(callCount).toBe(0);
     });
 
@@ -292,7 +292,7 @@ describe("requireNodeKeyForIdentifier / requireNodeIdentifierForKey", () => {
 
     test("returns identifier for existing key", () => {
         const lookup = makeIdentifierLookup([[ID_A, KEY_X]]);
-        expect(nodeIdentifierToString(requireNodeIdentifierForKey(lookup, KEY_X))).toBe("aaaaaaaaa");
+        expect(nodeIdentifierToString(requireNodeIdentifierForKey(lookup, KEY_X))).toBe("1-abcdefghi");
     });
 
     test("throws for missing key", () => {
@@ -309,8 +309,8 @@ describe("cloneIdentifierLookup", () => {
     test("clone has same entries", () => {
         const lookup = makeIdentifierLookup([[ID_A, KEY_X], [ID_B, KEY_Y]]);
         const clone = cloneIdentifierLookup(lookup);
-        expect(nodeIdentifierToString(requireNodeIdentifierForKey(clone, KEY_X))).toBe("aaaaaaaaa");
-        expect(nodeIdentifierToString(requireNodeIdentifierForKey(clone, KEY_Y))).toBe("bbbbbbbbb");
+        expect(nodeIdentifierToString(requireNodeIdentifierForKey(clone, KEY_X))).toBe("1-abcdefghi");
+        expect(nodeIdentifierToString(requireNodeIdentifierForKey(clone, KEY_Y))).toBe("2-abcdefghi");
     });
 
     test("mutating clone does not affect original", () => {
@@ -319,7 +319,7 @@ describe("cloneIdentifierLookup", () => {
         const clone = cloneIdentifierLookup(lookup);
         setIdentifierMapping(clone, ID_B, KEY_Y);
         expect(nodeKeyToIdFromLookup(lookup, KEY_Y)).toBeUndefined();
-        expect(nodeIdentifierToString(requireNodeIdentifierForKey(clone, KEY_Y))).toBe("bbbbbbbbb");
+        expect(nodeIdentifierToString(requireNodeIdentifierForKey(clone, KEY_Y))).toBe("2-abcdefghi");
     });
 
     test("clone shares serialized reference", () => {
@@ -338,7 +338,7 @@ describe("mergeIdentifierLookups", () => {
         const base = makeEmptyIdentifierLookup();
         const overlay = makeIdentifierLookup([[ID_A, KEY_X]]);
         mergeIdentifierLookups(base, overlay);
-        expect(nodeIdentifierToString(requireNodeIdentifierForKey(base, KEY_X))).toBe("aaaaaaaaa");
+        expect(nodeIdentifierToString(requireNodeIdentifierForKey(base, KEY_X))).toBe("1-abcdefghi");
     });
 
     test("updates serialized cache after merge", () => {
@@ -346,15 +346,15 @@ describe("mergeIdentifierLookups", () => {
         const overlay = makeIdentifierLookup([[ID_B, KEY_Y], [ID_A, KEY_X]]);
         mergeIdentifierLookups(base, overlay);
         expect(base.serialized.length).toBe(2);
-        expect(nodeIdentifierToString(base.serialized[0][0])).toBe("aaaaaaaaa");
-        expect(nodeIdentifierToString(base.serialized[1][0])).toBe("bbbbbbbbb");
+        expect(nodeIdentifierToString(base.serialized[0][0])).toBe("1-abcdefghi");
+        expect(nodeIdentifierToString(base.serialized[1][0])).toBe("2-abcdefghi");
     });
 
     test("no-op when overlay is empty", () => {
         const base = makeIdentifierLookup([[ID_A, KEY_X]]);
         const overlay = makeEmptyIdentifierLookup();
         mergeIdentifierLookups(base, overlay);
-        expect(nodeIdentifierToString(requireNodeIdentifierForKey(base, KEY_X))).toBe("aaaaaaaaa");
+        expect(nodeIdentifierToString(requireNodeIdentifierForKey(base, KEY_X))).toBe("1-abcdefghi");
     });
 
     test("throws on conflicting mapping", () => {
@@ -376,9 +376,9 @@ describe("mergeIdentifierLookups", () => {
         mergeIdentifierLookups(base, makeIdentifierLookup([[ID_A, KEY_X]]));
         mergeIdentifierLookups(base, makeIdentifierLookup([[ID_D, KEY_Z]]));
         expect(base.serialized.length).toBe(3);
-        expect(nodeIdentifierToString(base.serialized[0][0])).toBe("aaaaaaaaa");
-        expect(nodeIdentifierToString(base.serialized[1][0])).toBe("bbbbbbbbb");
-        expect(nodeIdentifierToString(base.serialized[2][0])).toBe("ddddddddd");
+        expect(nodeIdentifierToString(base.serialized[0][0])).toBe("1-abcdefghi");
+        expect(nodeIdentifierToString(base.serialized[1][0])).toBe("2-abcdefghi");
+        expect(nodeIdentifierToString(base.serialized[2][0])).toBe("4-abcdefghi");
     });
 });
 
@@ -397,7 +397,7 @@ describe("mergeSorted (internal)", () => {
         const txLookup = makeTransactionIdentifierLookup(base);
         const result = serializeTransactionLookup(txLookup);
         expect(result.length).toBe(1);
-        expect(nodeIdentifierToString(result[0][0])).toBe("aaaaaaaaa");
+        expect(nodeIdentifierToString(result[0][0])).toBe("1-abcdefghi");
     });
 });
 
@@ -424,7 +424,7 @@ describe("txNodeKeyToId / txNodeIdToKey", () => {
     test("returns base entry when overlay is empty", () => {
         const base = makeIdentifierLookup([[ID_A, KEY_X]]);
         const txLookup = makeTransactionIdentifierLookup(base);
-        expect(nodeIdentifierToString(txNodeKeyToId(txLookup, KEY_X))).toBe("aaaaaaaaa");
+        expect(nodeIdentifierToString(txNodeKeyToId(txLookup, KEY_X))).toBe("1-abcdefghi");
         expect(keyStr(txNodeIdToKey(txLookup, ID_A))).toBe("key_x");
     });
 
@@ -432,8 +432,8 @@ describe("txNodeKeyToId / txNodeIdToKey", () => {
         const base = makeEmptyIdentifierLookup();
         const txLookup = makeTransactionIdentifierLookup(base);
         txLookup.keyToId.set("key_x", ID_B);
-        txLookup.idToKey.set("bbbbbbbbb", KEY_X);
-        expect(nodeIdentifierToString(txNodeKeyToId(txLookup, KEY_X))).toBe("bbbbbbbbb");
+        txLookup.idToKey.set("2-abcdefghi", KEY_X);
+        expect(nodeIdentifierToString(txNodeKeyToId(txLookup, KEY_X))).toBe("2-abcdefghi");
         expect(keyStr(txNodeIdToKey(txLookup, ID_B))).toBe("key_x");
     });
 
@@ -470,8 +470,8 @@ describe("txAllocateNodeIdentifier", () => {
         const rootDb = makeRootDatabase([]);
         const txLookup = makeTransactionIdentifierLookup(rootDb.identifierLookup);
         const result = txAllocateNodeIdentifier(txLookup, KEY_X, () => ID_B, rootDb);
-        expect(nodeIdentifierToString(result)).toBe("bbbbbbbbb");
-        expect(nodeIdentifierToString(txNodeKeyToId(txLookup, KEY_X))).toBe("bbbbbbbbb");
+        expect(nodeIdentifierToString(result)).toBe("2-abcdefghi");
+        expect(nodeIdentifierToString(txNodeKeyToId(txLookup, KEY_X))).toBe("2-abcdefghi");
         expect(txLookup.ownedKeys.has("key_x")).toBe(true);
     });
 
@@ -480,7 +480,7 @@ describe("txAllocateNodeIdentifier", () => {
         const txLookup = makeTransactionIdentifierLookup(rootDb.identifierLookup);
         txAllocateNodeIdentifier(txLookup, KEY_X, () => ID_A, rootDb);
         const second = txAllocateNodeIdentifier(txLookup, KEY_X, () => ID_B, rootDb);
-        expect(nodeIdentifierToString(second)).toBe("aaaaaaaaa");
+        expect(nodeIdentifierToString(second)).toBe("1-abcdefghi");
     });
 
     test("reuses identifier from base when key already committed", () => {
@@ -488,7 +488,7 @@ describe("txAllocateNodeIdentifier", () => {
         const rootDb = { ...makeRootDatabase([]), identifierLookup: base };
         const txLookup = makeTransactionIdentifierLookup(base);
         const result = txAllocateNodeIdentifier(txLookup, KEY_X, () => ID_B, rootDb);
-        expect(nodeIdentifierToString(result)).toBe("aaaaaaaaa");
+        expect(nodeIdentifierToString(result)).toBe("1-abcdefghi");
     });
 });
 
@@ -507,17 +507,17 @@ describe("serializeTransactionLookup", () => {
     test("includes new entries from overlay", () => {
         const base = makeEmptyIdentifierLookup();
         const txLookup = makeTransactionIdentifierLookup(base);
-        txLookup.idToKey.set("aaaaaaaaa", KEY_X);
+        txLookup.idToKey.set("1-abcdefghi", KEY_X);
         const result = serializeTransactionLookup(txLookup);
         expect(result.length).toBe(1);
-        expect(nodeIdentifierToString(result[0][0])).toBe("aaaaaaaaa");
+        expect(nodeIdentifierToString(result[0][0])).toBe("1-abcdefghi");
         expect(keyStr(result[0][1])).toBe("key_x");
     });
 
     test("skips overlay entries already in base (dedup)", () => {
         const base = makeIdentifierLookup([[ID_A, KEY_X]]);
         const txLookup = makeTransactionIdentifierLookup(base);
-        txLookup.idToKey.set("aaaaaaaaa", KEY_X);
+        txLookup.idToKey.set("1-abcdefghi", KEY_X);
         const result = serializeTransactionLookup(txLookup);
         expect(result).toBe(base.serialized);
     });
@@ -525,17 +525,17 @@ describe("serializeTransactionLookup", () => {
     test("merges base and overlay sorted", () => {
         const base = makeIdentifierLookup([[ID_B, KEY_Y]]);
         const txLookup = makeTransactionIdentifierLookup(base);
-        txLookup.idToKey.set("aaaaaaaaa", KEY_X);
+        txLookup.idToKey.set("1-abcdefghi", KEY_X);
         const result = serializeTransactionLookup(txLookup);
         expect(result.length).toBe(2);
-        expect(nodeIdentifierToString(result[0][0])).toBe("aaaaaaaaa");
-        expect(nodeIdentifierToString(result[1][0])).toBe("bbbbbbbbb");
+        expect(nodeIdentifierToString(result[0][0])).toBe("1-abcdefghi");
+        expect(nodeIdentifierToString(result[1][0])).toBe("2-abcdefghi");
     });
 
     test("result is immutable (readonly) — cannot be mutated via base.serialized", () => {
         const base = makeEmptyIdentifierLookup();
         const txLookup = makeTransactionIdentifierLookup(base);
-        txLookup.idToKey.set("aaaaaaaaa", KEY_X);
+        txLookup.idToKey.set("1-abcdefghi", KEY_X);
         const result = serializeTransactionLookup(txLookup);
         // result is the mergeSorted return — a new array; can be spread
         expect(Array.isArray(result)).toBe(true);
@@ -551,9 +551,9 @@ describe("commitTransactionLookup", () => {
         const base = makeEmptyIdentifierLookup();
         const txLookup = makeTransactionIdentifierLookup(base);
         txLookup.keyToId.set("key_x", ID_A);
-        txLookup.idToKey.set("aaaaaaaaa", KEY_X);
+        txLookup.idToKey.set("1-abcdefghi", KEY_X);
         commitTransactionLookup(txLookup);
-        expect(nodeIdentifierToString(requireNodeIdentifierForKey(base, KEY_X))).toBe("aaaaaaaaa");
+        expect(nodeIdentifierToString(requireNodeIdentifierForKey(base, KEY_X))).toBe("1-abcdefghi");
         expect(keyStr(requireNodeKeyForIdentifier(base, ID_A))).toBe("key_x");
     });
 
@@ -561,10 +561,10 @@ describe("commitTransactionLookup", () => {
         const base = makeEmptyIdentifierLookup();
         const txLookup = makeTransactionIdentifierLookup(base);
         txLookup.keyToId.set("key_x", ID_A);
-        txLookup.idToKey.set("aaaaaaaaa", KEY_X);
+        txLookup.idToKey.set("1-abcdefghi", KEY_X);
         commitTransactionLookup(txLookup);
         expect(base.serialized.length).toBe(1);
-        expect(nodeIdentifierToString(base.serialized[0][0])).toBe("aaaaaaaaa");
+        expect(nodeIdentifierToString(base.serialized[0][0])).toBe("1-abcdefghi");
     });
 
     test("idempotent when overlay entries are already in base", () => {
@@ -572,7 +572,7 @@ describe("commitTransactionLookup", () => {
         const originalSerialized = base.serialized;
         const txLookup = makeTransactionIdentifierLookup(base);
         txLookup.keyToId.set("key_x", ID_A);
-        txLookup.idToKey.set("aaaaaaaaa", KEY_X);
+        txLookup.idToKey.set("1-abcdefghi", KEY_X);
         commitTransactionLookup(txLookup);
         expect(base.idToKey.size).toBe(1);
         expect(base.serialized).toBe(originalSerialized);
@@ -582,11 +582,11 @@ describe("commitTransactionLookup", () => {
         const base = makeIdentifierLookup([[ID_B, KEY_Y]]);
         const txLookup = makeTransactionIdentifierLookup(base);
         txLookup.keyToId.set("key_x", ID_A);
-        txLookup.idToKey.set("aaaaaaaaa", KEY_X);
+        txLookup.idToKey.set("1-abcdefghi", KEY_X);
         commitTransactionLookup(txLookup);
         expect(base.serialized.length).toBe(2);
-        expect(nodeIdentifierToString(base.serialized[0][0])).toBe("aaaaaaaaa");
-        expect(nodeIdentifierToString(base.serialized[1][0])).toBe("bbbbbbbbb");
+        expect(nodeIdentifierToString(base.serialized[0][0])).toBe("1-abcdefghi");
+        expect(nodeIdentifierToString(base.serialized[1][0])).toBe("2-abcdefghi");
     });
 
     test("multiple commits accumulate correctly", () => {
@@ -594,19 +594,19 @@ describe("commitTransactionLookup", () => {
 
         const tx1 = makeTransactionIdentifierLookup(base);
         tx1.keyToId.set("key_x", ID_A);
-        tx1.idToKey.set("aaaaaaaaa", KEY_X);
+        tx1.idToKey.set("1-abcdefghi", KEY_X);
         commitTransactionLookup(tx1);
 
         const tx2 = makeTransactionIdentifierLookup(base);
         tx2.keyToId.set("key_y", ID_B);
-        tx2.idToKey.set("bbbbbbbbb", KEY_Y);
+        tx2.idToKey.set("2-abcdefghi", KEY_Y);
         commitTransactionLookup(tx2);
 
         expect(base.serialized.length).toBe(2);
         expect(base.keyToId.size).toBe(2);
         expect(base.idToKey.size).toBe(2);
-        expect(nodeIdentifierToString(requireNodeIdentifierForKey(base, KEY_X))).toBe("aaaaaaaaa");
-        expect(nodeIdentifierToString(requireNodeIdentifierForKey(base, KEY_Y))).toBe("bbbbbbbbb");
+        expect(nodeIdentifierToString(requireNodeIdentifierForKey(base, KEY_X))).toBe("1-abcdefghi");
+        expect(nodeIdentifierToString(requireNodeIdentifierForKey(base, KEY_Y))).toBe("2-abcdefghi");
     });
 });
 
@@ -643,8 +643,8 @@ describe("Serialization roundtrip", () => {
         const original = makeIdentifierLookup([[ID_B, KEY_Y], [ID_A, KEY_X]]);
         const serialized = serializeIdentifierLookup(original);
         const restored = makeIdentifierLookup(serialized);
-        expect(nodeIdentifierToString(requireNodeIdentifierForKey(restored, KEY_X))).toBe("aaaaaaaaa");
-        expect(nodeIdentifierToString(requireNodeIdentifierForKey(restored, KEY_Y))).toBe("bbbbbbbbb");
+        expect(nodeIdentifierToString(requireNodeIdentifierForKey(restored, KEY_X))).toBe("1-abcdefghi");
+        expect(nodeIdentifierToString(requireNodeIdentifierForKey(restored, KEY_Y))).toBe("2-abcdefghi");
         expect(keyStr(requireNodeKeyForIdentifier(restored, ID_A))).toBe("key_x");
         expect(keyStr(requireNodeKeyForIdentifier(restored, ID_B))).toBe("key_y");
     });
@@ -671,13 +671,13 @@ describe("Serialization roundtrip", () => {
 
         const beforeCommit = serializeTransactionLookup(tx);
         expect(beforeCommit.length).toBe(1);
-        expect(nodeIdentifierToString(beforeCommit[0][0])).toBe("aaaaaaaaa");
+        expect(nodeIdentifierToString(beforeCommit[0][0])).toBe("1-abcdefghi");
 
         commitTransactionLookup(tx);
 
         const afterCommit = serializeTransactionLookup(makeTransactionIdentifierLookup(base));
         expect(afterCommit.length).toBe(1);
-        expect(nodeIdentifierToString(afterCommit[0][0])).toBe("aaaaaaaaa");
+        expect(nodeIdentifierToString(afterCommit[0][0])).toBe("1-abcdefghi");
 
         // Verify serialized cache was updated
         expect(base.serialized.length).toBe(1);

--- a/backend/tests/identifier_resolver.test.js
+++ b/backend/tests/identifier_resolver.test.js
@@ -88,7 +88,7 @@ describe("Transaction-based identifier operations", () => {
     });
 
     test("lookupNodeIdentifier finds existing mapping", () => {
-        const existingIdentifier = nodeIdentifierFromString("existinga");
+        const existingIdentifier = nodeIdentifierFromString("1-abcdefghi");
         const existingKey = stringToNodeKeyString('{"head":"existing","args":[]}');
         const tx = makeTransaction([[existingIdentifier, existingKey]]);
         const found = lookupNodeIdentifier(tx, existingKey);
@@ -96,7 +96,7 @@ describe("Transaction-based identifier operations", () => {
     });
 
     test("getOrAllocateNodeIdentifier returns existing identifier without allocating", () => {
-        const existingIdentifier = nodeIdentifierFromString("existinga");
+        const existingIdentifier = nodeIdentifierFromString("1-abcdefghi");
         const existingKey = stringToNodeKeyString('{"head":"existing","args":[]}');
         const tx = makeTransaction([[existingIdentifier, existingKey]]);
         const db = makeRootDatabase();
@@ -129,7 +129,7 @@ describe("Transaction-based identifier operations", () => {
     });
 
     test("requireNodeKey retrieves the key for an existing identifier", () => {
-        const id = nodeIdentifierFromString("existinga");
+        const id = nodeIdentifierFromString("1-abcdefghi");
         const key = stringToNodeKeyString('{"head":"existing","args":[]}');
         const tx = makeTransaction([[id, key]]);
         
@@ -138,7 +138,7 @@ describe("Transaction-based identifier operations", () => {
 
     test("requireNodeKey throws for an unknown identifier", () => {
         const tx = makeTransaction([]);
-        const id = nodeIdentifierFromString("unknownxx");
+        const id = nodeIdentifierFromString("2-abcdefghi");
         expect(() => requireNodeKey(tx, id)).toThrow();
     });
 
@@ -177,7 +177,7 @@ describe("Transaction-based identifier operations", () => {
     });
 
     test("allocations include pre-existing base lookup mappings", () => {
-        const baseId = nodeIdentifierFromString("baseidaaa");
+        const baseId = nodeIdentifierFromString("3-abcdefghi");
         const baseKey = stringToNodeKeyString('{"head":"base","args":[]}');
         const tx = makeTransaction([[baseId, baseKey]]);
         const db = makeRootDatabase();

--- a/backend/tests/identifiers_keys_map_correctness.test.js
+++ b/backend/tests/identifiers_keys_map_correctness.test.js
@@ -101,13 +101,13 @@ describe('serializeTransactionLookup includes both base and overlay entries', ()
     });
 
     test('populated base + empty overlay → base entries only', () => {
-        const idA = nodeIdentifierFromString('aaaaaaaaa');
+        const idA = nodeIdentifierFromString('1-abcdefghi');
         const keyA = stringToNodeKeyString('keyA');
         const base = makeIdentifierLookup([[idA, keyA]]);
         const txLookup = makeTransactionIdentifierLookup(base);
 
         const result = toStringPairs(serializeTransactionLookup(txLookup));
-        expect(result).toEqual([['aaaaaaaaa', 'keyA']]);
+        expect(result).toEqual([['1-abcdefghi', 'keyA']]);
     });
 
     test('empty base + overlay allocation → overlay entry only', () => {
@@ -115,44 +115,44 @@ describe('serializeTransactionLookup includes both base and overlay entries', ()
         const txLookup = makeTransactionIdentifierLookup(base);
 
         const keyB = stringToNodeKeyString('keyB');
-        txAllocateNodeIdentifier(txLookup, keyB, makeIdFactory(['bbbbbbbbb']), makeMockRootDatabase());
+        txAllocateNodeIdentifier(txLookup, keyB, makeIdFactory(['2-abcdefghi']), makeMockRootDatabase());
 
         const result = toStringPairs(serializeTransactionLookup(txLookup));
-        expect(result).toEqual([['bbbbbbbbb', 'keyB']]);
+        expect(result).toEqual([['2-abcdefghi', 'keyB']]);
     });
 
     test('populated base + overlay allocation → BOTH base and overlay entries present', () => {
         // This is the critical invariant: every disk write captures the complete
         // state, so no prior allocation is ever silently lost.
-        const idA = nodeIdentifierFromString('aaaaaaaaa');
+        const idA = nodeIdentifierFromString('1-abcdefghi');
         const keyA = stringToNodeKeyString('keyA');
         const base = makeIdentifierLookup([[idA, keyA]]);
         const txLookup = makeTransactionIdentifierLookup(base);
 
         const keyB = stringToNodeKeyString('keyB');
-        txAllocateNodeIdentifier(txLookup, keyB, makeIdFactory(['bbbbbbbbb']), makeMockRootDatabase());
+        txAllocateNodeIdentifier(txLookup, keyB, makeIdFactory(['2-abcdefghi']), makeMockRootDatabase());
 
         const result = toStringPairs(serializeTransactionLookup(txLookup));
         // Sorted ascending by identifier string.
         expect(result).toEqual([
-            ['aaaaaaaaa', 'keyA'],
-            ['bbbbbbbbb', 'keyB'],
+            ['1-abcdefghi', 'keyA'],
+            ['2-abcdefghi', 'keyB'],
         ]);
     });
 
     test('output is sorted ascending by identifier string regardless of insertion order', () => {
-        const idZ = nodeIdentifierFromString('zzzzzzzzz');
+        const idZ = nodeIdentifierFromString('z-abcdefghi');
         const keyZ = stringToNodeKeyString('keyZ');
         const base = makeIdentifierLookup([[idZ, keyZ]]);
         const txLookup = makeTransactionIdentifierLookup(base);
 
-        // Allocate 'aaaaaaaaa' in the overlay — lexicographically before base entry.
+        // Allocate '1-abcdefghi' in the overlay — lexicographically before base entry.
         const keyA = stringToNodeKeyString('keyA');
-        txAllocateNodeIdentifier(txLookup, keyA, makeIdFactory(['aaaaaaaaa']), makeMockRootDatabase());
+        txAllocateNodeIdentifier(txLookup, keyA, makeIdFactory(['1-abcdefghi']), makeMockRootDatabase());
 
         const result = toStringPairs(serializeTransactionLookup(txLookup));
-        expect(result[0][0]).toBe('aaaaaaaaa');
-        expect(result[1][0]).toBe('zzzzzzzzz');
+        expect(result[0][0]).toBe('1-abcdefghi');
+        expect(result[1][0]).toBe('z-abcdefghi');
     });
 });
 
@@ -164,43 +164,43 @@ describe('sequential commits accumulate all entries without loss', () => {
     test('T1 commits, T2 sees T1 allocations and adds its own', () => {
         const base = makeEmptyIdentifierLookup();
 
-        // Transaction T1: allocate keyA → 'aaaaaaaaa'
+        // Transaction T1: allocate keyA → '1-abcdefghi'
         const tx1 = makeTransactionIdentifierLookup(base);
         const keyA = stringToNodeKeyString('keyA');
-        txAllocateNodeIdentifier(tx1, keyA, makeIdFactory(['aaaaaaaaa']), makeMockRootDatabase());
+        txAllocateNodeIdentifier(tx1, keyA, makeIdFactory(['1-abcdefghi']), makeMockRootDatabase());
 
         // Simulate disk flush: serialize (verifies full state captured).
         const t1Serialized = toStringPairs(serializeTransactionLookup(tx1));
-        expect(t1Serialized).toEqual([['aaaaaaaaa', 'keyA']]);
+        expect(t1Serialized).toEqual([['1-abcdefghi', 'keyA']]);
 
         // Commit T1 into base (equivalent to commitTransactionLookup).
         commitTransactionLookup(tx1);
 
-        // Transaction T2: base now has keyA; allocate keyB → 'bbbbbbbbb'
+        // Transaction T2: base now has keyA; allocate keyB → '2-abcdefghi'
         const tx2 = makeTransactionIdentifierLookup(base);
         const keyB = stringToNodeKeyString('keyB');
-        txAllocateNodeIdentifier(tx2, keyB, makeIdFactory(['bbbbbbbbb']), makeMockRootDatabase());
+        txAllocateNodeIdentifier(tx2, keyB, makeIdFactory(['2-abcdefghi']), makeMockRootDatabase());
 
         // Serialize T2: must contain BOTH keyA (from base) AND keyB (new).
         const t2Serialized = toStringPairs(serializeTransactionLookup(tx2));
         expect(t2Serialized).toEqual([
-            ['aaaaaaaaa', 'keyA'],
-            ['bbbbbbbbb', 'keyB'],
+            ['1-abcdefghi', 'keyA'],
+            ['2-abcdefghi', 'keyB'],
         ]);
 
         // Commit T2 into base.
         commitTransactionLookup(tx2);
 
-        // Transaction T3: allocate keyC → 'ccccccccc'
+        // Transaction T3: allocate keyC → '3-abcdefghi'
         const tx3 = makeTransactionIdentifierLookup(base);
         const keyC = stringToNodeKeyString('keyC');
-        txAllocateNodeIdentifier(tx3, keyC, makeIdFactory(['ccccccccc']), makeMockRootDatabase());
+        txAllocateNodeIdentifier(tx3, keyC, makeIdFactory(['3-abcdefghi']), makeMockRootDatabase());
 
         const t3Serialized = toStringPairs(serializeTransactionLookup(tx3));
         expect(t3Serialized).toEqual([
-            ['aaaaaaaaa', 'keyA'],
-            ['bbbbbbbbb', 'keyB'],
-            ['ccccccccc', 'keyC'],
+            ['1-abcdefghi', 'keyA'],
+            ['2-abcdefghi', 'keyB'],
+            ['3-abcdefghi', 'keyC'],
         ]);
     });
 
@@ -208,12 +208,12 @@ describe('sequential commits accumulate all entries without loss', () => {
         const base = makeEmptyIdentifierLookup();
         const tx1 = makeTransactionIdentifierLookup(base);
         const keyA = stringToNodeKeyString('keyA');
-        const id1 = txAllocateNodeIdentifier(tx1, keyA, makeIdFactory(['aaaaaaaaa']), makeMockRootDatabase());
+        const id1 = txAllocateNodeIdentifier(tx1, keyA, makeIdFactory(['1-abcdefghi']), makeMockRootDatabase());
         commitTransactionLookup(tx1);
 
         // Second transaction: re-request the same key — must get the same identifier.
         const tx2 = makeTransactionIdentifierLookup(base);
-        const id2 = txAllocateNodeIdentifier(tx2, keyA, makeIdFactory(['zzzzzzzzz']), makeMockRootDatabase());
+        const id2 = txAllocateNodeIdentifier(tx2, keyA, makeIdFactory(['z-abcdefghi']), makeMockRootDatabase());
         expect(String(id2)).toBe(String(id1));
     });
 });
@@ -224,7 +224,7 @@ describe('sequential commits accumulate all entries without loss', () => {
 
 describe('collision detection covers base and overlay simultaneously', () => {
     test('a candidate identifier already in the base throws a BUG error', () => {
-        const idA = nodeIdentifierFromString('aaaaaaaaa');
+        const idA = nodeIdentifierFromString('1-abcdefghi');
         const keyA = stringToNodeKeyString('keyA');
         const base = makeIdentifierLookup([[idA, keyA]]);
         const txLookup = makeTransactionIdentifierLookup(base);
@@ -232,7 +232,7 @@ describe('collision detection covers base and overlay simultaneously', () => {
         // With fingerprint-prefixed identifiers collisions are impossible;
         // if one occurs it is a correctness bug.
         const keyB = stringToNodeKeyString('keyB');
-        expect(() => txAllocateNodeIdentifier(txLookup, keyB, makeIdFactory(['aaaaaaaaa']), makeMockRootDatabase()))
+        expect(() => txAllocateNodeIdentifier(txLookup, keyB, makeIdFactory(['1-abcdefghi']), makeMockRootDatabase()))
             .toThrow(/BUG.*collision.*committed/);
     });
 
@@ -241,14 +241,14 @@ describe('collision detection covers base and overlay simultaneously', () => {
         const txLookup = makeTransactionIdentifierLookup(base);
         const overlayMock = makeMockRootDatabase();
 
-        // Allocate 'aaaaaaaaa' to keyA in the overlay.
+        // Allocate '1-abcdefghi' to keyA in the overlay.
         const keyA = stringToNodeKeyString('keyA');
-        txAllocateNodeIdentifier(txLookup, keyA, makeIdFactory(['aaaaaaaaa']), overlayMock);
+        txAllocateNodeIdentifier(txLookup, keyA, makeIdFactory(['1-abcdefghi']), overlayMock);
 
         // With fingerprint-prefixed identifiers collisions are impossible;
         // if one occurs it is a correctness bug.
         const keyB = stringToNodeKeyString('keyB');
-        expect(() => txAllocateNodeIdentifier(txLookup, keyB, makeIdFactory(['aaaaaaaaa']), overlayMock))
+        expect(() => txAllocateNodeIdentifier(txLookup, keyB, makeIdFactory(['1-abcdefghi']), overlayMock))
             .toThrow(/BUG.*collision.*pending/);
     });
 });
@@ -263,19 +263,19 @@ describe('commitTransactionLookup merges overlay into base', () => {
         const txLookup = makeTransactionIdentifierLookup(base);
 
         const keyA = stringToNodeKeyString('keyA');
-        txAllocateNodeIdentifier(txLookup, keyA, makeIdFactory(['aaaaaaaaa']), makeMockRootDatabase());
+        txAllocateNodeIdentifier(txLookup, keyA, makeIdFactory(['1-abcdefghi']), makeMockRootDatabase());
 
         expect(base.keyToId.size).toBe(0); // base unchanged before commit
 
         commitTransactionLookup(txLookup);
 
         expect(base.keyToId.size).toBe(1); // base now has the allocation
-        expect(String(base.keyToId.get('keyA'))).toBe('aaaaaaaaa');
-        expect(String(base.idToKey.get('aaaaaaaaa'))).toBe('keyA');
+        expect(String(base.keyToId.get('keyA'))).toBe('1-abcdefghi');
+        expect(String(base.idToKey.get('1-abcdefghi'))).toBe('keyA');
     });
 
     test('no-op transaction (no allocations) leaves base unchanged', () => {
-        const idA = nodeIdentifierFromString('aaaaaaaaa');
+        const idA = nodeIdentifierFromString('1-abcdefghi');
         const keyA = stringToNodeKeyString('keyA');
         const base = makeIdentifierLookup([[idA, keyA]]);
         const txLookup = makeTransactionIdentifierLookup(base);
@@ -327,7 +327,7 @@ describe('parseIdentifierLookup negative tests', () => {
     });
 
     test('duplicate identifiers in entries throws IdentifierLookupError', () => {
-        const idA = nodeIdentifierFromString('aaaaaaaaa');
+        const idA = nodeIdentifierFromString('1-abcdefghi');
         const keyA = stringToNodeKeyString('keyA');
         const keyB = stringToNodeKeyString('keyB');
         const entries = [[idA, keyA], [idA, keyB]];
@@ -335,27 +335,27 @@ describe('parseIdentifierLookup negative tests', () => {
     });
 
     test('duplicate identifiers error message mentions the identifier', () => {
-        const idA = nodeIdentifierFromString('aaaaaaaaa');
+        const idA = nodeIdentifierFromString('1-abcdefghi');
         const keyA = stringToNodeKeyString('keyA');
         const keyB = stringToNodeKeyString('keyB');
         const entries = [[idA, keyA], [idA, keyB]];
         let error;
         try { makeIdentifierLookup(entries); } catch (e) { error = e; }
         expect(isIdentifierLookupError(error)).toBe(true);
-        expect(String(error.message)).toContain('aaaaaaaaa');
+        expect(String(error.message)).toContain('1-abcdefghi');
     });
 
     test('duplicate keys in entries throws IdentifierLookupError', () => {
-        const idA = nodeIdentifierFromString('aaaaaaaaa');
-        const idB = nodeIdentifierFromString('bbbbbbbbb');
+        const idA = nodeIdentifierFromString('1-abcdefghi');
+        const idB = nodeIdentifierFromString('2-abcdefghi');
         const keyA = stringToNodeKeyString('keyA');
         const entries = [[idA, keyA], [idB, keyA]];
         expect(() => makeIdentifierLookup(entries)).toThrow(IdentifierLookupError);
     });
 
     test('duplicate keys error message mentions the key', () => {
-        const idA = nodeIdentifierFromString('aaaaaaaaa');
-        const idB = nodeIdentifierFromString('bbbbbbbbb');
+        const idA = nodeIdentifierFromString('1-abcdefghi');
+        const idB = nodeIdentifierFromString('2-abcdefghi');
         const keyA = stringToNodeKeyString('keyA');
         const entries = [[idA, keyA], [idB, keyA]];
         let error;
@@ -365,7 +365,7 @@ describe('parseIdentifierLookup negative tests', () => {
     });
 
     test('parseIdentifierLookup forwards duplicate-identifier error from makeIdentifierLookup', () => {
-        const idA = nodeIdentifierFromString('aaaaaaaaa');
+        const idA = nodeIdentifierFromString('1-abcdefghi');
         const keyA = stringToNodeKeyString('keyA');
         const keyB = stringToNodeKeyString('keyB');
         expect(() => parseIdentifierLookup([[idA, keyA], [idA, keyB]], 'test'))

--- a/backend/tests/migration_script_compatibility.test.js
+++ b/backend/tests/migration_script_compatibility.test.js
@@ -142,6 +142,21 @@ describe('standalone migration script compatibility', () => {
         rimrafSync(tmpDir);
     });
 
+    test.each([
+        123,
+        'abcdefgh',
+        'abc123def',
+        'ABCdefghi',
+        'abcdefghi-',
+    ])('migration fails hard for malformed persisted fingerprint %p', async (fingerprint) => {
+        buildOldFormatFixture(tmpDir);
+        writeJson(tmpDir, 'rendered/r/global/fingerprint', fingerprint);
+
+        await expect(migrateSnapshot(tmpDir)).rejects.toThrow(
+            /Invalid fingerprint in snapshot file/
+        );
+    });
+
     test('old-format fixture with zero-arg and parameterized nodes round-trips through migration', async () => {
         // Arrange: build old-format fixture
         buildOldFormatFixture(tmpDir);
@@ -150,7 +165,7 @@ describe('standalone migration script compatibility', () => {
         await migrateSnapshot(tmpDir);
 
         // Verify structural properties:
-        // - Each identifier is a 9-char string
+        // - Each identifier uses the current index-fingerprint format
         // - identifiers_keys_map has exactly 3 entries
         // - All 3 unique keys appear in the map
         // - All old paths are gone

--- a/backend/tests/sync_merge.test.js
+++ b/backend/tests/sync_merge.test.js
@@ -57,12 +57,12 @@ function makeLogger() {
     };
 }
 
-// Stable 9-letter lowercase NodeIdentifiers used as test node keys.
-const NODE_A = nodeIdentifierFromString('aaaaaaaaa');
-const NODE_B = nodeIdentifierFromString('bbbbbbbbb');
-const NODE_C = nodeIdentifierFromString('ccccccccc');
-const NODE_P = nodeIdentifierFromString('ppppppppp');
-const NODE_H = nodeIdentifierFromString('hhhhhhhhh');
+// Current-format deterministic NodeIdentifiers used as test node keys.
+const NODE_A = nodeIdentifierFromString('1-abcdefghi');
+const NODE_B = nodeIdentifierFromString('2-abcdefghi');
+const NODE_C = nodeIdentifierFromString('3-abcdefghi');
+const NODE_P = nodeIdentifierFromString('4-abcdefghi');
+const NODE_H = nodeIdentifierFromString('5-abcdefghi');
 
 // Hardcoded ISO 8601 UTC timestamps for test reproducibility.
 // Values are chosen to be clearly ordered: TS1 < TS2 < TS3.
@@ -226,10 +226,10 @@ describe('mergeHostIntoReplica', () => {
             await db.setGlobalVersion(appVersionStr);
             await db.setHostnameGlobal(hostname, 'version', appVersionStr);
 
-            const targetParent = nodeIdentifierFromString('parentaaa');
-            const targetChild = nodeIdentifierFromString('childaaaa');
-            const hostParent = nodeIdentifierFromString('parentbbb');
-            const hostChild = nodeIdentifierFromString('childbbbb');
+            const targetParent = nodeIdentifierFromString('6-abcdefghi');
+            const targetChild = nodeIdentifierFromString('7-abcdefghi');
+            const hostParent = nodeIdentifierFromString('8-abcdefghi');
+            const hostChild = nodeIdentifierFromString('9-abcdefghi');
             const parentKey = stringToNodeKeyString('{"head":"parent","args":[]}');
             const childKey = stringToNodeKeyString('{"head":"child","args":[]}');
             const L = db.schemaStorageForReplica('x');
@@ -257,7 +257,7 @@ describe('mergeHostIntoReplica', () => {
 
             expect(isIdentifierLookupConflictError(error)).toBe(true);
             expect(String(error?.message)).toContain('Conflicting identifier assignment for node key');
-            expect(String(error?.message)).toContain(String(childKey));
+            expect(String(error?.message)).toContain(String(parentKey));
             expect(String(error?.message)).toContain('Volodyslav will not resolve this automatically');
             expect(String(error?.message)).toContain('manually fix the identifiers_keys_map records');
 
@@ -741,8 +741,8 @@ describe('mergeHostIntoReplica', () => {
             await db.setGlobalVersion(appVersionStr);
             await db.setHostnameGlobal(hostname, 'version', appVersionStr);
 
-            const idA = nodeIdentifierFromString('aaaaaaaaa');
-            const idB = nodeIdentifierFromString('bbbbbbbbb');
+            const idA = nodeIdentifierFromString('1-abcdefghi');
+            const idB = nodeIdentifierFromString('2-abcdefghi');
             const keyA = stringToNodeKeyString('{"head":"event","args":["a"]}');
             const keyB = stringToNodeKeyString('{"head":"event","args":["b"]}');
             const keyC = stringToNodeKeyString('{"head":"event","args":["c"]}');

--- a/backend/tests/topo_sort.test.js
+++ b/backend/tests/topo_sort.test.js
@@ -40,22 +40,22 @@ function getTestCapabilities() {
 
 /**
  * Return a stable 9-letter lowercase NodeIdentifier for test index i (0-25).
- * Uses letter repetition: 0 → "aaaaaaaaa", 1 → "bbbbbbbbb", ... 25 → "zzzzzzzzz".
+ * Uses current-format identifiers with a base36 index and fixed fingerprint.
  * @param {number} i
  * @returns {import('../src/generators/incremental_graph/database/types').NodeIdentifier}
  */
 function makeTestId(i) {
-    return nodeIdentifierFromString(String.fromCharCode(97 + i).repeat(9));
+    return nodeIdentifierFromString(`${i.toString(36)}-abcdefghi`);
 }
 
 // Named constants for the most commonly used test node identifiers.
-const NODE_A = makeTestId(0);  // 'aaaaaaaaa'
-const NODE_B = makeTestId(1);  // 'bbbbbbbbb'
-const NODE_C = makeTestId(2);  // 'ccccccccc'
+const NODE_A = makeTestId(0);  // '1-abcdefghi'
+const NODE_B = makeTestId(1);  // '2-abcdefghi'
+const NODE_C = makeTestId(2);  // '3-abcdefghi'
 const NODE_D = makeTestId(3);  // 'ddddddddd'
 const NODE_E = makeTestId(4);  // 'eeeeeeeee'  (used as external/unlisted node)
 const NODE_M = makeTestId(12); // 'mmmmmmmmm'
-const NODE_Z = makeTestId(25); // 'zzzzzzzzz'
+const NODE_Z = makeTestId(25); // 'z-abcdefghi'
 
 /**
  * Write an inputs record for `node` whose dependencies are `inputs`.

--- a/backend/tests/unification_db_to_db.test.js
+++ b/backend/tests/unification_db_to_db.test.js
@@ -18,12 +18,12 @@ const {
 const { nodeIdentifierFromString } = require('../src/generators/incremental_graph/database');
 
 // Stable 9-letter lowercase NodeIdentifiers used as test node keys.
-const NODE_FOO = nodeIdentifierFromString('foofoofoo');
-const NODE_BAR = nodeIdentifierFromString('barbarbar');
-const NODE_BAZ = nodeIdentifierFromString('bazbazbaz');
-const NODE_K   = nodeIdentifierFromString('kkkkkkkkk');
-const NODE_N   = nodeIdentifierFromString('nnnnnnnnn');
-const NODE_S   = nodeIdentifierFromString('sssssssss');
+const NODE_FOO = nodeIdentifierFromString('1-abcdefghi');
+const NODE_BAR = nodeIdentifierFromString('2-abcdefghi');
+const NODE_BAZ = nodeIdentifierFromString('3-abcdefghi');
+const NODE_K   = nodeIdentifierFromString('4-abcdefghi');
+const NODE_N   = nodeIdentifierFromString('5-abcdefghi');
+const NODE_S   = nodeIdentifierFromString('6-abcdefghi');
 
 // ---------------------------------------------------------------------------
 // makeInMemorySchemaStorage tests

--- a/docs/specs/incremental-graph-fingerprint.md
+++ b/docs/specs/incremental-graph-fingerprint.md
@@ -44,11 +44,15 @@ the project's seeded PRNG. It is generated exactly once:
 
 ## Format
 
-The fingerprint is a lowercase ASCII string of at least 9 characters,
-matching `/^[a-z]{9,}$/`. It is not validated at runtime — the format
-exists only as a specification invariant. The existing code style treats
-node identifiers as nominal strings and does not validate the documented
-format at conversion boundaries.
+The fingerprint is a lowercase ASCII string of at least 9 characters and is
+runtime validated against the full-string pattern `/^[a-z]{9,}$/`. Any
+persisted fingerprint loaded from active replica metadata, replica-switch
+target metadata, a rendered snapshot used for restore/reset, or the standalone
+snapshot migration path must satisfy this pattern. Missing or malformed values
+fail hard instead of being silently accepted or replaced.
+
+This runtime validation applies to fingerprints only. `NodeIdentifier` remains
+a nominal string whose documented format is specification-only.
 
 ## Lifecycle
 

--- a/docs/specs/incremental-graph-last-node-index.md
+++ b/docs/specs/incremental-graph-last-node-index.md
@@ -57,31 +57,20 @@ Gaps are acceptable and expected:
 
 ## Sync merge semantics
 
-When merging a host's staged snapshot into the local database, the merged
-`last_node_index` is computed as:
+During normal sync merge, `last_node_index` is local allocation metadata and is
+preserved from the target/local replica. A host's `last_node_index` belongs to
+that host's fingerprint namespace and is not adopted.
 
-```
-mergedLastNodeIndex = max(targetLastNodeIndex, hostLastNodeIndex)
-```
+Numeric indices are meaningful only together with their allocation fingerprint.
+Two hosts may safely allocate the same numeric index because the resulting node
+identifiers contain different fingerprints. Consequently, a host watermark must
+not advance or retire indices in the local fingerprint namespace.
 
-This is safe even though identifiers are fingerprint-namespaced:
-
-- Taking the max may skip local index values. Gaps in the index sequence are
-  acceptable and expected (see "Gaps" above). The value is a watermark of
-  retired future local allocation indices, not a count of materialized nodes.
-- The local fingerprint is preserved (host fingerprint is never adopted), so
-  local allocations after the merge use the local fingerprint. The merged
-  index watermark simply ensures the next local allocation does not reuse an
-  index value that was already retired on the host side.
-- The merged `last_node_index` is written durably as part of the merge commit
-  and becomes the basis for subsequent local allocations.
-
-### Metadata-only merge
-
-When graph records are identical but `last_node_index` differs (e.g., the
-host has a higher watermark), the merge commits the metadata change even
-when no graph nodes were modified. This ensures the watermark propagates
-and future local allocations do not collide with host-allocated indices.
+When host graph records are merged, the merge writes the target/local
+`last_node_index` to the target replica. A higher host `last_node_index` does not
+change that value. If the graph is otherwise unchanged, differences in the
+host's `last_node_index` are metadata-only and do not cause a merge commit or a
+replica switch.
 
 ## Concurrency
 

--- a/scripts/migrate-snapshot-to-identifiers.js
+++ b/scripts/migrate-snapshot-to-identifiers.js
@@ -17,6 +17,7 @@ const path = require("path");
 const fs = require("fs/promises");
 const { basicString } = require("../backend/src/random/basic_string");
 const { compareConstValue } = require("../backend/src/generators/incremental_graph/database/node_key");
+const { requireValidFingerprint } = require("../backend/src/generators/incremental_graph/database/fingerprint");
 const { convertReferences } = require("./lib/convert_references");
 
 const MIGRATED_VERSION = "0.0.0-dev";
@@ -116,6 +117,36 @@ function compareOldNodeKeyJson(left, right) {
     }
 
     return 0;
+}
+
+/**
+ * Read and validate an existing snapshot fingerprint, or generate one when the
+ * snapshot has no fingerprint file yet.
+ * @param {string} fingerprintPath
+ * @returns {Promise<string>}
+ */
+async function loadOrCreateFingerprint(fingerprintPath) {
+    let fingerprintExists = true;
+    try {
+        await fs.stat(fingerprintPath);
+    } catch {
+        fingerprintExists = false;
+    }
+
+    if (fingerprintExists) {
+        const raw = await fs.readFile(fingerprintPath, "utf-8");
+        return requireValidFingerprint(
+            JSON.parse(raw),
+            `snapshot file ${fingerprintPath}`
+        );
+    }
+
+    const fingerprint = basicString(
+        { seed: { generate: () => Math.floor(Math.random() * Number.MAX_SAFE_INTEGER) } }
+    );
+    await fs.mkdir(path.dirname(fingerprintPath), { recursive: true });
+    await fs.writeFile(fingerprintPath, JSON.stringify(fingerprint));
+    return fingerprint;
 }
 
 // ─── Main migration logic ───────────────────────────────────────────────────
@@ -246,17 +277,9 @@ async function migrateSnapshot(snapshotDir) {
         console.log("No old-format entries found, nothing to migrate.");
         // Still ensure identifiers_keys_map exists
         await ensureIdentifiersKeysMap(renderedDir, []);
-        // Ensure fingerprint exists
+        // Ensure any persisted fingerprint is valid, or create one when absent.
         const fingerprintPath = path.join(renderedDir, "r", "global", "fingerprint");
-        try {
-            await fs.stat(fingerprintPath);
-        } catch {
-            const fingerprint = basicString(
-                { seed: { generate: () => Math.floor(Math.random() * Number.MAX_SAFE_INTEGER) } }
-            );
-            await fs.mkdir(path.dirname(fingerprintPath), { recursive: true });
-            await fs.writeFile(fingerprintPath, JSON.stringify(fingerprint));
-        }
+        await loadOrCreateFingerprint(fingerprintPath);
         // Write last_node_index
         await fs.mkdir(path.join(renderedDir, "r", "global"), { recursive: true });
         await fs.writeFile(path.join(renderedDir, "r", "global", "last_node_index"), JSON.stringify(0));
@@ -267,20 +290,7 @@ async function migrateSnapshot(snapshotDir) {
 
     // ── Step 1.5: Obtain or generate fingerprint ──
     const fingerprintPath = path.join(renderedDir, "r", "global", "fingerprint");
-    let fingerprint;
-    try {
-        const raw = await fs.readFile(fingerprintPath, "utf-8");
-        fingerprint = JSON.parse(raw);
-        if (typeof fingerprint !== 'string') {
-            throw new Error('fingerprint is not a string');
-        }
-    } catch {
-        fingerprint = basicString(
-            { seed: { generate: () => Math.floor(Math.random() * Number.MAX_SAFE_INTEGER) } }
-        );
-        await fs.mkdir(path.dirname(fingerprintPath), { recursive: true });
-        await fs.writeFile(fingerprintPath, JSON.stringify(fingerprint));
-    }
+    const fingerprint = await loadOrCreateFingerprint(fingerprintPath);
 
     // ── Step 2: Assign deterministic identifiers ──
     // Preserve insertion order so subsequent runs are stable.


### PR DESCRIPTION
### Motivation

- Ensure the database allocation fingerprint at `rendered/r/global/fingerprint` is treated as authoritative and safely validated at runtime so malformed or missing persisted fingerprints fail fast. 
- Keep fingerprint logic local to `r/global` (do not move to `_meta`) so restore/import/reset paths only need `rendered/r/` scans. 
- Treat `last_node_index` as local allocation metadata that must not be max-merged from hosts, because indices are namespaced by fingerprint.

### Description

- Add a reusable fingerprint helper module with `FINGERPRINT_PATTERN`, `isValidFingerprint`, `requireValidFingerprint`, `InvalidFingerprintError`, and a type guard in `backend/src/generators/incremental_graph/database/fingerprint.js`. 
- Validate persisted fingerprints via `requireValidFingerprint` when loading the active replica and when switching to a replica in `root_database.js`, and during reset/import in `synchronize_reset_snapshot.js`, while keeping `NodeIdentifier` conversion nominal (no runtime validation added). 
- Update the per-host merge logic in `sync_merge.js` to stop merging host `last_node_index` (remove the previous `Math.max(target, host)` behavior) and preserve the target/local `last_node_index`; metadata-only host differences are treated as no-ops and do not switch replicas. 
- Preserve first-boot restore semantics: a valid snapshot `r/global/fingerprint` is accepted on first boot; for reset/import into an existing live DB the pre-import local fingerprint is explicitly written back to the imported target replica before pointer switch. 
- Update the standalone migration script `scripts/migrate-snapshot-to-identifiers.js` to validate snapshot fingerprints (or generate one when absent) before assigning deterministic `index-fingerprint` identifiers. 
- Update specs: `docs/specs/incremental-graph-fingerprint.md` now documents runtime fingerprint validation and `r/global/fingerprint` location; `docs/specs/incremental-graph-last-node-index.md` documents that `last_node_index` is preserved locally and not merged from hosts. 
- Tests: replace legacy 9-letter fixtures with current-format deterministic `index-fingerprint` identifiers and add tests covering malformed persisted fingerprints, replica-switch fingerprint validation, first-boot import, reset-preserve behavior, metadata-only no-op merge, and that `NodeIdentifier` remains nominal.

### Testing

- Ran static analysis and linting with `npm run static-analysis` (TypeScript + ESLint): succeeded. 
- Built the frontend with `npm run build`: succeeded. 
- Ran focused and broader test suites with Jest: `npx jest backend/tests/fingerprint_design.test.js backend/tests/sync_merge.test.js backend/tests/migration_script_compatibility.test.js --runInBand` and multiple related suites; all modified and related tests passed locally. 
- Ran `npm test -- --runInBand` (full suite): one unrelated asset API test exceeded its 5s timeout under full-suite load but passed when run in isolation (`npx jest backend/tests/entries_assets.test.js --runInBand`), otherwise the runs showed the repository tests passing locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24970afb08832eaa0046a6199dae9d)