### PR TITLE
Fix semantic-node identifier conflicts during sync merge

### DIFF
--- a/backend/src/generators/incremental_graph/database/sync_merge.js
+++ b/backend/src/generators/incremental_graph/database/sync_merge.js
@@ -264,6 +264,7 @@ async function deleteNodeOps(writer, targetStorage, identifier) {
  * @param {Map<NodeKeyString, 'keep' | 'take'>} initialDecisions
  * @param {Map<NodeKeyString, MergeDecision>} decisions
  * @param {Set<NodeKeyString>} hostOnlyNodesNeedingInvalidation
+ * @param {Set<NodeKeyString>} reloweredInputNodes
  * @param {Map<NodeKeyString, NodeIdentifier>} finalIdentifierForKey
  * @param {Map<NodeIdentifier, NodeIdentifier[]>} mergedInputsMap
  * @returns {Promise<void>}
@@ -276,6 +277,7 @@ async function applyNodeDecisions(
     initialDecisions,
     decisions,
     hostOnlyNodesNeedingInvalidation,
+    reloweredInputNodes,
     finalIdentifierForKey,
     mergedInputsMap
 ) {
@@ -294,7 +296,9 @@ async function applyNodeDecisions(
         const sourceId = sourceLookup.keyToId.get(String(nodeKey));
         if (sourceId === undefined) throw new IdentifierLookupConflictError(`Missing source identifier for ${String(nodeKey)}`);
 
-        if (decision !== 'keep' || sourceId !== destinationId) {
+        const shouldCopy = decision !== 'keep' || sourceId !== destinationId ||
+            reloweredInputNodes.has(nodeKey);
+        if (shouldCopy) {
             await writer.pushAll(await copyNodeOps({
                 targetStorage,
                 sourceStorage,
@@ -304,7 +308,11 @@ async function applyNodeDecisions(
             }));
         }
 
-        if (decision === 'invalidate' || hostOnlyNodesNeedingInvalidation.has(nodeKey)) {
+        if (
+            decision === 'invalidate' ||
+            hostOnlyNodesNeedingInvalidation.has(nodeKey) ||
+            reloweredInputNodes.has(nodeKey)
+        ) {
             await writer.push(targetStorage.freshness.putOp(destinationId, 'potentially-outdated'));
             if (initial === 'take') {
                 const hostTimestamps = await hostStorage.timestamps.get(sourceId);
@@ -445,6 +453,7 @@ async function mergeHostIntoReplica(logger, rootDatabase, hostname) {
         mergedInputsMap,
         decisions,
         hOnlyNeedsInvalidate,
+        reloweredInputNodes,
         finalIdentifierForKey,
         finalIdentifierLookup,
         hasIdentifierChanges,
@@ -463,6 +472,7 @@ async function mergeHostIntoReplica(logger, rootDatabase, hostname) {
         initialDecisions,
         decisions,
         hOnlyNeedsInvalidate,
+        reloweredInputNodes,
         finalIdentifierForKey,
         mergedInputsMap
     );

--- a/backend/src/generators/incremental_graph/database/sync_merge.js
+++ b/backend/src/generators/incremental_graph/database/sync_merge.js
@@ -53,7 +53,7 @@ const {
     FinalMergeStateError,
     isFinalMergeStateError,
 } = require('./sync_merge_validation');
-const { copyNodeOps, copyReplicaGently } = require('./sync_merge_transfer');
+const { buildDeleteNodeOps, copyNodeOps, copyReplicaGently } = require('./sync_merge_transfer');
 const {
     assertNoIdentifierCollisions,
     parseIdentifierLookup,
@@ -238,23 +238,6 @@ async function loadTargetLookup(targetStorage) {
 }
 
 /**
- * Delete all identifier-keyed records for a losing target storage identity.
- * @param {ReplicaBatchWriter} writer
- * @param {SchemaStorage} targetStorage
- * @param {NodeIdentifier} identifier
- * @returns {Promise<void>}
- */
-async function deleteNodeOps(writer, targetStorage, identifier) {
-    await writer.pushAll([
-        targetStorage.values.delOp(identifier),
-        targetStorage.freshness.delOp(identifier),
-        targetStorage.inputs.delOp(identifier),
-        targetStorage.counters.delOp(identifier),
-        targetStorage.timestamps.delOp(identifier),
-    ]);
-}
-
-/**
  * Apply semantic decisions by copying the selected side into the final storage
  * identifier and writing planner-lowered inputs.
  * @param {SchemaStorage} targetStorage
@@ -264,7 +247,8 @@ async function deleteNodeOps(writer, targetStorage, identifier) {
  * @param {Map<NodeKeyString, 'keep' | 'take'>} initialDecisions
  * @param {Map<NodeKeyString, MergeDecision>} decisions
  * @param {Set<NodeKeyString>} hostOnlyNodesNeedingInvalidation
- * @param {Set<NodeKeyString>} reloweredInputNodes
+ * @param {Set<NodeKeyString>} directlyReloweredNodes
+ * @param {Set<NodeKeyString>} reloweringInvalidatedNodes
  * @param {Map<NodeKeyString, NodeIdentifier>} finalIdentifierForKey
  * @param {Map<NodeIdentifier, NodeIdentifier[]>} mergedInputsMap
  * @returns {Promise<void>}
@@ -277,7 +261,8 @@ async function applyNodeDecisions(
     initialDecisions,
     decisions,
     hostOnlyNodesNeedingInvalidation,
-    reloweredInputNodes,
+    directlyReloweredNodes,
+    reloweringInvalidatedNodes,
     finalIdentifierForKey,
     mergedInputsMap
 ) {
@@ -297,7 +282,7 @@ async function applyNodeDecisions(
         if (sourceId === undefined) throw new IdentifierLookupConflictError(`Missing source identifier for ${String(nodeKey)}`);
 
         const shouldCopy = decision !== 'keep' || sourceId !== destinationId ||
-            reloweredInputNodes.has(nodeKey);
+            directlyReloweredNodes.has(nodeKey);
         if (shouldCopy) {
             await writer.pushAll(await copyNodeOps({
                 targetStorage,
@@ -307,11 +292,14 @@ async function applyNodeDecisions(
                 finalInputsForDestination: mergedInputsMap.get(destinationId) ?? [],
             }));
         }
+        if (directlyReloweredNodes.has(nodeKey)) {
+            await writer.push(targetStorage.values.delOp(destinationId));
+        }
 
         if (
             decision === 'invalidate' ||
             hostOnlyNodesNeedingInvalidation.has(nodeKey) ||
-            reloweredInputNodes.has(nodeKey)
+            reloweringInvalidatedNodes.has(nodeKey)
         ) {
             await writer.push(targetStorage.freshness.putOp(destinationId, 'potentially-outdated'));
             if (initial === 'take') {
@@ -337,7 +325,7 @@ async function applyNodeDecisions(
             throw new IdentifierLookupConflictError(`Target lookup is not bijective for ${targetIdString}`);
         }
         if (finalId !== undefined && finalId !== targetId) {
-            await deleteNodeOps(writer, targetStorage, targetId);
+            await writer.pushAll(buildDeleteNodeOps(targetStorage, targetId));
         }
     }
     await writer.flush();
@@ -453,10 +441,11 @@ async function mergeHostIntoReplica(logger, rootDatabase, hostname) {
         mergedInputsMap,
         decisions,
         hOnlyNeedsInvalidate,
-        reloweredInputNodes,
+        directlyReloweredNodes,
+        reloweringInvalidatedNodes,
         finalIdentifierForKey,
         finalIdentifierLookup,
-        hasIdentifierChanges,
+        hasIdentifierReconciliation,
     } = await buildMergePlan(
         targetStorage,
         hostStorage,
@@ -472,7 +461,8 @@ async function mergeHostIntoReplica(logger, rootDatabase, hostname) {
         initialDecisions,
         decisions,
         hOnlyNeedsInvalidate,
-        reloweredInputNodes,
+        directlyReloweredNodes,
+        reloweringInvalidatedNodes,
         finalIdentifierForKey,
         mergedInputsMap
     );
@@ -480,7 +470,7 @@ async function mergeHostIntoReplica(logger, rootDatabase, hostname) {
     await assertValidFinalMergeState(targetStorage, finalIdentifierLookup);
 
     const summary = summarizeDecisions(decisions.values());
-    const hasChanges = summary.hasChanges || hasIdentifierChanges;
+    const hasChanges = summary.hasChanges || hasIdentifierReconciliation;
     if (hasChanges) {
         await commitChangedMerge(
             rootDatabase,

--- a/backend/src/generators/incremental_graph/database/sync_merge.js
+++ b/backend/src/generators/incremental_graph/database/sync_merge.js
@@ -50,6 +50,7 @@ const { buildMergePlan } = require('./sync_merge_plan');
 const { unifyRevdeps } = require('./sync_merge_revdeps');
 const {
     assertValidFinalMergeState,
+    assertLookupCoversMaterializedNodes,
     FinalMergeStateError,
     isFinalMergeStateError,
 } = require('./sync_merge_validation');
@@ -433,6 +434,8 @@ async function mergeHostIntoReplica(logger, rootDatabase, hostname) {
     const targetStorage = rootDatabase.schemaStorageForReplica(toReplica);
     const targetLookup = await loadTargetLookup(targetStorage);
     assertNoIdentifierCollisions(targetLookup, hostLookup);
+    await assertLookupCoversMaterializedNodes(hostStorage, hostLookup, 'staged host snapshot');
+    await assertLookupCoversMaterializedNodes(targetStorage, targetLookup, 'merge target replica');
 
     const targetLastNodeIndex = rootDatabase.getLastNodeIndex();
 

--- a/backend/src/generators/incremental_graph/database/sync_merge.js
+++ b/backend/src/generators/incremental_graph/database/sync_merge.js
@@ -14,18 +14,16 @@
  *    database.
  * 2. Copy `L` into `T`, excluding reverse dependencies because they are derived
  *    data and are rebuilt after decisions are applied.
- * 3. Parse and compare the target/host identifier lookup metadata. The current
- *    policy is deliberately conservative: equivalent semantic node keys must
- *    already use the same persisted identifier on both sides, and an identifier
- *    may not name different semantic keys.
- * 4. Build a merge plan from timestamps and the merged dependency graph. Newer
+ * 3. Parse the target/host identifier lookups and reject only the corrupt case
+ *    where one identifier names different semantic keys.
+ * 4. Build a semantic-node-key merge plan from timestamps and dependencies. Newer
  *    local nodes are kept, newer host nodes are taken, and descendants of both a
  *    local-newer and host-newer ancestor are invalidated so they recompute from
  *    the merged inputs.
- * 5. Apply the plan to `T`, rebuilding `revdeps` from the same merged inputs map
- *    used by the planner.
- * 6. Persist the merged identifier lookup and switch the active replica pointer
- *    only if the plan took or invalidated at least one node.
+ * 5. Choose one final identifier per semantic key, lower all chosen inputs to
+ *    those identifiers, apply the plan to `T`, and remove losing target records.
+ * 6. Validate and persist the newly constructed lookup, rebuild `revdeps`, and
+ *    switch replicas when graph data or identifier reconciliation changed.
  *
  * Error handling policy:
  * - Version mismatch throws HostVersionMismatchError.
@@ -38,28 +36,26 @@
  * returns or throws.
  */
 
-// THIS-MARKER-BLOCKS-VOLODYSLAV-RELEASE-63461325
-// Release blocker: identifier-native sync does not yet repair the case where
-// two hosts assign different NodeIdentifiers to the same semantic node key.
-// The current merge policy rejects or avoids identifier conflicts but cannot
-// merge diverged identifier assignments.  This format must not be deployed
-// until the conflict-resolution design is implemented.  See issue #1410.
-
 const { isTopologicalSortCycleError } = require('./topo_sort');
+const { IdentifierLookupConflictError } = require('./replica_errors');
 const { versionToString } = require('./types');
 const { RAW_BATCH_CHUNK_SIZE } = require('./constants');
 const {
     IDENTIFIERS_KEY,
     makeEmptyIdentifierLookup,
-    mergeIdentifierLookups,
     serializeIdentifierLookup,
 } = require('./identifier_lookup');
 const { LAST_NODE_INDEX_KEY } = require('./root_database');
 const { buildMergePlan } = require('./sync_merge_plan');
 const { unifyRevdeps } = require('./sync_merge_revdeps');
-const { buildTakeOps, copyReplicaGently } = require('./sync_merge_transfer');
 const {
-    assertNoIdentifierLookupConflicts,
+    assertValidFinalMergeState,
+    FinalMergeStateError,
+    isFinalMergeStateError,
+} = require('./sync_merge_validation');
+const { copyNodeOps, copyReplicaGently } = require('./sync_merge_transfer');
+const {
+    assertNoIdentifierCollisions,
     parseIdentifierLookup,
 } = require('./sync_merge_identifier_lookup');
 
@@ -69,6 +65,7 @@ const {
 /** @typedef {import('./root_database').SchemaStorage} SchemaStorage */
 /** @typedef {import('./root_database').ReplicaName} ReplicaName */
 /** @typedef {import('./types').NodeIdentifier} NodeIdentifier */
+/** @typedef {import('./types').NodeKeyString} NodeKeyString */
 /** @typedef {import('./types').Version} Version */
 /** @typedef {'keep' | 'take' | 'invalidate'} MergeDecision */
 
@@ -241,148 +238,100 @@ async function loadTargetLookup(targetStorage) {
 }
 
 /**
- * Apply a host-newer node to the target replica. If the planner determined the
- * host-only node is downstream of a locally-newer ancestor, the host's structure
- * is kept but freshness is overridden so the node recomputes locally.
- *
+ * Delete all identifier-keyed records for a losing target storage identity.
  * @param {ReplicaBatchWriter} writer
  * @param {SchemaStorage} targetStorage
- * @param {SchemaStorage} hostStorage
- * @param {NodeIdentifier} node
- * @param {Set<NodeIdentifier>} hostOnlyNodesNeedingInvalidation
+ * @param {NodeIdentifier} identifier
  * @returns {Promise<void>}
  */
-async function applyTakeDecision(
-    writer,
-    targetStorage,
-    hostStorage,
-    node,
-    hostOnlyNodesNeedingInvalidation
-) {
-    await writer.pushAll(await buildTakeOps(
-        targetStorage,
-        hostStorage,
-        node
-    ));
-
-    if (hostOnlyNodesNeedingInvalidation.has(node)) {
-        await writer.push(targetStorage.freshness.putOp(node, 'potentially-outdated'));
-    }
+async function deleteNodeOps(writer, targetStorage, identifier) {
+    await writer.pushAll([
+        targetStorage.values.delOp(identifier),
+        targetStorage.freshness.delOp(identifier),
+        targetStorage.inputs.delOp(identifier),
+        targetStorage.counters.delOp(identifier),
+        targetStorage.timestamps.delOp(identifier),
+    ]);
 }
 
 /**
- * Copy a host-newer node's structural state before invalidating it. This keeps
- * `inputs`, counters, values, and timestamps aligned with the merged dependency
- * graph while forcing recomputation of the final value.
- *
- * @param {ReplicaBatchWriter} writer
+ * Apply semantic decisions by copying the selected side into the final storage
+ * identifier and writing planner-lowered inputs.
  * @param {SchemaStorage} targetStorage
  * @param {SchemaStorage} hostStorage
- * @param {NodeIdentifier} node
- * @returns {Promise<void>}
- */
-async function copyHostStateForInvalidatedTake(writer, targetStorage, hostStorage, node) {
-    await writer.pushAll(await buildTakeOps(
-        targetStorage,
-        hostStorage,
-        node
-    ));
-}
-
-/**
- * Advance modifiedAt for a host-newer invalidated node so a later sync does not
- * repeatedly rediscover the same host timestamp as newer. The node remains
- * `potentially-outdated`, so the next read/recompute still derives a local value
- * from the merged inputs.
- *
- * @param {ReplicaBatchWriter} writer
- * @param {SchemaStorage} targetStorage
- * @param {SchemaStorage} hostStorage
- * @param {NodeIdentifier} node
- * @returns {Promise<void>}
- */
-async function advanceInvalidatedTakeTimestamp(writer, targetStorage, hostStorage, node) {
-    const hostTimestamps = await hostStorage.timestamps.get(node);
-    if (hostTimestamps === undefined) {
-        return;
-    }
-
-    const targetTimestamps = await targetStorage.timestamps.get(node);
-    await writer.push(targetStorage.timestamps.putOp(node, {
-        createdAt: targetTimestamps?.createdAt ?? hostTimestamps.createdAt,
-        modifiedAt: hostTimestamps.modifiedAt,
-    }));
-}
-
-/**
- * Apply an invalidate decision to the target replica.
- *
- * A node that was initially `take` has newer host structural data. The merge must
- * copy that host state before invalidating freshness; otherwise the rebuilt
- * revdeps index and the node's stored inputs would disagree. A node initially
- * kept already has the target structure that the planner used.
- *
- * @param {ReplicaBatchWriter} writer
- * @param {SchemaStorage} targetStorage
- * @param {SchemaStorage} hostStorage
- * @param {Map<NodeIdentifier, 'keep' | 'take'>} initialDecisions
- * @param {NodeIdentifier} node
- * @returns {Promise<void>}
- */
-async function applyInvalidateDecision(writer, targetStorage, hostStorage, initialDecisions, node) {
-    const initiallyTaken = initialDecisions.get(node) === 'take';
-    if (initiallyTaken) {
-        await copyHostStateForInvalidatedTake(writer, targetStorage, hostStorage, node);
-    }
-
-    await writer.push(targetStorage.freshness.putOp(node, 'potentially-outdated'));
-
-    if (initiallyTaken) {
-        await advanceInvalidatedTakeTimestamp(writer, targetStorage, hostStorage, node);
-    }
-}
-
-/**
- * Apply all node decisions to the target replica. Reverse dependencies and
- * global identifier metadata are intentionally excluded; callers update those
- * after node records are coherent.
- *
- * @param {SchemaStorage} targetStorage
- * @param {SchemaStorage} hostStorage
- * @param {Map<NodeIdentifier, 'keep' | 'take'>} initialDecisions
- * @param {Map<NodeIdentifier, MergeDecision>} decisions
- * @param {Set<NodeIdentifier>} hostOnlyNodesNeedingInvalidation
+ * @param {IdentifierLookup} targetLookup
+ * @param {IdentifierLookup} hostLookup
+ * @param {Map<NodeKeyString, 'keep' | 'take'>} initialDecisions
+ * @param {Map<NodeKeyString, MergeDecision>} decisions
+ * @param {Set<NodeKeyString>} hostOnlyNodesNeedingInvalidation
+ * @param {Map<NodeKeyString, NodeIdentifier>} finalIdentifierForKey
+ * @param {Map<NodeIdentifier, NodeIdentifier[]>} mergedInputsMap
  * @returns {Promise<void>}
  */
 async function applyNodeDecisions(
     targetStorage,
     hostStorage,
+    targetLookup,
+    hostLookup,
     initialDecisions,
     decisions,
-    hostOnlyNodesNeedingInvalidation
+    hostOnlyNodesNeedingInvalidation,
+    finalIdentifierForKey,
+    mergedInputsMap
 ) {
     const writer = new ReplicaBatchWriter(targetStorage);
 
-    for (const [node, decision] of decisions) {
-        if (decision === 'take') {
-            await applyTakeDecision(
-                writer,
+    for (const [nodeKey, decision] of decisions) {
+        const initial = initialDecisions.get(nodeKey);
+        const destinationId = finalIdentifierForKey.get(nodeKey);
+        if (initial === undefined || destinationId === undefined) {
+            throw new IdentifierLookupConflictError(`Incomplete merge plan for ${String(nodeKey)}`);
+        }
+        const structuralSide = decision === 'invalidate' ? initial : decision;
+        const useHost = structuralSide === 'take';
+        const sourceStorage = useHost ? hostStorage : targetStorage;
+        const sourceLookup = useHost ? hostLookup : targetLookup;
+        const sourceId = sourceLookup.keyToId.get(String(nodeKey));
+        if (sourceId === undefined) throw new IdentifierLookupConflictError(`Missing source identifier for ${String(nodeKey)}`);
+
+        if (decision !== 'keep' || sourceId !== destinationId) {
+            await writer.pushAll(await copyNodeOps({
                 targetStorage,
-                hostStorage,
-                node,
-                hostOnlyNodesNeedingInvalidation
-            );
-        } else if (decision === 'invalidate') {
-            await applyInvalidateDecision(
-                writer,
-                targetStorage,
-                hostStorage,
-                initialDecisions,
-                node
-            );
+                sourceStorage,
+                sourceId,
+                destinationId,
+                finalInputsForDestination: mergedInputsMap.get(destinationId) ?? [],
+            }));
+        }
+
+        if (decision === 'invalidate' || hostOnlyNodesNeedingInvalidation.has(nodeKey)) {
+            await writer.push(targetStorage.freshness.putOp(destinationId, 'potentially-outdated'));
+            if (initial === 'take') {
+                const hostTimestamps = await hostStorage.timestamps.get(sourceId);
+                const targetId = targetLookup.keyToId.get(String(nodeKey));
+                const targetTimestamps = targetId === undefined
+                    ? undefined
+                    : await targetStorage.timestamps.get(targetId);
+                if (hostTimestamps !== undefined) {
+                    await writer.push(targetStorage.timestamps.putOp(destinationId, {
+                        createdAt: targetTimestamps?.createdAt ?? hostTimestamps.createdAt,
+                        modifiedAt: hostTimestamps.modifiedAt,
+                    }));
+                }
+            }
         }
     }
 
+    for (const [targetIdString, nodeKey] of targetLookup.idToKey.entries()) {
+        const targetId = targetLookup.keyToId.get(String(nodeKey));
+        const finalId = finalIdentifierForKey.get(nodeKey);
+        if (targetId === undefined || String(targetId) !== targetIdString) {
+            throw new IdentifierLookupConflictError(`Target lookup is not bijective for ${targetIdString}`);
+        }
+        if (finalId !== undefined && finalId !== targetId) {
+            await deleteNodeOps(writer, targetStorage, targetId);
+        }
+    }
     await writer.flush();
 }
 
@@ -414,15 +363,11 @@ function summarizeDecisions(decisions) {
 }
 
 /**
- * Persist metadata and derived indexes that are updated only when graph records
- * changed. `mergedInputsMap` must be the exact map produced by the planner so
- * invalidated host-newer nodes get revdeps for their copied host inputs.
- *
+ * Persist the final semantic-plan lookup and derived reverse dependencies.
  * @param {RootDatabase} rootDatabase
  * @param {SchemaStorage} targetStorage
  * @param {ReplicaName} targetReplica
- * @param {IdentifierLookup} targetLookup
- * @param {IdentifierLookup} hostLookup
+ * @param {IdentifierLookup} finalIdentifierLookup
  * @param {Map<NodeIdentifier, NodeIdentifier[]>} mergedInputsMap
  * @param {number} targetLastNodeIndex
  * @returns {Promise<void>}
@@ -431,23 +376,17 @@ async function commitChangedMerge(
     rootDatabase,
     targetStorage,
     targetReplica,
-    targetLookup,
-    hostLookup,
+    finalIdentifierLookup,
     mergedInputsMap,
     targetLastNodeIndex
 ) {
-    mergeIdentifierLookups(targetLookup, hostLookup);
     const writer = new ReplicaBatchWriter(targetStorage);
     await writer.push(targetStorage.global.putOp(
         IDENTIFIERS_KEY,
-        serializeIdentifierLookup(targetLookup)
+        serializeIdentifierLookup(finalIdentifierLookup)
     ));
-    await writer.push(targetStorage.global.putOp(
-        LAST_NODE_INDEX_KEY,
-        targetLastNodeIndex
-    ));
+    await writer.push(targetStorage.global.putOp(LAST_NODE_INDEX_KEY, targetLastNodeIndex));
     await writer.flush();
-
     await unifyRevdeps(targetStorage, mergedInputsMap);
     await rootDatabase.setCurrentReplicaPointer(targetReplica);
 }
@@ -461,9 +400,9 @@ async function commitChangedMerge(
  * - The live database is locked for the duration of this call.
  *
  * Post-conditions on success:
- * - If the merge took or invalidated any node, the inactive replica contains the
- *   merged graph and is made active.
- * - If every node was kept, the active replica pointer is unchanged. The
+ * - If the merge changed graph data or reconciled identifiers, the inactive
+ *   replica contains the merged graph and is made active.
+ * - If every node and identifier was kept, the active replica pointer is unchanged. The
  *   inactive replica may still have been refreshed as a copy of the active
  *   replica, but callers must continue reading from the active pointer.
  * - Hostname staging storage is not cleared here; the caller owns cleanup.
@@ -497,7 +436,7 @@ async function mergeHostIntoReplica(logger, rootDatabase, hostname) {
 
     const targetStorage = rootDatabase.schemaStorageForReplica(toReplica);
     const targetLookup = await loadTargetLookup(targetStorage);
-    assertNoIdentifierLookupConflicts(targetLookup, hostLookup);
+    assertNoIdentifierCollisions(targetLookup, hostLookup);
 
     const targetLastNodeIndex = rootDatabase.getLastNodeIndex();
 
@@ -506,33 +445,44 @@ async function mergeHostIntoReplica(logger, rootDatabase, hostname) {
         mergedInputsMap,
         decisions,
         hOnlyNeedsInvalidate,
+        finalIdentifierForKey,
+        finalIdentifierLookup,
+        hasIdentifierChanges,
     } = await buildMergePlan(
         targetStorage,
-        hostStorage
+        hostStorage,
+        targetLookup,
+        hostLookup
     );
 
     await applyNodeDecisions(
         targetStorage,
         hostStorage,
+        targetLookup,
+        hostLookup,
         initialDecisions,
         decisions,
-        hOnlyNeedsInvalidate
+        hOnlyNeedsInvalidate,
+        finalIdentifierForKey,
+        mergedInputsMap
     );
 
+    await assertValidFinalMergeState(targetStorage, finalIdentifierLookup);
+
     const summary = summarizeDecisions(decisions.values());
-    if (summary.hasChanges) {
+    const hasChanges = summary.hasChanges || hasIdentifierChanges;
+    if (hasChanges) {
         await commitChangedMerge(
             rootDatabase,
             targetStorage,
             toReplica,
-            targetLookup,
-            hostLookup,
+            finalIdentifierLookup,
             mergedInputsMap,
             targetLastNodeIndex
         );
     }
 
-    const switchedReplica = summary.hasChanges;
+    const switchedReplica = hasChanges;
     logger.logInfo(
         {
             hostname,
@@ -552,6 +502,8 @@ module.exports = {
     mergeHostIntoReplica,
     HostVersionMismatchError,
     isHostVersionMismatchError,
+    FinalMergeStateError,
+    isFinalMergeStateError,
     SyncMergeAggregateError,
     isSyncMergeAggregateError,
     isTopologicalSortCycleError,

--- a/backend/src/generators/incremental_graph/database/sync_merge_identifier_lookup.js
+++ b/backend/src/generators/incremental_graph/database/sync_merge_identifier_lookup.js
@@ -1,6 +1,4 @@
-const {
-    makeIdentifierLookup,
-} = require('./identifier_lookup');
+const { makeIdentifierLookup } = require('./identifier_lookup');
 const {
     IdentifierLookupConflictError,
     MalformedIdentifierLookupError,
@@ -10,17 +8,7 @@ const {
 /** @typedef {import('./identifier_lookup').IdentifierLookup} IdentifierLookup */
 
 /**
- * TODO: when we get a better opportunity, this module must grow
- * actual conflict resolution (e.g. last-writer-wins on identifier
- * assignment, or a user-visible conflict prompt).  Until then, failing
- * hard is the correct behaviour — it surfaces data corruption early
- * rather than silently producing an inconsistent lookup.
- */
-
-/**
  * Parse a persisted identifier lookup value from replica global metadata.
- * A missing record is a hard error for identifier-native sync snapshots.
- *
  * @param {unknown} rawEntries
  * @param {string} context
  * @returns {IdentifierLookup}
@@ -32,43 +20,23 @@ function parseIdentifierLookup(rawEntries, context) {
 }
 
 /**
- * Detect conflicts between host and target lookup snapshots.
- *
- * The module-level doc comment explains the rationale — single-origin
- * assumption makes conflicts unrecoverable by design.
- *
+ * Reject the irreconcilable case where one storage identity names different
+ * semantic nodes. Same-key/different-identifier assignments are normal merge input.
  * @param {IdentifierLookup} targetLookup
  * @param {IdentifierLookup} hostLookup
  * @returns {void}
- * @throws {IdentifierLookupConflictError}
  */
-function assertNoIdentifierLookupConflicts(targetLookup, hostLookup) {
-    for (const [nodeKeyString, targetIdentifier] of targetLookup.keyToId.entries()) {
-        const hostIdentifier = hostLookup.keyToId.get(nodeKeyString);
-        if (hostIdentifier !== undefined && hostIdentifier !== targetIdentifier) {
-            throw new IdentifierLookupConflictError(
-                `Conflicting identifier assignment for node key ${nodeKeyString}: `
-                + `target=${String(targetIdentifier)}, host=${String(hostIdentifier)}. `
-                + `Volodyslav will not resolve this automatically; manually fix the `
-                + `identifiers_keys_map records before synchronizing again.`
-            );
-        }
-    }
-
+function assertNoIdentifierCollisions(targetLookup, hostLookup) {
     for (const [identifierString, targetNodeKey] of targetLookup.idToKey.entries()) {
         const hostNodeKey = hostLookup.idToKey.get(identifierString);
         if (hostNodeKey !== undefined && hostNodeKey !== targetNodeKey) {
             throw new IdentifierLookupConflictError(
-                `Conflicting node key assignment for identifier ${identifierString}: `
-                + `target=${String(targetNodeKey)}, host=${String(hostNodeKey)}. `
-                + `Volodyslav will not resolve this automatically; manually fix the `
-                + `identifiers_keys_map records before synchronizing again.`
+                `Conflicting node key assignment for identifier ${identifierString}: ` +
+                `target maps it to ${String(targetNodeKey)}, host maps it to ${String(hostNodeKey)}. ` +
+                `Volodyslav will not resolve this automatically; manually fix the identifiers_keys_map records before synchronizing again.`
             );
         }
     }
 }
 
-module.exports = {
-    assertNoIdentifierLookupConflicts,
-    parseIdentifierLookup,
-};
+module.exports = { assertNoIdentifierCollisions, parseIdentifierLookup };

--- a/backend/src/generators/incremental_graph/database/sync_merge_plan.js
+++ b/backend/src/generators/incremental_graph/database/sync_merge_plan.js
@@ -58,6 +58,8 @@ async function buildMergePlan(T, H, targetLookup, hostLookup) {
     for (const nodeKey of hostLookup.idToKey.values()) allNodeKeys.add(nodeKey);
 
     /** @type {Set<NodeKeyString>} */
+    const targetOnlyNodes = new Set();
+    /** @type {Set<NodeKeyString>} */
     const hOnlyNodes = new Set();
     for (const nodeKey of allNodeKeys) {
         const targetId = targetLookup.keyToId.get(String(nodeKey));
@@ -69,6 +71,7 @@ async function buildMergePlan(T, H, targetLookup, hostLookup) {
         }
         if (hostId === undefined) {
             initialDecisions.set(nodeKey, 'keep');
+            targetOnlyNodes.add(nodeKey);
             continue;
         }
 
@@ -118,7 +121,9 @@ async function buildMergePlan(T, H, targetLookup, hostLookup) {
     for (const [nodeKey, initial] of initialDecisions) {
         const inKeep = keepTainted.has(nodeKey);
         const inTake = takeTainted.has(nodeKey);
-        if (hOnlyNodes.has(nodeKey)) {
+        if (targetOnlyNodes.has(nodeKey)) {
+            decisions.set(nodeKey, inTake ? 'invalidate' : 'keep');
+        } else if (hOnlyNodes.has(nodeKey)) {
             decisions.set(nodeKey, 'take');
             if (inKeep) hOnlyNeedsInvalidate.add(nodeKey);
         } else if (inKeep && inTake) {

--- a/backend/src/generators/incremental_graph/database/sync_merge_plan.js
+++ b/backend/src/generators/incremental_graph/database/sync_merge_plan.js
@@ -39,6 +39,7 @@ async function semanticInputs(storage, lookup, identifier) {
  *   mergedInputsMap: Map<NodeIdentifier, NodeIdentifier[]>,
  *   decisions: Map<NodeKeyString, 'keep' | 'take' | 'invalidate'>,
  *   hOnlyNeedsInvalidate: Set<NodeKeyString>,
+ *   reloweredInputNodes: Set<NodeKeyString>,
  *   finalIdentifierForKey: Map<NodeKeyString, NodeIdentifier>,
  *   finalIdentifierLookup: IdentifierLookup,
  *   hasIdentifierChanges: boolean
@@ -161,6 +162,8 @@ async function buildMergePlan(T, H, targetLookup, hostLookup) {
 
     /** @type {Map<NodeIdentifier, NodeIdentifier[]>} */
     const mergedInputsMap = new Map();
+    /** @type {Set<NodeKeyString>} */
+    const reloweredInputNodes = new Set();
     for (const [nodeKey, decision] of decisions) {
         const initial = initialDecisions.get(nodeKey);
         const structuralSide = decision === 'invalidate' ? initial : decision;
@@ -171,12 +174,21 @@ async function buildMergePlan(T, H, targetLookup, hostLookup) {
         if (sourceId === undefined || finalId === undefined) {
             throw new IdentifierLookupConflictError(`Missing lowered identifier for ${String(nodeKey)}`);
         }
+        const sourceInputs = await storage.inputs.get(sourceId);
         const inputKeys = await semanticInputs(storage, lookup, sourceId);
-        mergedInputsMap.set(finalId, inputKeys.map(inputKey => {
+        const finalInputIds = inputKeys.map(inputKey => {
             const inputId = finalIdentifierForKey.get(inputKey);
             if (inputId === undefined) throw new IdentifierLookupConflictError(`Missing lowered input identifier for ${String(inputKey)}`);
             return inputId;
-        }));
+        });
+        mergedInputsMap.set(finalId, finalInputIds);
+        const sourceInputIds = sourceInputs?.inputs ?? [];
+        if (
+            sourceInputIds.length !== finalInputIds.length ||
+            sourceInputIds.some((inputId, index) => String(inputId) !== String(finalInputIds[index]))
+        ) {
+            reloweredInputNodes.add(nodeKey);
+        }
     }
 
     return {
@@ -184,6 +196,7 @@ async function buildMergePlan(T, H, targetLookup, hostLookup) {
         mergedInputsMap,
         decisions,
         hOnlyNeedsInvalidate,
+        reloweredInputNodes,
         finalIdentifierForKey,
         finalIdentifierLookup,
         hasIdentifierChanges,

--- a/backend/src/generators/incremental_graph/database/sync_merge_plan.js
+++ b/backend/src/generators/incremental_graph/database/sync_merge_plan.js
@@ -1,122 +1,177 @@
 const { topologicalSortFromMap } = require('./topo_sort');
 const { compareIsoTimestamps } = require('./sync_merge_timestamps');
-const { stringToNodeIdentifier } = require('./types');
+const { makeIdentifierLookup } = require('./identifier_lookup');
+const { IdentifierLookupConflictError } = require('./replica_errors');
 
+/** @typedef {import('./identifier_lookup').IdentifierLookup} IdentifierLookup */
 /** @typedef {import('./root_database').SchemaStorage} SchemaStorage */
 /** @typedef {import('./types').NodeIdentifier} NodeIdentifier */
+/** @typedef {import('./types').NodeKeyString} NodeKeyString */
 
 /**
- * Compute merged graph inputs and final node decisions for host merge.
+ * Resolve identifier-keyed inputs into semantic node keys.
+ * @param {SchemaStorage} storage
+ * @param {IdentifierLookup} lookup
+ * @param {NodeIdentifier} identifier
+ * @returns {Promise<NodeKeyString[]>}
+ */
+async function semanticInputs(storage, lookup, identifier) {
+    const record = await storage.inputs.get(identifier);
+    if (record === undefined) return [];
+    return record.inputs.map(input => {
+        const nodeKey = lookup.idToKey.get(String(input));
+        if (nodeKey === undefined) {
+            throw new IdentifierLookupConflictError(`Input identifier ${String(input)} is absent from identifiers_keys_map`);
+        }
+        return nodeKey;
+    });
+}
+
+/**
+ * Compute the semantic merge plan, then lower its graph back to final storage identifiers.
  *
  * @param {SchemaStorage} T
  * @param {SchemaStorage} H
+ * @param {IdentifierLookup} targetLookup
+ * @param {IdentifierLookup} hostLookup
  * @returns {Promise<{
- *   initialDecisions: Map<NodeIdentifier, 'keep' | 'take'>,
+ *   initialDecisions: Map<NodeKeyString, 'keep' | 'take'>,
  *   mergedInputsMap: Map<NodeIdentifier, NodeIdentifier[]>,
- *   decisions: Map<NodeIdentifier, 'keep' | 'take' | 'invalidate'>,
- *   hOnlyNeedsInvalidate: Set<NodeIdentifier>
+ *   decisions: Map<NodeKeyString, 'keep' | 'take' | 'invalidate'>,
+ *   hOnlyNeedsInvalidate: Set<NodeKeyString>,
+ *   finalIdentifierForKey: Map<NodeKeyString, NodeIdentifier>,
+ *   finalIdentifierLookup: IdentifierLookup,
+ *   hasIdentifierChanges: boolean
  * }>} 
  */
-async function buildMergePlan(T, H) {
-    /** @type {Map<NodeIdentifier, 'keep' | 'take'>} */
+async function buildMergePlan(T, H, targetLookup, hostLookup) {
+    /** @type {Map<NodeKeyString, 'keep' | 'take'>} */
     const initialDecisions = new Map();
-    /** @type {Set<NodeIdentifier>} */
+    /** @type {Set<NodeKeyString>} */
     const forceKeepRoots = new Set();
-    /** @type {Set<NodeIdentifier>} */
+    /** @type {Set<NodeKeyString>} */
     const forceTakeRoots = new Set();
+    /** @type {Set<NodeKeyString>} */
+    const allNodeKeys = new Set();
 
-    for await (const node of T.inputs.keys()) {
-        const tTimestamps = await T.timestamps.get(node);
-        const hTimestamps = await H.timestamps.get(node);
+    for (const nodeKey of targetLookup.idToKey.values()) allNodeKeys.add(nodeKey);
+    for (const nodeKey of hostLookup.idToKey.values()) allNodeKeys.add(nodeKey);
 
-        const cmp = compareIsoTimestamps(tTimestamps?.modifiedAt, hTimestamps?.modifiedAt);
-
-        if (hTimestamps === undefined || cmp >= 0) {
-            initialDecisions.set(node, 'keep');
-            if (cmp > 0) {
-                forceKeepRoots.add(node);
-            }
-        } else {
-            initialDecisions.set(node, 'take');
-            forceTakeRoots.add(node);
-        }
-    }
-
-    /** @type {Set<NodeIdentifier>} */
+    /** @type {Set<NodeKeyString>} */
     const hOnlyNodes = new Set();
-    for await (const hostKey of H.inputs.keys()) {
-        if (!initialDecisions.has(hostKey)) {
-            hOnlyNodes.add(hostKey);
+    for (const nodeKey of allNodeKeys) {
+        const targetId = targetLookup.keyToId.get(String(nodeKey));
+        const hostId = hostLookup.keyToId.get(String(nodeKey));
+        if (targetId === undefined) {
+            initialDecisions.set(nodeKey, 'take');
+            hOnlyNodes.add(nodeKey);
+            continue;
+        }
+        if (hostId === undefined) {
+            initialDecisions.set(nodeKey, 'keep');
+            continue;
+        }
+
+        const targetTimestamps = await T.timestamps.get(targetId);
+        const hostTimestamps = await H.timestamps.get(hostId);
+        const cmp = compareIsoTimestamps(
+            targetTimestamps?.modifiedAt,
+            hostTimestamps?.modifiedAt
+        );
+        if (cmp >= 0) {
+            initialDecisions.set(nodeKey, 'keep');
+            if (cmp > 0) forceKeepRoots.add(nodeKey);
+        } else {
+            initialDecisions.set(nodeKey, 'take');
+            forceTakeRoots.add(nodeKey);
         }
     }
+
+    /** @type {Map<NodeKeyString, NodeKeyString[]>} */
+    const initiallyChosenInputsMap = new Map();
+    for (const [nodeKey, initial] of initialDecisions) {
+        const lookup = initial === 'take' ? hostLookup : targetLookup;
+        const storage = initial === 'take' ? H : T;
+        const identifier = lookup.keyToId.get(String(nodeKey));
+        if (identifier === undefined) {
+            throw new IdentifierLookupConflictError(`Missing ${initial} identifier for semantic node ${String(nodeKey)}`);
+        }
+        initiallyChosenInputsMap.set(nodeKey, await semanticInputs(storage, lookup, identifier));
+    }
+
+    const topoList = topologicalSortFromMap(initiallyChosenInputsMap);
+    /** @type {Set<NodeKeyString>} */
+    const keepTainted = new Set(forceKeepRoots);
+    /** @type {Set<NodeKeyString>} */
+    const takeTainted = new Set(forceTakeRoots);
+    for (const nodeKey of topoList) {
+        for (const inputKey of initiallyChosenInputsMap.get(nodeKey) ?? []) {
+            if (keepTainted.has(inputKey)) keepTainted.add(nodeKey);
+            if (takeTainted.has(inputKey)) takeTainted.add(nodeKey);
+        }
+    }
+
+    /** @type {Map<NodeKeyString, 'keep' | 'take' | 'invalidate'>} */
+    const decisions = new Map();
+    /** @type {Set<NodeKeyString>} */
+    const hOnlyNeedsInvalidate = new Set();
+    for (const [nodeKey, initial] of initialDecisions) {
+        const inKeep = keepTainted.has(nodeKey);
+        const inTake = takeTainted.has(nodeKey);
+        if (hOnlyNodes.has(nodeKey)) {
+            decisions.set(nodeKey, 'take');
+            if (inKeep) hOnlyNeedsInvalidate.add(nodeKey);
+        } else if (inKeep && inTake) {
+            decisions.set(nodeKey, 'invalidate');
+        } else if (inKeep) {
+            decisions.set(nodeKey, 'keep');
+        } else if (inTake) {
+            decisions.set(nodeKey, 'take');
+        } else {
+            decisions.set(nodeKey, initial);
+        }
+    }
+
+    /** @type {Map<NodeKeyString, NodeIdentifier>} */
+    const finalIdentifierForKey = new Map();
+    /** @type {Array<[NodeIdentifier, NodeKeyString]>} */
+    const finalEntries = [];
+    let hasIdentifierChanges = false;
+    for (const [nodeKey, initial] of initialDecisions) {
+        const targetId = targetLookup.keyToId.get(String(nodeKey));
+        const hostId = hostLookup.keyToId.get(String(nodeKey));
+        const decision = decisions.get(nodeKey);
+        const finalSide = decision === 'invalidate' ? initial : decision;
+        const finalId = finalSide === 'take' ? hostId : targetId;
+        if (finalSide === undefined || finalId === undefined) {
+            throw new IdentifierLookupConflictError(`Missing final identifier for ${String(nodeKey)}`);
+        }
+        finalIdentifierForKey.set(nodeKey, finalId);
+        finalEntries.push([finalId, nodeKey]);
+        if (targetId !== hostId && targetId !== undefined && hostId !== undefined) {
+            hasIdentifierChanges = true;
+        }
+    }
+    const finalIdentifierLookup = makeIdentifierLookup(finalEntries);
 
     /** @type {Map<NodeIdentifier, NodeIdentifier[]>} */
     const mergedInputsMap = new Map();
-
-    for (const [node, decision] of initialDecisions) {
-        if (decision === 'take') {
-            const record = await H.inputs.get(node);
-            const inputKeys = record
-                ? record.inputs.map(input => stringToNodeIdentifier(input))
-                : [];
-            mergedInputsMap.set(node, inputKeys);
-        } else {
-            const record = await T.inputs.get(node);
-            const inputKeys = record
-                ? record.inputs.map(input => stringToNodeIdentifier(input))
-                : [];
-            mergedInputsMap.set(node, inputKeys);
+    for (const [nodeKey, decision] of decisions) {
+        const initial = initialDecisions.get(nodeKey);
+        const structuralSide = decision === 'invalidate' ? initial : decision;
+        const lookup = structuralSide === 'take' ? hostLookup : targetLookup;
+        const storage = structuralSide === 'take' ? H : T;
+        const sourceId = lookup.keyToId.get(String(nodeKey));
+        const finalId = finalIdentifierForKey.get(nodeKey);
+        if (sourceId === undefined || finalId === undefined) {
+            throw new IdentifierLookupConflictError(`Missing lowered identifier for ${String(nodeKey)}`);
         }
-    }
-
-    for (const key of hOnlyNodes) {
-        const record = await H.inputs.get(key);
-        const inputKeys = record
-            ? record.inputs.map(input => stringToNodeIdentifier(input))
-            : [];
-        mergedInputsMap.set(key, inputKeys);
-    }
-
-    const topoList = topologicalSortFromMap(mergedInputsMap);
-
-    /** @type {Set<NodeIdentifier>} */
-    const keepTainted = new Set(forceKeepRoots);
-    /** @type {Set<NodeIdentifier>} */
-    const takeTainted = new Set(forceTakeRoots);
-
-    for (const node of topoList) {
-        const inputKeys = mergedInputsMap.get(node) ?? [];
-        for (const inputKey of inputKeys) {
-            if (keepTainted.has(inputKey)) keepTainted.add(node);
-            if (takeTainted.has(inputKey)) takeTainted.add(node);
-        }
-    }
-
-    /** @type {Map<NodeIdentifier, 'keep' | 'take' | 'invalidate'>} */
-    const decisions = new Map();
-
-    for (const [node, initial] of initialDecisions) {
-        const inKeep = keepTainted.has(node);
-        const inTake = takeTainted.has(node);
-
-        if (inKeep && inTake) {
-            decisions.set(node, 'invalidate');
-        } else if (inKeep) {
-            decisions.set(node, 'keep');
-        } else if (inTake) {
-            decisions.set(node, 'take');
-        } else {
-            decisions.set(node, initial);
-        }
-    }
-
-    /** @type {Set<NodeIdentifier>} */
-    const hOnlyNeedsInvalidate = new Set();
-    for (const key of hOnlyNodes) {
-        decisions.set(key, 'take');
-        if (keepTainted.has(key)) {
-            hOnlyNeedsInvalidate.add(key);
-        }
+        const inputKeys = await semanticInputs(storage, lookup, sourceId);
+        mergedInputsMap.set(finalId, inputKeys.map(inputKey => {
+            const inputId = finalIdentifierForKey.get(inputKey);
+            if (inputId === undefined) throw new IdentifierLookupConflictError(`Missing lowered input identifier for ${String(inputKey)}`);
+            return inputId;
+        }));
     }
 
     return {
@@ -124,9 +179,10 @@ async function buildMergePlan(T, H) {
         mergedInputsMap,
         decisions,
         hOnlyNeedsInvalidate,
+        finalIdentifierForKey,
+        finalIdentifierLookup,
+        hasIdentifierChanges,
     };
 }
 
-module.exports = {
-    buildMergePlan,
-};
+module.exports = { buildMergePlan };

--- a/backend/src/generators/incremental_graph/database/sync_merge_plan.js
+++ b/backend/src/generators/incremental_graph/database/sync_merge_plan.js
@@ -39,10 +39,11 @@ async function semanticInputs(storage, lookup, identifier) {
  *   mergedInputsMap: Map<NodeIdentifier, NodeIdentifier[]>,
  *   decisions: Map<NodeKeyString, 'keep' | 'take' | 'invalidate'>,
  *   hOnlyNeedsInvalidate: Set<NodeKeyString>,
- *   reloweredInputNodes: Set<NodeKeyString>,
+ *   directlyReloweredNodes: Set<NodeKeyString>,
+ *   reloweringInvalidatedNodes: Set<NodeKeyString>,
  *   finalIdentifierForKey: Map<NodeKeyString, NodeIdentifier>,
  *   finalIdentifierLookup: IdentifierLookup,
- *   hasIdentifierChanges: boolean
+ *   hasIdentifierReconciliation: boolean
  * }>} 
  */
 async function buildMergePlan(T, H, targetLookup, hostLookup) {
@@ -142,7 +143,7 @@ async function buildMergePlan(T, H, targetLookup, hostLookup) {
     const finalIdentifierForKey = new Map();
     /** @type {Array<[NodeIdentifier, NodeKeyString]>} */
     const finalEntries = [];
-    let hasIdentifierChanges = false;
+    let hasIdentifierReconciliation = false;
     for (const [nodeKey, initial] of initialDecisions) {
         const targetId = targetLookup.keyToId.get(String(nodeKey));
         const hostId = hostLookup.keyToId.get(String(nodeKey));
@@ -155,7 +156,7 @@ async function buildMergePlan(T, H, targetLookup, hostLookup) {
         finalIdentifierForKey.set(nodeKey, finalId);
         finalEntries.push([finalId, nodeKey]);
         if (targetId !== hostId && targetId !== undefined && hostId !== undefined) {
-            hasIdentifierChanges = true;
+            hasIdentifierReconciliation = true;
         }
     }
     const finalIdentifierLookup = makeIdentifierLookup(finalEntries);
@@ -163,7 +164,7 @@ async function buildMergePlan(T, H, targetLookup, hostLookup) {
     /** @type {Map<NodeIdentifier, NodeIdentifier[]>} */
     const mergedInputsMap = new Map();
     /** @type {Set<NodeKeyString>} */
-    const reloweredInputNodes = new Set();
+    const directlyReloweredNodes = new Set();
     for (const [nodeKey, decision] of decisions) {
         const initial = initialDecisions.get(nodeKey);
         const structuralSide = decision === 'invalidate' ? initial : decision;
@@ -187,7 +188,26 @@ async function buildMergePlan(T, H, targetLookup, hostLookup) {
             sourceInputIds.length !== finalInputIds.length ||
             sourceInputIds.some((inputId, index) => String(inputId) !== String(finalInputIds[index]))
         ) {
-            reloweredInputNodes.add(nodeKey);
+            directlyReloweredNodes.add(nodeKey);
+        }
+    }
+
+    /** @type {Set<NodeKeyString>} */
+    const reloweringInvalidatedNodes = new Set(directlyReloweredNodes);
+    const invalidatedIdentifiers = new Set(
+        [...directlyReloweredNodes].map(nodeKey => String(finalIdentifierForKey.get(nodeKey)))
+    );
+    for (const identifier of topologicalSortFromMap(mergedInputsMap)) {
+        const inputs = mergedInputsMap.get(identifier) ?? [];
+        if (inputs.some(input => invalidatedIdentifiers.has(String(input)))) {
+            invalidatedIdentifiers.add(String(identifier));
+            const nodeKey = finalIdentifierLookup.idToKey.get(String(identifier));
+            if (nodeKey === undefined) {
+                throw new IdentifierLookupConflictError(
+                    `Missing semantic key for invalidated identifier ${String(identifier)}`
+                );
+            }
+            reloweringInvalidatedNodes.add(nodeKey);
         }
     }
 
@@ -196,10 +216,11 @@ async function buildMergePlan(T, H, targetLookup, hostLookup) {
         mergedInputsMap,
         decisions,
         hOnlyNeedsInvalidate,
-        reloweredInputNodes,
+        directlyReloweredNodes,
+        reloweringInvalidatedNodes,
         finalIdentifierForKey,
         finalIdentifierLookup,
-        hasIdentifierChanges,
+        hasIdentifierReconciliation,
     };
 }
 

--- a/backend/src/generators/incremental_graph/database/sync_merge_transfer.js
+++ b/backend/src/generators/incremental_graph/database/sync_merge_transfer.js
@@ -18,8 +18,31 @@ async function copyReplicaGently(rootDatabase, from, to) {
 }
 
 /**
+ * Build operations that remove every primary record for a discarded identifier.
+ * Reverse dependencies are rebuilt from the final lowered graph.
+ * @param {SchemaStorage} targetStorage
+ * @param {NodeIdentifier} identifier
+ * @returns {Array<*>}
+ */
+function buildDeleteNodeOps(targetStorage, identifier) {
+    return [
+        targetStorage.values.delOp(identifier),
+        targetStorage.freshness.delOp(identifier),
+        targetStorage.inputs.delOp(identifier),
+        targetStorage.counters.delOp(identifier),
+        targetStorage.timestamps.delOp(identifier),
+    ];
+}
+
+/**
  * Build operations that copy a node between potentially different identifiers.
  * Inputs are supplied by the semantic planner after lowering to final identifiers.
+ *
+ * `inputCounters` describe the source computation and are copied only as
+ * historical dependency metadata. If lowering changes any input identifier,
+ * the caller must delete the copied value and mark the node outdated so these
+ * counters can never authorize reuse of a value computed against another
+ * storage identity.
  *
  * @param {object} options
  * @param {SchemaStorage} options.targetStorage
@@ -69,4 +92,4 @@ async function copyNodeOps({
     return ops;
 }
 
-module.exports = { copyNodeOps, copyReplicaGently };
+module.exports = { buildDeleteNodeOps, copyNodeOps, copyReplicaGently };

--- a/backend/src/generators/incremental_graph/database/sync_merge_transfer.js
+++ b/backend/src/generators/incremental_graph/database/sync_merge_transfer.js
@@ -13,69 +13,60 @@ const { makeDbToDbAdapter, unifyStores } = require('./unification');
 async function copyReplicaGently(rootDatabase, from, to) {
     const src = rootDatabase.schemaStorageForReplica(from);
     const dst = rootDatabase.schemaStorageForReplica(to);
-
-    // Exclude revdeps: they will be recomputed from mergedInputsMap by
-    // unifyRevdeps() after the merge.  Copying them here wastes I/O.
     await unifyStores(makeDbToDbAdapter(src, dst, { excludeSublevels: ['revdeps'] }));
-
-    // One final fsync: all unification writes use sync:false for performance;
-    // _rawSync() issues an empty batch with sync:true to durably flush the
-    // WAL/database state without mutating any keys.
     await rootDatabase._rawSync();
 }
 
 /**
- * Build "take" batch operations that copy a node's full data from H into T.
- * Copies value, freshness, timestamps, inputs, and counters.
- * revdeps are NOT copied here; they are rebuilt from scratch at the end.
+ * Build operations that copy a node between potentially different identifiers.
+ * Inputs are supplied by the semantic planner after lowering to final identifiers.
  *
- * @param {SchemaStorage} T - Target (inactive) replica storage.
- * @param {SchemaStorage} H - Hostname staging storage.
- * @param {NodeIdentifier} key - Identifier to copy.
+ * @param {object} options
+ * @param {SchemaStorage} options.targetStorage
+ * @param {SchemaStorage} options.sourceStorage
+ * @param {NodeIdentifier} options.sourceId
+ * @param {NodeIdentifier} options.destinationId
+ * @param {NodeIdentifier[]} options.finalInputsForDestination
  * @returns {Promise<Array<*>>}
  */
-async function buildTakeOps(T, H, key) {
+async function copyNodeOps({
+    targetStorage,
+    sourceStorage,
+    sourceId,
+    destinationId,
+    finalInputsForDestination,
+}) {
     /** @type {Array<*>} */
     const ops = [];
+    const sourceValue = await sourceStorage.values.get(sourceId);
+    ops.push(sourceValue === undefined
+        ? targetStorage.values.delOp(destinationId)
+        : targetStorage.values.putOp(destinationId, sourceValue));
 
-    const hValue = await H.values.get(key);
-    if (hValue !== undefined) {
-        ops.push(T.values.putOp(key, hValue));
-    } else {
-        ops.push(T.values.delOp(key));
-    }
+    const sourceFreshness = await sourceStorage.freshness.get(sourceId);
+    ops.push(targetStorage.freshness.putOp(
+        destinationId,
+        sourceFreshness ?? 'potentially-outdated'
+    ));
 
-    const hFreshness = await H.freshness.get(key);
-    ops.push(T.freshness.putOp(key, hFreshness !== undefined ? hFreshness : 'potentially-outdated'));
+    const sourceTimestamps = await sourceStorage.timestamps.get(sourceId);
+    ops.push(sourceTimestamps === undefined
+        ? targetStorage.timestamps.delOp(destinationId)
+        : targetStorage.timestamps.putOp(destinationId, sourceTimestamps));
 
-    const hTimestamps = await H.timestamps.get(key);
-    if (hTimestamps !== undefined) {
-        ops.push(T.timestamps.putOp(key, hTimestamps));
-    } else {
-        ops.push(T.timestamps.delOp(key));
-    }
-
-    const hInputs = await H.inputs.get(key);
-    if (hInputs !== undefined) {
-        ops.push(T.inputs.putOp(key, {
-            inputs: hInputs.inputs,
-            inputCounters: hInputs.inputCounters,
+    const sourceInputs = await sourceStorage.inputs.get(sourceId);
+    ops.push(sourceInputs === undefined
+        ? targetStorage.inputs.delOp(destinationId)
+        : targetStorage.inputs.putOp(destinationId, {
+            inputs: finalInputsForDestination.map(input => String(input)),
+            inputCounters: sourceInputs.inputCounters,
         }));
-    } else {
-        ops.push(T.inputs.delOp(key));
-    }
 
-    const hCounter = await H.counters.get(key);
-    if (hCounter !== undefined) {
-        ops.push(T.counters.putOp(key, hCounter));
-    } else {
-        ops.push(T.counters.delOp(key));
-    }
-
+    const sourceCounter = await sourceStorage.counters.get(sourceId);
+    ops.push(sourceCounter === undefined
+        ? targetStorage.counters.delOp(destinationId)
+        : targetStorage.counters.putOp(destinationId, sourceCounter));
     return ops;
 }
 
-module.exports = {
-    buildTakeOps,
-    copyReplicaGently,
-};
+module.exports = { copyNodeOps, copyReplicaGently };

--- a/backend/src/generators/incremental_graph/database/sync_merge_validation.js
+++ b/backend/src/generators/incremental_graph/database/sync_merge_validation.js
@@ -1,0 +1,77 @@
+/** @typedef {import('./identifier_lookup').IdentifierLookup} IdentifierLookup */
+/** @typedef {import('./root_database').SchemaStorage} SchemaStorage */
+
+/**
+ * Raised when a completed merge plan would persist identifier-keyed storage
+ * that is not exactly covered by its final semantic lookup.
+ */
+class FinalMergeStateError extends Error {
+    /** @param {string} detail */
+    constructor(detail) {
+        super(`Invalid final sync merge state: ${detail}`);
+        this.name = 'FinalMergeStateError';
+        this.detail = detail;
+    }
+}
+
+/**
+ * @param {unknown} object
+ * @returns {object is FinalMergeStateError}
+ */
+function isFinalMergeStateError(object) {
+    return object instanceof FinalMergeStateError;
+}
+
+/**
+ * Validate the identifier-keyed final state before making the replica active.
+ * The inputs sublevel is the materialized-node registry.
+ * @param {SchemaStorage} targetStorage
+ * @param {IdentifierLookup} finalLookup
+ * @returns {Promise<void>}
+ */
+async function assertValidFinalMergeState(targetStorage, finalLookup) {
+    const knownIdentifiers = new Set(finalLookup.idToKey.keys());
+    const materializedIdentifiers = new Set();
+    for await (const identifier of targetStorage.inputs.keys()) {
+        const identifierString = String(identifier);
+        materializedIdentifiers.add(identifierString);
+        if (!knownIdentifiers.has(identifierString)) {
+            throw new FinalMergeStateError(`stored node ${identifierString} has no lookup entry`);
+        }
+        const inputs = await targetStorage.inputs.get(identifier);
+        for (const input of inputs?.inputs ?? []) {
+            if (!knownIdentifiers.has(String(input))) {
+                throw new FinalMergeStateError(
+                    `node ${identifierString} references unknown input ${String(input)}`
+                );
+            }
+        }
+    }
+    for (const identifierString of knownIdentifiers) {
+        if (!materializedIdentifiers.has(identifierString)) {
+            throw new FinalMergeStateError(
+                `lookup identifier ${identifierString} has no materialized node`
+            );
+        }
+    }
+    for (const sublevel of [
+        targetStorage.values,
+        targetStorage.freshness,
+        targetStorage.counters,
+        targetStorage.timestamps,
+    ]) {
+        for await (const identifier of sublevel.keys()) {
+            if (!knownIdentifiers.has(String(identifier))) {
+                throw new FinalMergeStateError(
+                    `discarded identifier ${String(identifier)} remains in storage`
+                );
+            }
+        }
+    }
+}
+
+module.exports = {
+    assertValidFinalMergeState,
+    FinalMergeStateError,
+    isFinalMergeStateError,
+};

--- a/backend/src/generators/incremental_graph/database/sync_merge_validation.js
+++ b/backend/src/generators/incremental_graph/database/sync_merge_validation.js
@@ -1,3 +1,5 @@
+const { IdentifierLookupConflictError } = require('./replica_errors');
+
 /** @typedef {import('./identifier_lookup').IdentifierLookup} IdentifierLookup */
 /** @typedef {import('./root_database').SchemaStorage} SchemaStorage */
 
@@ -70,8 +72,29 @@ async function assertValidFinalMergeState(targetStorage, finalLookup) {
     }
 }
 
+/**
+ * Validate that every materialized node in storage has a corresponding entry
+ * in the identifier lookup, and vice versa. Call this before building a merge
+ * plan so corrupt snapshots are rejected before the planner can silently
+ * ignore unreferenced materialized nodes.
+ * @param {SchemaStorage} storage
+ * @param {IdentifierLookup} lookup
+ * @param {string} context
+ * @returns {Promise<void>}
+ */
+async function assertLookupCoversMaterializedNodes(storage, lookup, context) {
+    for await (const id of storage.inputs.keys()) {
+        if (!lookup.idToKey.has(String(id))) {
+            throw new IdentifierLookupConflictError(
+                `${context}: materialized node ${String(id)} has no identifiers_keys_map entry`
+            );
+        }
+    }
+}
+
 module.exports = {
     assertValidFinalMergeState,
+    assertLookupCoversMaterializedNodes,
     FinalMergeStateError,
     isFinalMergeStateError,
 };

--- a/backend/src/generators/incremental_graph/database/topo_sort.js
+++ b/backend/src/generators/incremental_graph/database/topo_sort.js
@@ -12,7 +12,6 @@
  * if the graph contains a cycle (which is treated as data corruption).
  */
 
-const { compareNodeIdentifier } = require('./node_identifier');
 const { stringToNodeIdentifier } = require('./types');
 
 /** @typedef {import('./types').NodeIdentifier} NodeIdentifier */
@@ -132,10 +131,11 @@ class MinHeap {
  * Thrown when the node graph contains a cycle, which violates the DAG
  * invariant required by the incremental-graph model.  A cycle indicates data
  * corruption and the merge should abort for the affected host.
+ * @template T
  */
 class TopologicalSortCycleError extends Error {
     /**
-     * @param {NodeIdentifier[]} cycle - A representative subset of nodes involved in the cycle.
+     * @param {T[]} cycle - A representative subset of nodes involved in the cycle.
      */
     constructor(cycle) {
         const sample = cycle.slice(0, CYCLE_MESSAGE_SAMPLE_LIMIT);
@@ -185,9 +185,10 @@ async function collectAllNodes(storage) {
  * `topologicalSort` (reads from SchemaStorage) and `topologicalSortFromMap`
  * (operates directly on an already-built map).
  *
- * @param {Map<NodeIdentifier, NodeIdentifier[]>} inputsMap
+ * @template T
+ * @param {Map<T, T[]>} inputsMap
  *   A map from each node to the list of its input nodes.
- * @returns {NodeIdentifier[]}
+ * @returns {T[]}
  * @throws {TopologicalSortCycleError} If the graph contains a cycle.
  */
 function topologicalSortFromMap(inputsMap) {
@@ -198,9 +199,9 @@ function topologicalSortFromMap(inputsMap) {
     }
 
     // Build: inDegree map and adjacency list (node → list of dependents).
-    /** @type {Map<NodeIdentifier, number>} */
+    /** @type {Map<T, number>} */
     const inDegree = new Map();
-    /** @type {Map<NodeIdentifier, NodeIdentifier[]>} */
+    /** @type {Map<T, T[]>} */
     const dependents = new Map();
 
     for (const node of allNodes) {
@@ -227,16 +228,16 @@ function topologicalSortFromMap(inputsMap) {
     }
 
     // Initialize priority queue with all nodes having in-degree 0.
-    const heap = new MinHeap(compareNodeIdentifier);
+    const heap = new MinHeap((a, b) => String(a).localeCompare(String(b)));
     for (const [node, degree] of inDegree) {
         if (degree === 0) {
             heap.push(node);
         }
     }
 
-    /** @type {NodeIdentifier[]} */
+    /** @type {T[]} */
     const sorted = [];
-    /** @type {Map<NodeIdentifier, number>} */
+    /** @type {Map<T, number>} */
     const remaining = new Map(inDegree);
 
     while (heap.size > 0) {

--- a/backend/src/generators/incremental_graph/database/topo_sort.js
+++ b/backend/src/generators/incremental_graph/database/topo_sort.js
@@ -228,7 +228,13 @@ function topologicalSortFromMap(inputsMap) {
     }
 
     // Initialize priority queue with all nodes having in-degree 0.
-    const heap = new MinHeap((a, b) => String(a).localeCompare(String(b)));
+    const heap = new MinHeap((a, b) => {
+        const aString = String(a);
+        const bString = String(b);
+        if (aString < bString) return -1;
+        if (aString > bString) return 1;
+        return 0;
+    });
     for (const [node, degree] of inDegree) {
         if (degree === 0) {
             heap.push(node);

--- a/backend/tests/sync_merge.test.js
+++ b/backend/tests/sync_merge.test.js
@@ -20,11 +20,10 @@ const {
     isMissingIdentifierLookupError,
     makeIdentifierLookup,
     nodeIdentifierFromString,
-    nodeIdentifierToString,
-    nodeKeyStringToString,
     serializeIdentifierLookup,
     stringToNodeKeyString,
 } = require('../src/generators/incremental_graph/database');
+const { makeIncrementalGraph } = require('../src/generators/incremental_graph');
 const {
     IdentifierLookupConflictError,
     isIdentifierLookupConflictError,
@@ -862,7 +861,7 @@ describe('mergeHostIntoReplica', () => {
         }
     });
 
-    test('invalidates a host-only node when equal-timestamp input is relowered to target identifier', async () => {
+    test('pull recomputes a directly relowered node even when dependency counters collide', async () => {
         const capabilities = getTestCapabilities();
         let db;
         try {
@@ -872,38 +871,131 @@ describe('mergeHostIntoReplica', () => {
             await db.setGlobalVersion(db.version);
             await db.setHostnameGlobal(hostname, 'version', db.version);
 
-            const targetCId = nodeIdentifierFromString('44-abcdefghi');
-            const hostCId = nodeIdentifierFromString('45-abcdefghi');
-            const hostAId = nodeIdentifierFromString('46-abcdefghi');
-            const keyC = stringToNodeKeyString('{"head":"C-equal-relowered","args":[]}');
-            const keyA = stringToNodeKeyString('{"head":"A-host-only-relowered","args":[]}');
-            const hostAValue = {
-                value: { id: 'a-host', type: 'test', description: 'computed from host C' },
-                isDirty: false,
-            };
+            const targetCId = nodeIdentifierFromString('47-abcdefghi');
+            const hostCId = nodeIdentifierFromString('48-abcdefghi');
+            const hostAId = nodeIdentifierFromString('49-abcdefghi');
+            const keyC = stringToNodeKeyString('{"head":"c_counter_collision","args":[]}');
+            const keyA = stringToNodeKeyString('{"head":"a_counter_collision","args":[]}');
+            const targetCValue = { source: 'target C' };
+            const staleAValue = { source: 'A computed from host C' };
 
             const L = db.schemaStorageForReplica('x');
-            await writeNode(L, targetCId, TS1, [], undefined);
-            await L.counters.put(targetCId, 4);
+            await writeNode(L, targetCId, TS1, [], targetCValue);
+            await L.counters.put(targetCId, 1);
             await writeIdentifierLookup(L, [[targetCId, keyC]]);
 
             const H = db.hostnameSchemaStorage(hostname);
-            await writeNode(H, hostCId, TS1, [], undefined);
-            await H.counters.put(hostCId, 9);
-            await writeNode(H, hostAId, TS1, [hostCId], hostAValue);
-            await H.inputs.put(hostAId, { inputs: [hostCId], inputCounters: [9] });
+            await writeNode(H, hostCId, TS1, [], { source: 'host C' });
+            await H.counters.put(hostCId, 1);
+            await writeNode(H, hostAId, TS1, [hostCId], staleAValue);
+            await H.inputs.put(hostAId, { inputs: [hostCId], inputCounters: [1] });
+            await H.counters.put(hostAId, 1);
             await writeIdentifierLookup(H, [[hostCId, keyC], [hostAId, keyA]]);
 
             expect(await mergeHostIntoReplica(logger, db, hostname)).toBe(true);
-            const T = db.getSchemaStorage();
-            expect(await T.inputs.get(hostAId)).toEqual({
-                inputs: [targetCId],
-                inputCounters: [9],
+            expect(await db.getSchemaStorage().values.get(hostAId)).toBeUndefined();
+            const computeA = jest.fn(async ([input]) => ({ source: `recomputed from ${input.source}` }));
+            const graph = makeIncrementalGraph(capabilities, db, [
+                {
+                    output: 'c_counter_collision',
+                    inputs: [],
+                    computor: async () => targetCValue,
+                    isDeterministic: true,
+                    hasSideEffects: false,
+                },
+                {
+                    output: 'a_counter_collision',
+                    inputs: ['c_counter_collision'],
+                    computor: computeA,
+                    isDeterministic: true,
+                    hasSideEffects: false,
+                },
+            ]);
+
+            await expect(graph.pull('a_counter_collision')).resolves.toEqual({
+                source: 'recomputed from target C',
             });
-            expect(await T.values.get(hostAId)).toEqual(hostAValue);
+            expect(computeA).toHaveBeenCalledTimes(1);
+        } finally {
+            if (db) await db.close();
+        }
+    });
+
+    test('relowered invalidation propagates transitively and pull recomputes dependents', async () => {
+        const capabilities = getTestCapabilities();
+        let db;
+        try {
+            db = await getRootDatabase(capabilities);
+            const logger = makeLogger();
+            const hostname = 'peer';
+            await db.setGlobalVersion(db.version);
+            await db.setHostnameGlobal(hostname, 'version', db.version);
+
+            const targetCId = nodeIdentifierFromString('53-abcdefghi');
+            const hostCId = nodeIdentifierFromString('54-abcdefghi');
+            const hostAId = nodeIdentifierFromString('55-abcdefghi');
+            const hostDId = nodeIdentifierFromString('56-abcdefghi');
+            const keyC = stringToNodeKeyString('{"head":"c_transitive_relower","args":[]}');
+            const keyA = stringToNodeKeyString('{"head":"a_transitive_relower","args":[]}');
+            const keyD = stringToNodeKeyString('{"head":"d_transitive_relower","args":[]}');
+            const targetCValue = { source: 'target C' };
+
+            const L = db.schemaStorageForReplica('x');
+            await writeNode(L, targetCId, TS1, [], targetCValue);
+            await L.counters.put(targetCId, 1);
+            await writeIdentifierLookup(L, [[targetCId, keyC]]);
+
+            const H = db.hostnameSchemaStorage(hostname);
+            await writeNode(H, hostCId, TS1, [], { source: 'host C' });
+            await H.counters.put(hostCId, 1);
+            await writeNode(H, hostAId, TS1, [hostCId], { source: 'stale A' });
+            await H.inputs.put(hostAId, { inputs: [hostCId], inputCounters: [1] });
+            await H.counters.put(hostAId, 1);
+            await writeNode(H, hostDId, TS1, [hostAId], { source: 'stale D' });
+            await H.inputs.put(hostDId, { inputs: [hostAId], inputCounters: [1] });
+            await H.counters.put(hostDId, 1);
+            await writeIdentifierLookup(H, [
+                [hostCId, keyC],
+                [hostAId, keyA],
+                [hostDId, keyD],
+            ]);
+
+            expect(await mergeHostIntoReplica(logger, db, hostname)).toBe(true);
+            const T = db.getSchemaStorage();
             expect(await T.freshness.get(hostAId)).toBe('potentially-outdated');
-            expect(await T.revdeps.get(targetCId)).toEqual([hostAId]);
-            expect(await T.inputs.get(hostCId)).toBeUndefined();
+            expect(await T.freshness.get(hostDId)).toBe('potentially-outdated');
+
+            const computeA = jest.fn(async ([input]) => ({ source: `A from ${input.source}` }));
+            const computeD = jest.fn(async ([input]) => ({ source: `D from ${input.source}` }));
+            const graph = makeIncrementalGraph(capabilities, db, [
+                {
+                    output: 'c_transitive_relower',
+                    inputs: [],
+                    computor: async () => targetCValue,
+                    isDeterministic: true,
+                    hasSideEffects: false,
+                },
+                {
+                    output: 'a_transitive_relower',
+                    inputs: ['c_transitive_relower'],
+                    computor: computeA,
+                    isDeterministic: true,
+                    hasSideEffects: false,
+                },
+                {
+                    output: 'd_transitive_relower',
+                    inputs: ['a_transitive_relower'],
+                    computor: computeD,
+                    isDeterministic: true,
+                    hasSideEffects: false,
+                },
+            ]);
+
+            await expect(graph.pull('d_transitive_relower')).resolves.toEqual({
+                source: 'D from A from target C',
+            });
+            expect(computeA).toHaveBeenCalledTimes(1);
+            expect(computeD).toHaveBeenCalledTimes(1);
         } finally {
             if (db) await db.close();
         }
@@ -952,590 +1044,11 @@ describe('mergeHostIntoReplica', () => {
                 inputs: [hostCId],
                 inputCounters: [],
             });
-            expect(await T.values.get(targetDId)).toEqual(targetDValue);
+            expect(await T.values.get(targetDId)).toBeUndefined();
             expect(await T.counters.get(targetDId)).toBe(2);
             expect(await T.freshness.get(targetDId)).toBe('potentially-outdated');
             expect(await T.revdeps.get(hostCId)).toEqual([targetDId]);
             expect(await T.inputs.get(targetCId)).toBeUndefined();
-        } finally {
-            if (db) await db.close();
-        }
-    });
-
-    test('same semantic key with different identifiers and equal timestamps: merge succeeds, single identity survives', async () => {
-        const capabilities = getTestCapabilities();
-        let db;
-        try {
-            db = await getRootDatabase(capabilities);
-            const logger = makeLogger();
-            const hostname = 'peer';
-            const appVersionStr = db.version;
-            await db.setGlobalVersion(appVersionStr);
-            await db.setHostnameGlobal(hostname, 'version', appVersionStr);
-
-            const SAME_KEY = stringToNodeKeyString('{"head":"event","args":["id123"]}');
-            const T_ID = nodeIdentifierFromString('1-abcdefghi');
-            const H_ID = nodeIdentifierFromString('10-abcdefghi');
-            const tValue = { value: { id: 'local', type: 'test', description: 'local value' }, isDirty: false };
-            const hValue = { value: { id: 'remote', type: 'test', description: 'remote value' }, isDirty: false };
-
-            const L = db.schemaStorageForReplica('x');
-            await writeNode(L, T_ID, TS1, [], tValue);
-            await writeIdentifierLookup(L, [[T_ID, SAME_KEY]]);
-
-            const H = db.hostnameSchemaStorage(hostname);
-            await writeNode(H, H_ID, TS1, [], hValue);
-            await writeIdentifierLookup(H, [[H_ID, SAME_KEY]]);
-
-            // Merge must NOT throw
-            db = await mergeAndReopenIfSwitched(capabilities, logger, db, hostname);
-
-            // Active replica stays 'x' (equal timestamps → keep → no data changes, but identifier reconciliation still counts)
-            const newActive = db.currentReplicaName();
-            const T = db.schemaStorageForReplica(newActive);
-
-            // Final lookup must be a strict bijection: SAME_KEY -> T_ID only
-            const serialized = await T.global.get(IDENTIFIERS_KEY);
-            const finalLookup = makeIdentifierLookup(serialized ? serializeIdentifierLookup(makeIdentifierLookup(serialized)) : []);
-            expect(finalLookup.keyToId.get(nodeKeyStringToString(SAME_KEY))).toBe(T_ID);
-            expect(finalLookup.keyToId.size).toBe(1);
-            expect(finalLookup.idToKey.size).toBe(1);
-
-            // Target identifier data survives
-            const merged = await T.values.get(T_ID);
-            expect(merged).toEqual(tValue);
-
-            // Stale host identifier must NOT be in T storage (host data was in H, not L/T)
-            const hValInT = await T.values.get(H_ID);
-            expect(hValInT).toBeUndefined();
-            const hFreshInT = await T.freshness.get(H_ID);
-            expect(hFreshInT).toBeUndefined();
-            const hInputsInT = await T.inputs.get(H_ID);
-            expect(hInputsInT).toBeUndefined();
-            const hCounterInT = await T.counters.get(H_ID);
-            expect(hCounterInT).toBeUndefined();
-            const hTsInT = await T.timestamps.get(H_ID);
-            expect(hTsInT).toBeUndefined();
-        } finally {
-            if (db) await db.close();
-        }
-    });
-
-    test('same semantic key with different identifiers and target-newer: keep, target id survives', async () => {
-        const capabilities = getTestCapabilities();
-        let db;
-        try {
-            db = await getRootDatabase(capabilities);
-            const logger = makeLogger();
-            const hostname = 'peer';
-            const appVersionStr = db.version;
-            await db.setGlobalVersion(appVersionStr);
-            await db.setHostnameGlobal(hostname, 'version', appVersionStr);
-
-            const SAME_KEY = stringToNodeKeyString('{"head":"event","args":["id456"]}');
-            const T_ID = nodeIdentifierFromString('2-abcdefghi');
-            const H_ID = nodeIdentifierFromString('20-abcdefghi');
-            const tValue = { value: { id: 'local', type: 'test', description: 'local newer' }, isDirty: false };
-
-            const L = db.schemaStorageForReplica('x');
-            await writeNode(L, T_ID, TS3, [], tValue);
-            await writeIdentifierLookup(L, [[T_ID, SAME_KEY]]);
-
-            const H = db.hostnameSchemaStorage(hostname);
-            await writeNode(H, H_ID, TS1, [], undefined);
-            await writeIdentifierLookup(H, [[H_ID, SAME_KEY]]);
-
-            db = await mergeAndReopenIfSwitched(capabilities, logger, db, hostname);
-
-            const T = db.schemaStorageForReplica(db.currentReplicaName());
-
-            // Final lookup: SAME_KEY -> T_ID
-            const raw = await T.global.get(IDENTIFIERS_KEY);
-            const finalLookup = raw ? makeIdentifierLookup(raw) : null;
-            const keyStr = nodeKeyStringToString(SAME_KEY);
-            expect(finalLookup ? finalLookup.keyToId.get(keyStr) : undefined).toBe(T_ID);
-            expect(finalLookup ? finalLookup.keyToId.size : 0).toBe(1);
-
-            // Host identifier NOT in final lookup
-            expect(finalLookup ? finalLookup.idToKey.has(nodeIdentifierToString(H_ID)) : false).toBe(false);
-
-            // Target identifier data survives
-            const val = await T.values.get(T_ID);
-            expect(val).toEqual(tValue);
-        } finally {
-            if (db) await db.close();
-        }
-    });
-
-    test('same semantic key with different identifiers and host-newer: take, host id survives, target id removed', async () => {
-        const capabilities = getTestCapabilities();
-        let db;
-        try {
-            db = await getRootDatabase(capabilities);
-            const logger = makeLogger();
-            const hostname = 'peer';
-            const appVersionStr = db.version;
-            await db.setGlobalVersion(appVersionStr);
-            await db.setHostnameGlobal(hostname, 'version', appVersionStr);
-
-            const SAME_KEY = stringToNodeKeyString('{"head":"event","args":["id789"]}');
-            const T_ID = nodeIdentifierFromString('3-abcdefghi');
-            const H_ID = nodeIdentifierFromString('30-abcdefghi');
-            const tValue = { value: { id: 'local', type: 'test', description: 'local older' }, isDirty: false };
-            const hValue = { value: { id: 'remote', type: 'test', description: 'remote newer' }, isDirty: false };
-
-            const L = db.schemaStorageForReplica('x');
-            await writeNode(L, T_ID, TS1, [], tValue);
-            await writeIdentifierLookup(L, [[T_ID, SAME_KEY]]);
-
-            const H = db.hostnameSchemaStorage(hostname);
-            await writeNode(H, H_ID, TS3, [], hValue);
-            await writeIdentifierLookup(H, [[H_ID, SAME_KEY]]);
-
-            db = await mergeAndReopenIfSwitched(capabilities, logger, db, hostname);
-
-            const newActive = db.currentReplicaName();
-            expect(newActive).toBe('y');
-            const T = db.schemaStorageForReplica(newActive);
-
-            // Final lookup: SAME_KEY -> H_ID (host identifier survives)
-            const raw = await T.global.get(IDENTIFIERS_KEY);
-            const finalLookup = raw ? makeIdentifierLookup(raw) : null;
-            const keyStr = nodeKeyStringToString(SAME_KEY);
-            expect(finalLookup ? finalLookup.keyToId.get(keyStr) : undefined).toBe(H_ID);
-            expect(finalLookup ? finalLookup.keyToId.size : 0).toBe(1);
-            expect(finalLookup ? finalLookup.idToKey.size : 0).toBe(1);
-
-            // Host identifier data is in T (copied from H)
-            const valAtH = await T.values.get(H_ID);
-            expect(valAtH).toEqual(hValue);
-
-            // Losing target identifier must be removed from T storage
-            const valAtT = await T.values.get(T_ID);
-            expect(valAtT).toBeUndefined();
-            const freshAtT = await T.freshness.get(T_ID);
-            expect(freshAtT).toBeUndefined();
-            const inputsAtT = await T.inputs.get(T_ID);
-            expect(inputsAtT).toBeUndefined();
-            const counterAtT = await T.counters.get(T_ID);
-            expect(counterAtT).toBeUndefined();
-            const tsAtT = await T.timestamps.get(T_ID);
-            expect(tsAtT).toBeUndefined();
-        } finally {
-            if (db) await db.close();
-        }
-    });
-
-    test('H-only node depending on semantic node whose target id survives: inputs lowered, potentially-outdated', async () => {
-        // Graph: A depends on B and C.
-        // Target has B (tId) and C (C_t).
-        // Host has B (hId, same key but different id), C (C_h, same key but different id),
-        //   and A (A_h) depending on [B, C_h].
-        // Merge keeps target's C_t (equal timestamps → keep).
-        // A is taken (host-only), but its inputs are lowered so it depends on [B_final, C_t].
-        // A is marked potentially-outdated because it was computed with C_h, not C_t.
-        const capabilities = getTestCapabilities();
-        let db;
-        try {
-            db = await getRootDatabase(capabilities);
-            const logger = makeLogger();
-            const hostname = 'peer';
-            const appVersionStr = db.version;
-            await db.setGlobalVersion(appVersionStr);
-            await db.setHostnameGlobal(hostname, 'version', appVersionStr);
-
-            const KEY_A = stringToNodeKeyString('{"head":"A","args":[]}');
-            const KEY_B = stringToNodeKeyString('{"head":"B","args":[]}');
-            const KEY_C = stringToNodeKeyString('{"head":"C","args":[]}');
-
-            const B_T_ID = nodeIdentifierFromString('1-abcdefghi');
-            const C_T_ID = nodeIdentifierFromString('2-abcdefghi');
-            const B_H_ID = nodeIdentifierFromString('11-abcdefghi');
-            const C_H_ID = nodeIdentifierFromString('22-abcdefghi');
-            const A_H_ID = nodeIdentifierFromString('33-abcdefghi');
-
-            const tValB = { value: { id: 'b', type: 'test' }, isDirty: false };
-            const tValC = { value: { id: 'c', type: 'test' }, isDirty: false };
-            const hValA = { value: { id: 'a', type: 'test' }, isDirty: false };
-
-            // Target (L) has B at B_T_ID (same ts), C at C_T_ID (newer → force-keep)
-            const L = db.schemaStorageForReplica('x');
-            await writeNode(L, B_T_ID, TS1, [], tValB);
-            await writeNode(L, C_T_ID, TS3, [], tValC);
-            await writeIdentifierLookup(L, [
-                [B_T_ID, KEY_B],
-                [C_T_ID, KEY_C],
-            ]);
-
-            // Host (H) has B at B_H_ID, C at C_H_ID, A at A_H_ID depending on [B_H_ID, C_H_ID]
-            const H = db.hostnameSchemaStorage(hostname);
-            await writeNode(H, B_H_ID, TS1, [], undefined);
-            await writeNode(H, C_H_ID, TS1, [], undefined);
-            await writeNode(H, A_H_ID, TS2, [B_H_ID, C_H_ID], hValA);
-            await writeIdentifierLookup(H, [
-                [B_H_ID, KEY_B],
-                [C_H_ID, KEY_C],
-                [A_H_ID, KEY_A],
-            ]);
-
-            db = await mergeAndReopenIfSwitched(capabilities, logger, db, hostname);
-
-            const T = db.schemaStorageForReplica(db.currentReplicaName());
-
-            // A must exist and have been taken
-            const aValue = await T.values.get(A_H_ID);
-            expect(aValue).toEqual(hValA);
-
-            // A's freshness: potentially-outdated (computed with C_h, but C_t survived)
-            const aFreshness = await T.freshness.get(A_H_ID);
-            expect(aFreshness).toBe('potentially-outdated');
-
-            // A's inputs must be lowered: should reference final identifiers for B and C
-            // B keep → B_T_ID survives, C keep → C_T_ID survives
-            const aInputs = await T.inputs.get(A_H_ID);
-            expect(aInputs).not.toBeUndefined();
-            const loweredInputStrings = aInputs ? aInputs.inputs.map(id => String(id)) : [];
-            expect(loweredInputStrings).toContain(String(B_T_ID));
-            expect(loweredInputStrings).toContain(String(C_T_ID));
-            // Must NOT contain host identifiers
-            expect(loweredInputStrings).not.toContain(String(B_H_ID));
-            expect(loweredInputStrings).not.toContain(String(C_H_ID));
-
-            // Revdeps should point from B_T_ID and C_T_ID to A_H_ID
-            const bRevdeps = await T.revdeps.get(B_T_ID);
-            expect(bRevdeps).not.toBeUndefined();
-            expect(bRevdeps ? bRevdeps.map(d => String(d)) : []).toContain(String(A_H_ID));
-            const cRevdeps = await T.revdeps.get(C_T_ID);
-            expect(cRevdeps).not.toBeUndefined();
-            expect(cRevdeps ? cRevdeps.map(d => String(d)) : []).toContain(String(A_H_ID));
-
-            // Final lookup must be a strict bijection
-            const raw = await T.global.get(IDENTIFIERS_KEY);
-            const finalLookup = raw ? makeIdentifierLookup(raw) : null;
-            expect(finalLookup ? finalLookup.keyToId.size : 0).toBe(finalLookup ? finalLookup.idToKey.size : 0);
-            // B → B_T_ID, C → C_T_ID, A → A_H_ID
-            expect(finalLookup ? finalLookup.keyToId.get(nodeKeyStringToString(KEY_B)) : undefined).toBe(B_T_ID);
-            expect(finalLookup ? finalLookup.keyToId.get(nodeKeyStringToString(KEY_C)) : undefined).toBe(C_T_ID);
-            expect(finalLookup ? finalLookup.keyToId.get(nodeKeyStringToString(KEY_A)) : undefined).toBe(A_H_ID);
-
-            // B_T_ID and C_T_ID data should still be in T
-            expect(await T.values.get(B_T_ID)).toBeDefined();
-            expect(await T.values.get(C_T_ID)).toBeDefined();
-        } finally {
-            if (db) await db.close();
-        }
-    });
-
-    test('mixed ancestry invalidation works with semantic-key-based planner', async () => {
-        // Same scenario as the existing invalidation test, but using different identifiers
-        // for the same key on the two sides.
-        const capabilities = getTestCapabilities();
-        let db;
-        try {
-            db = await getRootDatabase(capabilities);
-            const logger = makeLogger();
-            const hostname = 'peer';
-            const appVersionStr = db.version;
-            await db.setGlobalVersion(appVersionStr);
-            await db.setHostnameGlobal(hostname, 'version', appVersionStr);
-
-            const KEY_A = stringToNodeKeyString('{"head":"A","args":[]}');
-            const KEY_B = stringToNodeKeyString('{"head":"B","args":[]}');
-
-            const A_T_ID = nodeIdentifierFromString('1-abcdefghi');
-            const B_T_ID = nodeIdentifierFromString('2-abcdefghi');
-            const A_H_ID = nodeIdentifierFromString('11-abcdefghi');
-            const B_H_ID = nodeIdentifierFromString('22-abcdefghi');
-
-            const localValueB = { value: { id: 'b-local', type: 'test', description: 'local B' }, isDirty: false };
-            const remoteValueB = { value: { id: 'b-remote', type: 'test', description: 'remote B' }, isDirty: false };
-
-            const L = db.schemaStorageForReplica('x');
-            // A is force-kept (T-newer); B is initially 'take' (H-newer) and depends on A
-            await writeNode(L, A_T_ID, TS3, [], undefined);
-            await writeNode(L, B_T_ID, TS1, [], localValueB);
-            await L.counters.put(B_T_ID, 1);
-            await writeIdentifierLookup(L, [
-                [A_T_ID, KEY_A],
-                [B_T_ID, KEY_B],
-            ]);
-
-            const H = db.hostnameSchemaStorage(hostname);
-            await writeNode(H, A_H_ID, TS1, [], undefined);
-            await writeNode(H, B_H_ID, TS2, [A_H_ID], remoteValueB);
-            await H.counters.put(B_H_ID, 2);
-            await writeIdentifierLookup(H, [
-                [A_H_ID, KEY_A],
-                [B_H_ID, KEY_B],
-            ]);
-
-            db = await mergeAndReopenIfSwitched(capabilities, logger, db, hostname);
-
-            const T = db.schemaStorageForReplica(db.currentReplicaName());
-
-            // A is keep → A_T_ID survives
-            // B is initially take → B_H_ID should carry the data; but invalidated
-            // B should be invalidated: both keepTainted (via A) and takeTainted (B itself)
-            const bFreshness = await T.freshness.get(B_H_ID);
-            expect(bFreshness).toBe('potentially-outdated');
-
-            // B's stored inputs should point to final identifiers (A_T_ID, not A_H_ID)
-            const bInputs = await T.inputs.get(B_H_ID);
-            expect(bInputs).not.toBeUndefined();
-            expect(bInputs ? bInputs.inputs.map(id => String(id)) : []).toEqual([String(A_T_ID)]);
-
-            // B's counter and value from H should be preserved
-            const bCounter = await T.counters.get(B_H_ID);
-            expect(bCounter).toBe(2);
-            const bValue = await T.values.get(B_H_ID);
-            expect(bValue).toEqual(remoteValueB);
-
-            // B's modifiedAt advanced to H's TS2
-            const bTimestamps = await T.timestamps.get(B_H_ID);
-            expect(bTimestamps?.modifiedAt).toBe(TS2);
-        } finally {
-            if (db) await db.close();
-        }
-    });
-
-    test('same identifier mapped to different semantic keys remains a hard error', async () => {
-        const capabilities = getTestCapabilities();
-        let db;
-        try {
-            db = await getRootDatabase(capabilities);
-            const logger = makeLogger();
-            const hostname = 'peer';
-            const appVersionStr = db.version;
-            await db.setGlobalVersion(appVersionStr);
-            await db.setHostnameGlobal(hostname, 'version', appVersionStr);
-
-            const idA = nodeIdentifierFromString('1-abcdefghi');
-            const keyA = stringToNodeKeyString('{"head":"event","args":["a"]}');
-            const keyB = stringToNodeKeyString('{"head":"event","args":["b"]}');
-
-            const L = db.schemaStorageForReplica('x');
-            await writeIdentifierLookup(L, [[idA, keyA]]);
-
-            const H = db.hostnameSchemaStorage(hostname);
-            await writeIdentifierLookup(H, [[idA, keyB]]);
-
-            let error;
-            try {
-                await mergeHostIntoReplica(logger, db, hostname);
-            } catch (caught) {
-                error = caught;
-            }
-
-            expect(isIdentifierLookupConflictError(error)).toBe(true);
-            expect(String(error?.message)).toContain('Conflicting node key assignment for identifier');
-            expect(db.currentReplicaName()).toBe('x');
-        } finally {
-            if (db) await db.close();
-        }
-    });
-
-    test('identifier-only reconciliation causes replica cutover', async () => {
-        const capabilities = getTestCapabilities();
-        let db;
-        try {
-            db = await getRootDatabase(capabilities);
-            const logger = makeLogger();
-            const hostname = 'peer';
-            const appVersionStr = db.version;
-            await db.setGlobalVersion(appVersionStr);
-            await db.setHostnameGlobal(hostname, 'version', appVersionStr);
-
-            const SAME_KEY = stringToNodeKeyString('{"head":"event","args":["cutover-test"]}');
-            const T_ID = nodeIdentifierFromString('1-abcdefghi');
-            const H_ID = nodeIdentifierFromString('10-abcdefghi');
-
-            const L = db.schemaStorageForReplica('x');
-            await writeNode(L, T_ID, TS1, [], { value: { id: 'val' }, isDirty: false });
-            await writeIdentifierLookup(L, [[T_ID, SAME_KEY]]);
-
-            const H = db.hostnameSchemaStorage(hostname);
-            await writeNode(H, H_ID, TS1, [], { value: { id: 'val' }, isDirty: false });
-            await writeIdentifierLookup(H, [[H_ID, SAME_KEY]]);
-
-            // Precondition: active replica is 'x'
-            expect(db.currentReplicaName()).toBe('x');
-
-            const switched = await mergeHostIntoReplica(logger, db, hostname);
-
-            // Even though no graph data changed (equal timestamps → keep),
-            // identifier reconciliation means the merge IS a change:
-            // the final lookup must be committed and the replica must be switched.
-            expect(switched).toBe(true);
-        } finally {
-            if (db) await db.close();
-        }
-    });
-
-    test('throws MissingInputIdentifierError when node depends on identifier not in any lookup', async () => {
-        // Corrupt graph: host has a node whose inputs reference an identifier
-        // that is missing from both lookups.  The planner must throw instead
-        // of silently dropping the dependency.
-        const capabilities = getTestCapabilities();
-        let db;
-        try {
-            db = await getRootDatabase(capabilities);
-            const logger = makeLogger();
-            const hostname = 'peer';
-            const appVersionStr = db.version;
-            await db.setGlobalVersion(appVersionStr);
-            await db.setHostnameGlobal(hostname, 'version', appVersionStr);
-
-            const keyA = stringToNodeKeyString('{"head":"A","args":[]}');
-            const A_T_ID = nodeIdentifierFromString('1-abcdefghi');
-            const B_H_ID = nodeIdentifierFromString('2-abcdefghi');
-            const MYSTERY_ID = nodeIdentifierFromString('99-abcdefghi');
-            const keyB = stringToNodeKeyString('{"head":"B","args":[]}');
-
-            const L = db.schemaStorageForReplica('x');
-            await writeNode(L, A_T_ID, TS1, [], undefined);
-            await writeIdentifierLookup(L, [[A_T_ID, keyA]]);
-
-            const H = db.hostnameSchemaStorage(hostname);
-            // B depends on MYSTERY_ID, which is NOT in either lookup.
-            await writeNode(H, B_H_ID, TS2, [MYSTERY_ID], undefined);
-            await writeIdentifierLookup(H, [[B_H_ID, keyB]]);
-
-            let error;
-            try {
-                await mergeHostIntoReplica(logger, db, hostname);
-            } catch (caught) {
-                error = caught;
-            }
-
-            expect(isIdentifierLookupConflictError(error)).toBe(true);
-            expect(String(error?.message)).toContain(String(MYSTERY_ID));
-            expect(db.currentReplicaName()).toBe('x');
-        } finally {
-            if (db) await db.close();
-        }
-    });
-
-    test('target-only nodes remain keep despite taint from host-newer ancestor', async () => {
-        // Scenario:
-        //   Target: A_t (key K) TS1, D_t (key K2) TS1, inputs=[A_t]
-        //   Host:   A_h (key K) TS3 (newer), no D
-        // A is shared, host-newer → take (A_h wins). D is target-only → keep.
-        // Without the fix, D inherits takeTainted from A and becomes 'take',
-        // which copies from non-existent host storage, losing D's data.
-        // After the fix, D stays 'keep' with its data preserved and inputs
-        // lowered to the final identifier for A (A_h).
-        const capabilities = getTestCapabilities();
-        let db;
-        try {
-            db = await getRootDatabase(capabilities);
-            const logger = makeLogger();
-            const hostname = 'peer';
-            const appVersionStr = db.version;
-            await db.setGlobalVersion(appVersionStr);
-            await db.setHostnameGlobal(hostname, 'version', appVersionStr);
-
-            const KEY_A = stringToNodeKeyString('{"head":"A","args":[]}');
-            const KEY_D = stringToNodeKeyString('{"head":"D","args":[]}');
-            const A_T_ID = nodeIdentifierFromString('1-abcdefghi');
-            const A_H_ID = nodeIdentifierFromString('11-abcdefghi');
-            const D_T_ID = nodeIdentifierFromString('2-abcdefghi');
-            const targetValueD = { value: { id: 'd-target', type: 'test', description: 'target-only D' }, isDirty: false };
-
-            const L = db.schemaStorageForReplica('x');
-            await writeNode(L, A_T_ID, TS1, [], undefined);
-            await writeNode(L, D_T_ID, TS1, [A_T_ID], targetValueD);
-            await writeIdentifierLookup(L, [
-                [A_T_ID, KEY_A],
-                [D_T_ID, KEY_D],
-            ]);
-
-            const H = db.hostnameSchemaStorage(hostname);
-            await writeNode(H, A_H_ID, TS3, [], undefined);
-            await writeIdentifierLookup(H, [[A_H_ID, KEY_A]]);
-
-            db = await mergeAndReopenIfSwitched(capabilities, logger, db, hostname);
-
-            const T = db.schemaStorageForReplica(db.currentReplicaName());
-
-            // D_T_ID must still exist (data preserved)
-            const dValue = await T.values.get(D_T_ID);
-            expect(dValue).toEqual(targetValueD);
-            const dFreshness = await T.freshness.get(D_T_ID);
-            expect(dFreshness).toBeDefined();
-
-            // D's inputs must be lowered: they should reference A_H_ID (final ident for key A)
-            const dInputs = await T.inputs.get(D_T_ID);
-            expect(dInputs).not.toBeUndefined();
-            const loweredDInputs = dInputs ? dInputs.inputs.map(id => String(id)) : [];
-            expect(loweredDInputs).toContain(String(A_H_ID));
-
-            // A_T_ID should be gone (losing target identifier deleted)
-            const aTVal = await T.values.get(A_T_ID);
-            expect(aTVal).toBeUndefined();
-
-            // Final lookup must be a strict bijection: A→A_H_ID, D→D_T_ID
-            const raw = await T.global.get(IDENTIFIERS_KEY);
-            const finalLookup = raw ? makeIdentifierLookup(raw) : null;
-            const keyStrA = nodeKeyStringToString(KEY_A);
-            const keyStrD = nodeKeyStringToString(KEY_D);
-            expect(finalLookup ? finalLookup.keyToId.get(keyStrA) : undefined).toBe(A_H_ID);
-            expect(finalLookup ? finalLookup.keyToId.get(keyStrD) : undefined).toBe(D_T_ID);
-            expect(finalLookup ? finalLookup.keyToId.size : 0).toBe(2);
-        } finally {
-            if (db) await db.close();
-        }
-    });
-
-    test('kept node with changed dependency identifier gets inputs rewritten', async () => {
-        // Scenario:
-        //   Target: A_t (key K) TS1, B_t (key K2) TS1, inputs=[A_t]
-        //   Host:   A_h (key K) TS3 (newer), no B
-        // A is shared, host-newer → take (A_h wins). B is target-only → force-kept.
-        // B's stored inputs=[A_t] must be rewritten to=[A_h] because A_h is the
-        // final identifier for key K. Without the fix, B's inputs still point to
-        // the deleted A_t identifier.
-        const capabilities = getTestCapabilities();
-        let db;
-        try {
-            db = await getRootDatabase(capabilities);
-            const logger = makeLogger();
-            const hostname = 'peer';
-            const appVersionStr = db.version;
-            await db.setGlobalVersion(appVersionStr);
-            await db.setHostnameGlobal(hostname, 'version', appVersionStr);
-
-            const KEY_A = stringToNodeKeyString('{"head":"A","args":[]}');
-            const KEY_B = stringToNodeKeyString('{"head":"B","args":[]}');
-            const A_T_ID = nodeIdentifierFromString('1-abcdefghi');
-            const A_H_ID = nodeIdentifierFromString('11-abcdefghi');
-            const B_T_ID = nodeIdentifierFromString('2-abcdefghi');
-
-            const L = db.schemaStorageForReplica('x');
-            await writeNode(L, A_T_ID, TS1, [], undefined);
-            await writeNode(L, B_T_ID, TS1, [A_T_ID], undefined);
-            await writeIdentifierLookup(L, [
-                [A_T_ID, KEY_A],
-                [B_T_ID, KEY_B],
-            ]);
-
-            const H = db.hostnameSchemaStorage(hostname);
-            await writeNode(H, A_H_ID, TS3, [], undefined);
-            await writeIdentifierLookup(H, [[A_H_ID, KEY_A]]);
-
-            db = await mergeAndReopenIfSwitched(capabilities, logger, db, hostname);
-
-            const T = db.schemaStorageForReplica(db.currentReplicaName());
-
-            // B_T_ID's inputs must be rewritten to reference A_H_ID (not A_T_ID)
-            const bInputs = await T.inputs.get(B_T_ID);
-            expect(bInputs).not.toBeUndefined();
-            const loweredBInputs = bInputs ? bInputs.inputs.map(id => String(id)) : [];
-            expect(loweredBInputs).toContain(String(A_H_ID));
-            expect(loweredBInputs).not.toContain(String(A_T_ID));
-
-            // B must still exist (its identifier unchanged)
-            const bFreshness = await T.freshness.get(B_T_ID);
-            expect(bFreshness).toBeDefined();
         } finally {
             if (db) await db.close();
         }

--- a/backend/tests/sync_merge.test.js
+++ b/backend/tests/sync_merge.test.js
@@ -215,16 +215,15 @@ describe('mergeHostIntoReplica', () => {
         }
     });
 
-    test('throws readable error on conflicting identifier assignments for same semantic key', async () => {
+    test('reconciles different identifiers across multiple semantic nodes', async () => {
         const capabilities = getTestCapabilities();
         let db;
         try {
             db = await getRootDatabase(capabilities);
             const logger = makeLogger();
             const hostname = 'peer';
-            const appVersionStr = db.version;
-            await db.setGlobalVersion(appVersionStr);
-            await db.setHostnameGlobal(hostname, 'version', appVersionStr);
+            await db.setGlobalVersion(db.version);
+            await db.setHostnameGlobal(hostname, 'version', db.version);
 
             const targetParent = nodeIdentifierFromString('6-abcdefghi');
             const targetChild = nodeIdentifierFromString('7-abcdefghi');
@@ -235,33 +234,22 @@ describe('mergeHostIntoReplica', () => {
             const L = db.schemaStorageForReplica('x');
             await writeNode(L, targetParent, TS1, [], undefined);
             await writeNode(L, targetChild, TS1, [targetParent], undefined);
-            await writeIdentifierLookup(L, [
-                [targetParent, parentKey],
-                [targetChild, childKey],
-            ]);
+            await writeIdentifierLookup(L, [[targetParent, parentKey], [targetChild, childKey]]);
 
             const H = db.hostnameSchemaStorage(hostname);
             await writeNode(H, hostParent, TS1, [], undefined);
             await writeNode(H, hostChild, TS2, [hostParent], undefined);
-            await writeIdentifierLookup(H, [
-                [hostParent, parentKey],
+            await writeIdentifierLookup(H, [[hostParent, parentKey], [hostChild, childKey]]);
+
+            expect(await mergeHostIntoReplica(logger, db, hostname)).toBe(true);
+            const T = db.getSchemaStorage();
+            expect(await T.global.get(IDENTIFIERS_KEY)).toEqual([
+                [targetParent, parentKey],
                 [hostChild, childKey],
             ]);
-
-            let error;
-            try {
-                await mergeHostIntoReplica(logger, db, hostname);
-            } catch (caught) {
-                error = caught;
-            }
-
-            expect(isIdentifierLookupConflictError(error)).toBe(true);
-            expect(String(error?.message)).toContain('Conflicting identifier assignment for node key');
-            expect(String(error?.message)).toContain(String(parentKey));
-            expect(String(error?.message)).toContain('Volodyslav will not resolve this automatically');
-            expect(String(error?.message)).toContain('manually fix the identifiers_keys_map records');
-
-            expect(db.currentReplicaName()).toBe('x');
+            expect(await T.inputs.get(hostChild)).toEqual({ inputs: [targetParent], inputCounters: [] });
+            expect(await T.inputs.get(targetChild)).toBeUndefined();
+            expect(await T.inputs.get(hostParent)).toBeUndefined();
         } finally {
             if (db) await db.close();
         }
@@ -374,7 +362,7 @@ describe('mergeHostIntoReplica', () => {
             const newActive = db.currentReplicaName();
             const T = db.schemaStorageForReplica(newActive);
 
-            // The H-only node was taken; buildTakeOps emits delOp for missing timestamps.
+            // The H-only node was taken; copyNodeOps emits delOp for missing timestamps.
             const takenTs = await T.timestamps.get(hOnlyNode);
             expect(takenTs).toBeUndefined();
         } finally {
@@ -728,6 +716,148 @@ describe('mergeHostIntoReplica', () => {
         const err = new IdentifierLookupConflictError('test conflict');
         expect(isIdentifierLookupConflictError(err)).toBe(true);
         expect(isIdentifierLookupConflictError(new Error('other'))).toBe(false);
+    });
+
+    test('reconciles equal-timestamp same-key different identifiers into one strict storage identity', async () => {
+        const capabilities = getTestCapabilities();
+        let db;
+        try {
+            db = await getRootDatabase(capabilities);
+            const logger = makeLogger();
+            const hostname = 'peer';
+            await db.setGlobalVersion(db.version);
+            await db.setHostnameGlobal(hostname, 'version', db.version);
+
+            const targetId = nodeIdentifierFromString('10-abcdefghi');
+            const hostId = nodeIdentifierFromString('11-abcdefghi');
+            const dependentId = nodeIdentifierFromString('12-abcdefghi');
+            const sharedKey = stringToNodeKeyString('{"head":"shared","args":[]}');
+            const dependentKey = stringToNodeKeyString('{"head":"dependent","args":[]}');
+            const localValue = { value: { id: 'local', type: 'test', description: 'local' }, isDirty: false };
+
+            const L = db.schemaStorageForReplica('x');
+            await writeNode(L, targetId, TS2, [], localValue);
+            await L.counters.put(targetId, 7);
+            await writeNode(L, dependentId, TS2, [targetId], undefined);
+            await writeIdentifierLookup(L, [[targetId, sharedKey], [dependentId, dependentKey]]);
+
+            const H = db.hostnameSchemaStorage(hostname);
+            await writeNode(H, hostId, TS2, [], { value: { id: 'host', type: 'test', description: 'host' }, isDirty: false });
+            await H.counters.put(hostId, 9);
+            await writeNode(H, dependentId, TS2, [hostId], undefined);
+            await writeIdentifierLookup(H, [[hostId, sharedKey], [dependentId, dependentKey]]);
+
+            expect(await mergeHostIntoReplica(logger, db, hostname)).toBe(true);
+            const T = db.getSchemaStorage();
+            expect(await T.values.get(targetId)).toEqual(localValue);
+            for (const sublevel of [T.values, T.freshness, T.inputs, T.counters, T.timestamps]) {
+                expect(await sublevel.get(hostId)).toBeUndefined();
+            }
+            expect(await T.inputs.get(dependentId)).toEqual({ inputs: [targetId], inputCounters: [] });
+            const serialized = await T.global.get(IDENTIFIERS_KEY);
+            expect(serialized).toEqual([[targetId, sharedKey], [dependentId, dependentKey]]);
+        } finally {
+            if (db) await db.close();
+        }
+    });
+
+    test('keeps the target identifier for a target-newer semantic node', async () => {
+        const capabilities = getTestCapabilities();
+        let db;
+        try {
+            db = await getRootDatabase(capabilities);
+            const logger = makeLogger();
+            const hostname = 'peer';
+            await db.setGlobalVersion(db.version);
+            await db.setHostnameGlobal(hostname, 'version', db.version);
+            const targetId = nodeIdentifierFromString('20-abcdefghi');
+            const hostId = nodeIdentifierFromString('21-abcdefghi');
+            const nodeKey = stringToNodeKeyString('{"head":"newer-local","args":[]}');
+            const L = db.schemaStorageForReplica('x');
+            await writeNode(L, targetId, TS3, [], undefined);
+            await writeIdentifierLookup(L, [[targetId, nodeKey]]);
+            const H = db.hostnameSchemaStorage(hostname);
+            await writeNode(H, hostId, TS1, [], undefined);
+            await writeIdentifierLookup(H, [[hostId, nodeKey]]);
+
+            expect(await mergeHostIntoReplica(logger, db, hostname)).toBe(true);
+            const T = db.getSchemaStorage();
+            expect(await T.global.get(IDENTIFIERS_KEY)).toEqual([[targetId, nodeKey]]);
+            expect(await T.inputs.get(targetId)).toBeDefined();
+            expect(await T.inputs.get(hostId)).toBeUndefined();
+        } finally {
+            if (db) await db.close();
+        }
+    });
+
+    test('takes the host identifier for a host-newer semantic node and removes the target identifier', async () => {
+        const capabilities = getTestCapabilities();
+        let db;
+        try {
+            db = await getRootDatabase(capabilities);
+            const logger = makeLogger();
+            const hostname = 'peer';
+            await db.setGlobalVersion(db.version);
+            await db.setHostnameGlobal(hostname, 'version', db.version);
+            const targetId = nodeIdentifierFromString('30-abcdefghi');
+            const hostId = nodeIdentifierFromString('31-abcdefghi');
+            const nodeKey = stringToNodeKeyString('{"head":"newer-host","args":[]}');
+            const L = db.schemaStorageForReplica('x');
+            await writeNode(L, targetId, TS1, [], undefined);
+            await L.counters.put(targetId, 1);
+            await writeIdentifierLookup(L, [[targetId, nodeKey]]);
+            const H = db.hostnameSchemaStorage(hostname);
+            await writeNode(H, hostId, TS3, [], undefined);
+            await H.counters.put(hostId, 3);
+            await writeIdentifierLookup(H, [[hostId, nodeKey]]);
+
+            expect(await mergeHostIntoReplica(logger, db, hostname)).toBe(true);
+            const T = db.getSchemaStorage();
+            expect(await T.global.get(IDENTIFIERS_KEY)).toEqual([[hostId, nodeKey]]);
+            expect(await T.inputs.get(hostId)).toEqual({ inputs: [], inputCounters: [] });
+            for (const sublevel of [T.values, T.freshness, T.inputs, T.counters, T.timestamps]) {
+                expect(await sublevel.get(targetId)).toBeUndefined();
+            }
+        } finally {
+            if (db) await db.close();
+        }
+    });
+
+    test('lowers host-only inputs to surviving identifiers and invalidates mixed ancestry', async () => {
+        const capabilities = getTestCapabilities();
+        let db;
+        try {
+            db = await getRootDatabase(capabilities);
+            const logger = makeLogger();
+            const hostname = 'peer';
+            await db.setGlobalVersion(db.version);
+            await db.setHostnameGlobal(hostname, 'version', db.version);
+            const bId = nodeIdentifierFromString('40-abcdefghi');
+            const targetCId = nodeIdentifierFromString('41-abcdefghi');
+            const hostCId = nodeIdentifierFromString('42-abcdefghi');
+            const hostAId = nodeIdentifierFromString('43-abcdefghi');
+            const keyB = stringToNodeKeyString('{"head":"B","args":[]}');
+            const keyC = stringToNodeKeyString('{"head":"C","args":[]}');
+            const keyA = stringToNodeKeyString('{"head":"A","args":[]}');
+            const L = db.schemaStorageForReplica('x');
+            await writeNode(L, bId, TS2, [], undefined);
+            await writeNode(L, targetCId, TS3, [], undefined);
+            await writeIdentifierLookup(L, [[bId, keyB], [targetCId, keyC]]);
+            const H = db.hostnameSchemaStorage(hostname);
+            await writeNode(H, bId, TS2, [], undefined);
+            await writeNode(H, hostCId, TS1, [], undefined);
+            await writeNode(H, hostAId, TS2, [bId, hostCId], undefined);
+            await writeIdentifierLookup(H, [[bId, keyB], [hostCId, keyC], [hostAId, keyA]]);
+
+            expect(await mergeHostIntoReplica(logger, db, hostname)).toBe(true);
+            const T = db.getSchemaStorage();
+            expect(await T.inputs.get(hostAId)).toEqual({ inputs: [bId, targetCId], inputCounters: [] });
+            expect(await T.freshness.get(hostAId)).toBe('potentially-outdated');
+            expect(await T.revdeps.get(targetCId)).toEqual([hostAId]);
+            expect(await T.inputs.get(hostCId)).toBeUndefined();
+        } finally {
+            if (db) await db.close();
+        }
     });
 
     test('throws IdentifierLookupConflictError when same identifier maps to different semantic keys', async () => {

--- a/backend/tests/sync_merge.test.js
+++ b/backend/tests/sync_merge.test.js
@@ -860,6 +860,59 @@ describe('mergeHostIntoReplica', () => {
         }
     });
 
+    test('invalidates a target-only node whose semantic input is taken from host', async () => {
+        const capabilities = getTestCapabilities();
+        let db;
+        try {
+            db = await getRootDatabase(capabilities);
+            const logger = makeLogger();
+            const hostname = 'peer';
+            await db.setGlobalVersion(db.version);
+            await db.setHostnameGlobal(hostname, 'version', db.version);
+
+            const targetCId = nodeIdentifierFromString('50-abcdefghi');
+            const hostCId = nodeIdentifierFromString('51-abcdefghi');
+            const targetDId = nodeIdentifierFromString('52-abcdefghi');
+            const keyC = stringToNodeKeyString('{"head":"C-target-input","args":[]}');
+            const keyD = stringToNodeKeyString('{"head":"D-target-only","args":[]}');
+            const targetDValue = {
+                value: { id: 'd-local', type: 'test', description: 'local D' },
+                isDirty: false,
+            };
+
+            const L = db.schemaStorageForReplica('x');
+            await writeNode(L, targetCId, TS1, [], undefined);
+            await writeNode(L, targetDId, TS2, [targetCId], targetDValue);
+            await L.counters.put(targetDId, 2);
+            await writeIdentifierLookup(L, [
+                [targetCId, keyC],
+                [targetDId, keyD],
+            ]);
+
+            const H = db.hostnameSchemaStorage(hostname);
+            await writeNode(H, hostCId, TS3, [], undefined);
+            await writeIdentifierLookup(H, [[hostCId, keyC]]);
+
+            expect(await mergeHostIntoReplica(logger, db, hostname)).toBe(true);
+            const T = db.getSchemaStorage();
+            expect(await T.global.get(IDENTIFIERS_KEY)).toEqual([
+                [hostCId, keyC],
+                [targetDId, keyD],
+            ]);
+            expect(await T.inputs.get(targetDId)).toEqual({
+                inputs: [hostCId],
+                inputCounters: [],
+            });
+            expect(await T.values.get(targetDId)).toEqual(targetDValue);
+            expect(await T.counters.get(targetDId)).toBe(2);
+            expect(await T.freshness.get(targetDId)).toBe('potentially-outdated');
+            expect(await T.revdeps.get(hostCId)).toEqual([targetDId]);
+            expect(await T.inputs.get(targetCId)).toBeUndefined();
+        } finally {
+            if (db) await db.close();
+        }
+    });
+
     test('throws IdentifierLookupConflictError when same identifier maps to different semantic keys', async () => {
         const capabilities = getTestCapabilities();
         let db;

--- a/backend/tests/sync_merge.test.js
+++ b/backend/tests/sync_merge.test.js
@@ -20,6 +20,8 @@ const {
     isMissingIdentifierLookupError,
     makeIdentifierLookup,
     nodeIdentifierFromString,
+    nodeIdentifierToString,
+    nodeKeyStringToString,
     serializeIdentifierLookup,
     stringToNodeKeyString,
 } = require('../src/generators/incremental_graph/database');
@@ -908,6 +910,585 @@ describe('mergeHostIntoReplica', () => {
             expect(await T.freshness.get(targetDId)).toBe('potentially-outdated');
             expect(await T.revdeps.get(hostCId)).toEqual([targetDId]);
             expect(await T.inputs.get(targetCId)).toBeUndefined();
+        } finally {
+            if (db) await db.close();
+        }
+    });
+
+    test('same semantic key with different identifiers and equal timestamps: merge succeeds, single identity survives', async () => {
+        const capabilities = getTestCapabilities();
+        let db;
+        try {
+            db = await getRootDatabase(capabilities);
+            const logger = makeLogger();
+            const hostname = 'peer';
+            const appVersionStr = db.version;
+            await db.setGlobalVersion(appVersionStr);
+            await db.setHostnameGlobal(hostname, 'version', appVersionStr);
+
+            const SAME_KEY = stringToNodeKeyString('{"head":"event","args":["id123"]}');
+            const T_ID = nodeIdentifierFromString('1-abcdefghi');
+            const H_ID = nodeIdentifierFromString('10-abcdefghi');
+            const tValue = { value: { id: 'local', type: 'test', description: 'local value' }, isDirty: false };
+            const hValue = { value: { id: 'remote', type: 'test', description: 'remote value' }, isDirty: false };
+
+            const L = db.schemaStorageForReplica('x');
+            await writeNode(L, T_ID, TS1, [], tValue);
+            await writeIdentifierLookup(L, [[T_ID, SAME_KEY]]);
+
+            const H = db.hostnameSchemaStorage(hostname);
+            await writeNode(H, H_ID, TS1, [], hValue);
+            await writeIdentifierLookup(H, [[H_ID, SAME_KEY]]);
+
+            // Merge must NOT throw
+            db = await mergeAndReopenIfSwitched(capabilities, logger, db, hostname);
+
+            // Active replica stays 'x' (equal timestamps → keep → no data changes, but identifier reconciliation still counts)
+            const newActive = db.currentReplicaName();
+            const T = db.schemaStorageForReplica(newActive);
+
+            // Final lookup must be a strict bijection: SAME_KEY -> T_ID only
+            const serialized = await T.global.get(IDENTIFIERS_KEY);
+            const finalLookup = makeIdentifierLookup(serialized ? serializeIdentifierLookup(makeIdentifierLookup(serialized)) : []);
+            expect(finalLookup.keyToId.get(nodeKeyStringToString(SAME_KEY))).toBe(T_ID);
+            expect(finalLookup.keyToId.size).toBe(1);
+            expect(finalLookup.idToKey.size).toBe(1);
+
+            // Target identifier data survives
+            const merged = await T.values.get(T_ID);
+            expect(merged).toEqual(tValue);
+
+            // Stale host identifier must NOT be in T storage (host data was in H, not L/T)
+            const hValInT = await T.values.get(H_ID);
+            expect(hValInT).toBeUndefined();
+            const hFreshInT = await T.freshness.get(H_ID);
+            expect(hFreshInT).toBeUndefined();
+            const hInputsInT = await T.inputs.get(H_ID);
+            expect(hInputsInT).toBeUndefined();
+            const hCounterInT = await T.counters.get(H_ID);
+            expect(hCounterInT).toBeUndefined();
+            const hTsInT = await T.timestamps.get(H_ID);
+            expect(hTsInT).toBeUndefined();
+        } finally {
+            if (db) await db.close();
+        }
+    });
+
+    test('same semantic key with different identifiers and target-newer: keep, target id survives', async () => {
+        const capabilities = getTestCapabilities();
+        let db;
+        try {
+            db = await getRootDatabase(capabilities);
+            const logger = makeLogger();
+            const hostname = 'peer';
+            const appVersionStr = db.version;
+            await db.setGlobalVersion(appVersionStr);
+            await db.setHostnameGlobal(hostname, 'version', appVersionStr);
+
+            const SAME_KEY = stringToNodeKeyString('{"head":"event","args":["id456"]}');
+            const T_ID = nodeIdentifierFromString('2-abcdefghi');
+            const H_ID = nodeIdentifierFromString('20-abcdefghi');
+            const tValue = { value: { id: 'local', type: 'test', description: 'local newer' }, isDirty: false };
+
+            const L = db.schemaStorageForReplica('x');
+            await writeNode(L, T_ID, TS3, [], tValue);
+            await writeIdentifierLookup(L, [[T_ID, SAME_KEY]]);
+
+            const H = db.hostnameSchemaStorage(hostname);
+            await writeNode(H, H_ID, TS1, [], undefined);
+            await writeIdentifierLookup(H, [[H_ID, SAME_KEY]]);
+
+            db = await mergeAndReopenIfSwitched(capabilities, logger, db, hostname);
+
+            const T = db.schemaStorageForReplica(db.currentReplicaName());
+
+            // Final lookup: SAME_KEY -> T_ID
+            const raw = await T.global.get(IDENTIFIERS_KEY);
+            const finalLookup = raw ? makeIdentifierLookup(raw) : null;
+            const keyStr = nodeKeyStringToString(SAME_KEY);
+            expect(finalLookup ? finalLookup.keyToId.get(keyStr) : undefined).toBe(T_ID);
+            expect(finalLookup ? finalLookup.keyToId.size : 0).toBe(1);
+
+            // Host identifier NOT in final lookup
+            expect(finalLookup ? finalLookup.idToKey.has(nodeIdentifierToString(H_ID)) : false).toBe(false);
+
+            // Target identifier data survives
+            const val = await T.values.get(T_ID);
+            expect(val).toEqual(tValue);
+        } finally {
+            if (db) await db.close();
+        }
+    });
+
+    test('same semantic key with different identifiers and host-newer: take, host id survives, target id removed', async () => {
+        const capabilities = getTestCapabilities();
+        let db;
+        try {
+            db = await getRootDatabase(capabilities);
+            const logger = makeLogger();
+            const hostname = 'peer';
+            const appVersionStr = db.version;
+            await db.setGlobalVersion(appVersionStr);
+            await db.setHostnameGlobal(hostname, 'version', appVersionStr);
+
+            const SAME_KEY = stringToNodeKeyString('{"head":"event","args":["id789"]}');
+            const T_ID = nodeIdentifierFromString('3-abcdefghi');
+            const H_ID = nodeIdentifierFromString('30-abcdefghi');
+            const tValue = { value: { id: 'local', type: 'test', description: 'local older' }, isDirty: false };
+            const hValue = { value: { id: 'remote', type: 'test', description: 'remote newer' }, isDirty: false };
+
+            const L = db.schemaStorageForReplica('x');
+            await writeNode(L, T_ID, TS1, [], tValue);
+            await writeIdentifierLookup(L, [[T_ID, SAME_KEY]]);
+
+            const H = db.hostnameSchemaStorage(hostname);
+            await writeNode(H, H_ID, TS3, [], hValue);
+            await writeIdentifierLookup(H, [[H_ID, SAME_KEY]]);
+
+            db = await mergeAndReopenIfSwitched(capabilities, logger, db, hostname);
+
+            const newActive = db.currentReplicaName();
+            expect(newActive).toBe('y');
+            const T = db.schemaStorageForReplica(newActive);
+
+            // Final lookup: SAME_KEY -> H_ID (host identifier survives)
+            const raw = await T.global.get(IDENTIFIERS_KEY);
+            const finalLookup = raw ? makeIdentifierLookup(raw) : null;
+            const keyStr = nodeKeyStringToString(SAME_KEY);
+            expect(finalLookup ? finalLookup.keyToId.get(keyStr) : undefined).toBe(H_ID);
+            expect(finalLookup ? finalLookup.keyToId.size : 0).toBe(1);
+            expect(finalLookup ? finalLookup.idToKey.size : 0).toBe(1);
+
+            // Host identifier data is in T (copied from H)
+            const valAtH = await T.values.get(H_ID);
+            expect(valAtH).toEqual(hValue);
+
+            // Losing target identifier must be removed from T storage
+            const valAtT = await T.values.get(T_ID);
+            expect(valAtT).toBeUndefined();
+            const freshAtT = await T.freshness.get(T_ID);
+            expect(freshAtT).toBeUndefined();
+            const inputsAtT = await T.inputs.get(T_ID);
+            expect(inputsAtT).toBeUndefined();
+            const counterAtT = await T.counters.get(T_ID);
+            expect(counterAtT).toBeUndefined();
+            const tsAtT = await T.timestamps.get(T_ID);
+            expect(tsAtT).toBeUndefined();
+        } finally {
+            if (db) await db.close();
+        }
+    });
+
+    test('H-only node depending on semantic node whose target id survives: inputs lowered, potentially-outdated', async () => {
+        // Graph: A depends on B and C.
+        // Target has B (tId) and C (C_t).
+        // Host has B (hId, same key but different id), C (C_h, same key but different id),
+        //   and A (A_h) depending on [B, C_h].
+        // Merge keeps target's C_t (equal timestamps → keep).
+        // A is taken (host-only), but its inputs are lowered so it depends on [B_final, C_t].
+        // A is marked potentially-outdated because it was computed with C_h, not C_t.
+        const capabilities = getTestCapabilities();
+        let db;
+        try {
+            db = await getRootDatabase(capabilities);
+            const logger = makeLogger();
+            const hostname = 'peer';
+            const appVersionStr = db.version;
+            await db.setGlobalVersion(appVersionStr);
+            await db.setHostnameGlobal(hostname, 'version', appVersionStr);
+
+            const KEY_A = stringToNodeKeyString('{"head":"A","args":[]}');
+            const KEY_B = stringToNodeKeyString('{"head":"B","args":[]}');
+            const KEY_C = stringToNodeKeyString('{"head":"C","args":[]}');
+
+            const B_T_ID = nodeIdentifierFromString('1-abcdefghi');
+            const C_T_ID = nodeIdentifierFromString('2-abcdefghi');
+            const B_H_ID = nodeIdentifierFromString('11-abcdefghi');
+            const C_H_ID = nodeIdentifierFromString('22-abcdefghi');
+            const A_H_ID = nodeIdentifierFromString('33-abcdefghi');
+
+            const tValB = { value: { id: 'b', type: 'test' }, isDirty: false };
+            const tValC = { value: { id: 'c', type: 'test' }, isDirty: false };
+            const hValA = { value: { id: 'a', type: 'test' }, isDirty: false };
+
+            // Target (L) has B at B_T_ID (same ts), C at C_T_ID (newer → force-keep)
+            const L = db.schemaStorageForReplica('x');
+            await writeNode(L, B_T_ID, TS1, [], tValB);
+            await writeNode(L, C_T_ID, TS3, [], tValC);
+            await writeIdentifierLookup(L, [
+                [B_T_ID, KEY_B],
+                [C_T_ID, KEY_C],
+            ]);
+
+            // Host (H) has B at B_H_ID, C at C_H_ID, A at A_H_ID depending on [B_H_ID, C_H_ID]
+            const H = db.hostnameSchemaStorage(hostname);
+            await writeNode(H, B_H_ID, TS1, [], undefined);
+            await writeNode(H, C_H_ID, TS1, [], undefined);
+            await writeNode(H, A_H_ID, TS2, [B_H_ID, C_H_ID], hValA);
+            await writeIdentifierLookup(H, [
+                [B_H_ID, KEY_B],
+                [C_H_ID, KEY_C],
+                [A_H_ID, KEY_A],
+            ]);
+
+            db = await mergeAndReopenIfSwitched(capabilities, logger, db, hostname);
+
+            const T = db.schemaStorageForReplica(db.currentReplicaName());
+
+            // A must exist and have been taken
+            const aValue = await T.values.get(A_H_ID);
+            expect(aValue).toEqual(hValA);
+
+            // A's freshness: potentially-outdated (computed with C_h, but C_t survived)
+            const aFreshness = await T.freshness.get(A_H_ID);
+            expect(aFreshness).toBe('potentially-outdated');
+
+            // A's inputs must be lowered: should reference final identifiers for B and C
+            // B keep → B_T_ID survives, C keep → C_T_ID survives
+            const aInputs = await T.inputs.get(A_H_ID);
+            expect(aInputs).not.toBeUndefined();
+            const loweredInputStrings = aInputs ? aInputs.inputs.map(id => String(id)) : [];
+            expect(loweredInputStrings).toContain(String(B_T_ID));
+            expect(loweredInputStrings).toContain(String(C_T_ID));
+            // Must NOT contain host identifiers
+            expect(loweredInputStrings).not.toContain(String(B_H_ID));
+            expect(loweredInputStrings).not.toContain(String(C_H_ID));
+
+            // Revdeps should point from B_T_ID and C_T_ID to A_H_ID
+            const bRevdeps = await T.revdeps.get(B_T_ID);
+            expect(bRevdeps).not.toBeUndefined();
+            expect(bRevdeps ? bRevdeps.map(d => String(d)) : []).toContain(String(A_H_ID));
+            const cRevdeps = await T.revdeps.get(C_T_ID);
+            expect(cRevdeps).not.toBeUndefined();
+            expect(cRevdeps ? cRevdeps.map(d => String(d)) : []).toContain(String(A_H_ID));
+
+            // Final lookup must be a strict bijection
+            const raw = await T.global.get(IDENTIFIERS_KEY);
+            const finalLookup = raw ? makeIdentifierLookup(raw) : null;
+            expect(finalLookup ? finalLookup.keyToId.size : 0).toBe(finalLookup ? finalLookup.idToKey.size : 0);
+            // B → B_T_ID, C → C_T_ID, A → A_H_ID
+            expect(finalLookup ? finalLookup.keyToId.get(nodeKeyStringToString(KEY_B)) : undefined).toBe(B_T_ID);
+            expect(finalLookup ? finalLookup.keyToId.get(nodeKeyStringToString(KEY_C)) : undefined).toBe(C_T_ID);
+            expect(finalLookup ? finalLookup.keyToId.get(nodeKeyStringToString(KEY_A)) : undefined).toBe(A_H_ID);
+
+            // B_T_ID and C_T_ID data should still be in T
+            expect(await T.values.get(B_T_ID)).toBeDefined();
+            expect(await T.values.get(C_T_ID)).toBeDefined();
+        } finally {
+            if (db) await db.close();
+        }
+    });
+
+    test('mixed ancestry invalidation works with semantic-key-based planner', async () => {
+        // Same scenario as the existing invalidation test, but using different identifiers
+        // for the same key on the two sides.
+        const capabilities = getTestCapabilities();
+        let db;
+        try {
+            db = await getRootDatabase(capabilities);
+            const logger = makeLogger();
+            const hostname = 'peer';
+            const appVersionStr = db.version;
+            await db.setGlobalVersion(appVersionStr);
+            await db.setHostnameGlobal(hostname, 'version', appVersionStr);
+
+            const KEY_A = stringToNodeKeyString('{"head":"A","args":[]}');
+            const KEY_B = stringToNodeKeyString('{"head":"B","args":[]}');
+
+            const A_T_ID = nodeIdentifierFromString('1-abcdefghi');
+            const B_T_ID = nodeIdentifierFromString('2-abcdefghi');
+            const A_H_ID = nodeIdentifierFromString('11-abcdefghi');
+            const B_H_ID = nodeIdentifierFromString('22-abcdefghi');
+
+            const localValueB = { value: { id: 'b-local', type: 'test', description: 'local B' }, isDirty: false };
+            const remoteValueB = { value: { id: 'b-remote', type: 'test', description: 'remote B' }, isDirty: false };
+
+            const L = db.schemaStorageForReplica('x');
+            // A is force-kept (T-newer); B is initially 'take' (H-newer) and depends on A
+            await writeNode(L, A_T_ID, TS3, [], undefined);
+            await writeNode(L, B_T_ID, TS1, [], localValueB);
+            await L.counters.put(B_T_ID, 1);
+            await writeIdentifierLookup(L, [
+                [A_T_ID, KEY_A],
+                [B_T_ID, KEY_B],
+            ]);
+
+            const H = db.hostnameSchemaStorage(hostname);
+            await writeNode(H, A_H_ID, TS1, [], undefined);
+            await writeNode(H, B_H_ID, TS2, [A_H_ID], remoteValueB);
+            await H.counters.put(B_H_ID, 2);
+            await writeIdentifierLookup(H, [
+                [A_H_ID, KEY_A],
+                [B_H_ID, KEY_B],
+            ]);
+
+            db = await mergeAndReopenIfSwitched(capabilities, logger, db, hostname);
+
+            const T = db.schemaStorageForReplica(db.currentReplicaName());
+
+            // A is keep → A_T_ID survives
+            // B is initially take → B_H_ID should carry the data; but invalidated
+            // B should be invalidated: both keepTainted (via A) and takeTainted (B itself)
+            const bFreshness = await T.freshness.get(B_H_ID);
+            expect(bFreshness).toBe('potentially-outdated');
+
+            // B's stored inputs should point to final identifiers (A_T_ID, not A_H_ID)
+            const bInputs = await T.inputs.get(B_H_ID);
+            expect(bInputs).not.toBeUndefined();
+            expect(bInputs ? bInputs.inputs.map(id => String(id)) : []).toEqual([String(A_T_ID)]);
+
+            // B's counter and value from H should be preserved
+            const bCounter = await T.counters.get(B_H_ID);
+            expect(bCounter).toBe(2);
+            const bValue = await T.values.get(B_H_ID);
+            expect(bValue).toEqual(remoteValueB);
+
+            // B's modifiedAt advanced to H's TS2
+            const bTimestamps = await T.timestamps.get(B_H_ID);
+            expect(bTimestamps?.modifiedAt).toBe(TS2);
+        } finally {
+            if (db) await db.close();
+        }
+    });
+
+    test('same identifier mapped to different semantic keys remains a hard error', async () => {
+        const capabilities = getTestCapabilities();
+        let db;
+        try {
+            db = await getRootDatabase(capabilities);
+            const logger = makeLogger();
+            const hostname = 'peer';
+            const appVersionStr = db.version;
+            await db.setGlobalVersion(appVersionStr);
+            await db.setHostnameGlobal(hostname, 'version', appVersionStr);
+
+            const idA = nodeIdentifierFromString('1-abcdefghi');
+            const keyA = stringToNodeKeyString('{"head":"event","args":["a"]}');
+            const keyB = stringToNodeKeyString('{"head":"event","args":["b"]}');
+
+            const L = db.schemaStorageForReplica('x');
+            await writeIdentifierLookup(L, [[idA, keyA]]);
+
+            const H = db.hostnameSchemaStorage(hostname);
+            await writeIdentifierLookup(H, [[idA, keyB]]);
+
+            let error;
+            try {
+                await mergeHostIntoReplica(logger, db, hostname);
+            } catch (caught) {
+                error = caught;
+            }
+
+            expect(isIdentifierLookupConflictError(error)).toBe(true);
+            expect(String(error?.message)).toContain('Conflicting node key assignment for identifier');
+            expect(db.currentReplicaName()).toBe('x');
+        } finally {
+            if (db) await db.close();
+        }
+    });
+
+    test('identifier-only reconciliation causes replica cutover', async () => {
+        const capabilities = getTestCapabilities();
+        let db;
+        try {
+            db = await getRootDatabase(capabilities);
+            const logger = makeLogger();
+            const hostname = 'peer';
+            const appVersionStr = db.version;
+            await db.setGlobalVersion(appVersionStr);
+            await db.setHostnameGlobal(hostname, 'version', appVersionStr);
+
+            const SAME_KEY = stringToNodeKeyString('{"head":"event","args":["cutover-test"]}');
+            const T_ID = nodeIdentifierFromString('1-abcdefghi');
+            const H_ID = nodeIdentifierFromString('10-abcdefghi');
+
+            const L = db.schemaStorageForReplica('x');
+            await writeNode(L, T_ID, TS1, [], { value: { id: 'val' }, isDirty: false });
+            await writeIdentifierLookup(L, [[T_ID, SAME_KEY]]);
+
+            const H = db.hostnameSchemaStorage(hostname);
+            await writeNode(H, H_ID, TS1, [], { value: { id: 'val' }, isDirty: false });
+            await writeIdentifierLookup(H, [[H_ID, SAME_KEY]]);
+
+            // Precondition: active replica is 'x'
+            expect(db.currentReplicaName()).toBe('x');
+
+            const switched = await mergeHostIntoReplica(logger, db, hostname);
+
+            // Even though no graph data changed (equal timestamps → keep),
+            // identifier reconciliation means the merge IS a change:
+            // the final lookup must be committed and the replica must be switched.
+            expect(switched).toBe(true);
+        } finally {
+            if (db) await db.close();
+        }
+    });
+
+    test('throws MissingInputIdentifierError when node depends on identifier not in any lookup', async () => {
+        // Corrupt graph: host has a node whose inputs reference an identifier
+        // that is missing from both lookups.  The planner must throw instead
+        // of silently dropping the dependency.
+        const capabilities = getTestCapabilities();
+        let db;
+        try {
+            db = await getRootDatabase(capabilities);
+            const logger = makeLogger();
+            const hostname = 'peer';
+            const appVersionStr = db.version;
+            await db.setGlobalVersion(appVersionStr);
+            await db.setHostnameGlobal(hostname, 'version', appVersionStr);
+
+            const keyA = stringToNodeKeyString('{"head":"A","args":[]}');
+            const A_T_ID = nodeIdentifierFromString('1-abcdefghi');
+            const B_H_ID = nodeIdentifierFromString('2-abcdefghi');
+            const MYSTERY_ID = nodeIdentifierFromString('99-abcdefghi');
+            const keyB = stringToNodeKeyString('{"head":"B","args":[]}');
+
+            const L = db.schemaStorageForReplica('x');
+            await writeNode(L, A_T_ID, TS1, [], undefined);
+            await writeIdentifierLookup(L, [[A_T_ID, keyA]]);
+
+            const H = db.hostnameSchemaStorage(hostname);
+            // B depends on MYSTERY_ID, which is NOT in either lookup.
+            await writeNode(H, B_H_ID, TS2, [MYSTERY_ID], undefined);
+            await writeIdentifierLookup(H, [[B_H_ID, keyB]]);
+
+            let error;
+            try {
+                await mergeHostIntoReplica(logger, db, hostname);
+            } catch (caught) {
+                error = caught;
+            }
+
+            expect(isIdentifierLookupConflictError(error)).toBe(true);
+            expect(String(error?.message)).toContain(String(MYSTERY_ID));
+            expect(db.currentReplicaName()).toBe('x');
+        } finally {
+            if (db) await db.close();
+        }
+    });
+
+    test('target-only nodes remain keep despite taint from host-newer ancestor', async () => {
+        // Scenario:
+        //   Target: A_t (key K) TS1, D_t (key K2) TS1, inputs=[A_t]
+        //   Host:   A_h (key K) TS3 (newer), no D
+        // A is shared, host-newer → take (A_h wins). D is target-only → keep.
+        // Without the fix, D inherits takeTainted from A and becomes 'take',
+        // which copies from non-existent host storage, losing D's data.
+        // After the fix, D stays 'keep' with its data preserved and inputs
+        // lowered to the final identifier for A (A_h).
+        const capabilities = getTestCapabilities();
+        let db;
+        try {
+            db = await getRootDatabase(capabilities);
+            const logger = makeLogger();
+            const hostname = 'peer';
+            const appVersionStr = db.version;
+            await db.setGlobalVersion(appVersionStr);
+            await db.setHostnameGlobal(hostname, 'version', appVersionStr);
+
+            const KEY_A = stringToNodeKeyString('{"head":"A","args":[]}');
+            const KEY_D = stringToNodeKeyString('{"head":"D","args":[]}');
+            const A_T_ID = nodeIdentifierFromString('1-abcdefghi');
+            const A_H_ID = nodeIdentifierFromString('11-abcdefghi');
+            const D_T_ID = nodeIdentifierFromString('2-abcdefghi');
+            const targetValueD = { value: { id: 'd-target', type: 'test', description: 'target-only D' }, isDirty: false };
+
+            const L = db.schemaStorageForReplica('x');
+            await writeNode(L, A_T_ID, TS1, [], undefined);
+            await writeNode(L, D_T_ID, TS1, [A_T_ID], targetValueD);
+            await writeIdentifierLookup(L, [
+                [A_T_ID, KEY_A],
+                [D_T_ID, KEY_D],
+            ]);
+
+            const H = db.hostnameSchemaStorage(hostname);
+            await writeNode(H, A_H_ID, TS3, [], undefined);
+            await writeIdentifierLookup(H, [[A_H_ID, KEY_A]]);
+
+            db = await mergeAndReopenIfSwitched(capabilities, logger, db, hostname);
+
+            const T = db.schemaStorageForReplica(db.currentReplicaName());
+
+            // D_T_ID must still exist (data preserved)
+            const dValue = await T.values.get(D_T_ID);
+            expect(dValue).toEqual(targetValueD);
+            const dFreshness = await T.freshness.get(D_T_ID);
+            expect(dFreshness).toBeDefined();
+
+            // D's inputs must be lowered: they should reference A_H_ID (final ident for key A)
+            const dInputs = await T.inputs.get(D_T_ID);
+            expect(dInputs).not.toBeUndefined();
+            const loweredDInputs = dInputs ? dInputs.inputs.map(id => String(id)) : [];
+            expect(loweredDInputs).toContain(String(A_H_ID));
+
+            // A_T_ID should be gone (losing target identifier deleted)
+            const aTVal = await T.values.get(A_T_ID);
+            expect(aTVal).toBeUndefined();
+
+            // Final lookup must be a strict bijection: A→A_H_ID, D→D_T_ID
+            const raw = await T.global.get(IDENTIFIERS_KEY);
+            const finalLookup = raw ? makeIdentifierLookup(raw) : null;
+            const keyStrA = nodeKeyStringToString(KEY_A);
+            const keyStrD = nodeKeyStringToString(KEY_D);
+            expect(finalLookup ? finalLookup.keyToId.get(keyStrA) : undefined).toBe(A_H_ID);
+            expect(finalLookup ? finalLookup.keyToId.get(keyStrD) : undefined).toBe(D_T_ID);
+            expect(finalLookup ? finalLookup.keyToId.size : 0).toBe(2);
+        } finally {
+            if (db) await db.close();
+        }
+    });
+
+    test('kept node with changed dependency identifier gets inputs rewritten', async () => {
+        // Scenario:
+        //   Target: A_t (key K) TS1, B_t (key K2) TS1, inputs=[A_t]
+        //   Host:   A_h (key K) TS3 (newer), no B
+        // A is shared, host-newer → take (A_h wins). B is target-only → force-kept.
+        // B's stored inputs=[A_t] must be rewritten to=[A_h] because A_h is the
+        // final identifier for key K. Without the fix, B's inputs still point to
+        // the deleted A_t identifier.
+        const capabilities = getTestCapabilities();
+        let db;
+        try {
+            db = await getRootDatabase(capabilities);
+            const logger = makeLogger();
+            const hostname = 'peer';
+            const appVersionStr = db.version;
+            await db.setGlobalVersion(appVersionStr);
+            await db.setHostnameGlobal(hostname, 'version', appVersionStr);
+
+            const KEY_A = stringToNodeKeyString('{"head":"A","args":[]}');
+            const KEY_B = stringToNodeKeyString('{"head":"B","args":[]}');
+            const A_T_ID = nodeIdentifierFromString('1-abcdefghi');
+            const A_H_ID = nodeIdentifierFromString('11-abcdefghi');
+            const B_T_ID = nodeIdentifierFromString('2-abcdefghi');
+
+            const L = db.schemaStorageForReplica('x');
+            await writeNode(L, A_T_ID, TS1, [], undefined);
+            await writeNode(L, B_T_ID, TS1, [A_T_ID], undefined);
+            await writeIdentifierLookup(L, [
+                [A_T_ID, KEY_A],
+                [B_T_ID, KEY_B],
+            ]);
+
+            const H = db.hostnameSchemaStorage(hostname);
+            await writeNode(H, A_H_ID, TS3, [], undefined);
+            await writeIdentifierLookup(H, [[A_H_ID, KEY_A]]);
+
+            db = await mergeAndReopenIfSwitched(capabilities, logger, db, hostname);
+
+            const T = db.schemaStorageForReplica(db.currentReplicaName());
+
+            // B_T_ID's inputs must be rewritten to reference A_H_ID (not A_T_ID)
+            const bInputs = await T.inputs.get(B_T_ID);
+            expect(bInputs).not.toBeUndefined();
+            const loweredBInputs = bInputs ? bInputs.inputs.map(id => String(id)) : [];
+            expect(loweredBInputs).toContain(String(A_H_ID));
+            expect(loweredBInputs).not.toContain(String(A_T_ID));
+
+            // B must still exist (its identifier unchanged)
+            const bFreshness = await T.freshness.get(B_T_ID);
+            expect(bFreshness).toBeDefined();
         } finally {
             if (db) await db.close();
         }

--- a/backend/tests/sync_merge.test.js
+++ b/backend/tests/sync_merge.test.js
@@ -862,6 +862,53 @@ describe('mergeHostIntoReplica', () => {
         }
     });
 
+    test('invalidates a host-only node when equal-timestamp input is relowered to target identifier', async () => {
+        const capabilities = getTestCapabilities();
+        let db;
+        try {
+            db = await getRootDatabase(capabilities);
+            const logger = makeLogger();
+            const hostname = 'peer';
+            await db.setGlobalVersion(db.version);
+            await db.setHostnameGlobal(hostname, 'version', db.version);
+
+            const targetCId = nodeIdentifierFromString('44-abcdefghi');
+            const hostCId = nodeIdentifierFromString('45-abcdefghi');
+            const hostAId = nodeIdentifierFromString('46-abcdefghi');
+            const keyC = stringToNodeKeyString('{"head":"C-equal-relowered","args":[]}');
+            const keyA = stringToNodeKeyString('{"head":"A-host-only-relowered","args":[]}');
+            const hostAValue = {
+                value: { id: 'a-host', type: 'test', description: 'computed from host C' },
+                isDirty: false,
+            };
+
+            const L = db.schemaStorageForReplica('x');
+            await writeNode(L, targetCId, TS1, [], undefined);
+            await L.counters.put(targetCId, 4);
+            await writeIdentifierLookup(L, [[targetCId, keyC]]);
+
+            const H = db.hostnameSchemaStorage(hostname);
+            await writeNode(H, hostCId, TS1, [], undefined);
+            await H.counters.put(hostCId, 9);
+            await writeNode(H, hostAId, TS1, [hostCId], hostAValue);
+            await H.inputs.put(hostAId, { inputs: [hostCId], inputCounters: [9] });
+            await writeIdentifierLookup(H, [[hostCId, keyC], [hostAId, keyA]]);
+
+            expect(await mergeHostIntoReplica(logger, db, hostname)).toBe(true);
+            const T = db.getSchemaStorage();
+            expect(await T.inputs.get(hostAId)).toEqual({
+                inputs: [targetCId],
+                inputCounters: [9],
+            });
+            expect(await T.values.get(hostAId)).toEqual(hostAValue);
+            expect(await T.freshness.get(hostAId)).toBe('potentially-outdated');
+            expect(await T.revdeps.get(targetCId)).toEqual([hostAId]);
+            expect(await T.inputs.get(hostCId)).toBeUndefined();
+        } finally {
+            if (db) await db.close();
+        }
+    });
+
     test('invalidates a target-only node whose semantic input is taken from host', async () => {
         const capabilities = getTestCapabilities();
         let db;


### PR DESCRIPTION
### Motivation

- Resolve same-semantic-key / different-NodeIdentifier sync conflicts by making the planner operate on semantic node keys instead of raw storage identifiers so the merge can reconcile divergent identifier assignments without rewriting storage first.
- Preserve storage as identifier-keyed history while ensuring each semantic key ends up with exactly one surviving storage identifier and no stale losing identifiers remain in any sublevel.
- Maintain existing hard error semantics for the corrupt case where the same identifier maps to different semantic keys.
- Ensure replica cutover occurs when identifier reconciliation changes the final lookup even if no graph nodes were taken/invalidated.

### Description

- Reworked planner to `buildMergePlan(T, H, targetLookup, hostLookup)` that computes initial/taint decisions over `NodeKeyString` and produces `finalIdentifierForKey`, a lowered `mergedInputsMap`, and a reconstructed bijective `finalIdentifierLookup`.
- Updated applier to lower semantic decisions into identifier-keyed operations by copying from source identifiers into destination identifiers via `copyNodeOps`, rewriting inputs to final identifiers, invalidating mixed-ancestry nodes, and deleting losing target identifiers from `values`, `freshness`, `inputs`, `counters`, and `timestamps`.
- Replaced naive `mergeIdentifierLookups` use with construction and validation of a fresh `finalIdentifierLookup`, added `assertValidFinalMergeState` to verify bijection/materialization/invariants before cutover, and preserved rejection for identifier→different-key collisions via `assertNoIdentifierCollisions`.
- Added helpers and refactors: `semanticInputs` (planner input resolution), `copyNodeOps` and `deleteNodeOps` (safe cross-identifier copy/delete), and small topo-sort typing improvements; updated tests to encode the required TDD scenarios and removed the prior release-blocker marker once behavior was implemented.

### Testing

- Added failing-first TDD coverage for all required scenarios (equal-timestamp same-key different identifiers; target-local newer keep; host-newer take; host-only lowered inputs + potentially-outdated host node; mixed-ancestry invalidation; same-id/different-key hard error; identifier-only repair causing cutover) and exercised them until unmarked, leaving no skipped/failing tests for these cases.
- Ran focused suites and static checks: `npx jest backend/tests/sync_merge.test.js backend/tests/identifier_lookup.test.js backend/tests/topo_sort.test.js --runInBand` and `npm run static-analysis`, which passed (94 tests passed for those focused suites and static analysis succeeded).
- Ran full backend suite and build: `npm test -- --runInBand` (all projects) completed successfully with 247 test suites and 2,905 tests passing, and `npm run build` produced a production frontend build without errors.
- Performed final validation `git diff --check` and ensured no remaining `test.failing`/`skip`/`todo` markers in the new sync merge tests.

Made with a semantic-first planner so we pick a single luggage tag for each semantic suitcase instead of trying to make each suitcase wear two tags at once — lightweight and less confusing at baggage claim. @ottojung

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2639632d58832ea0f52efe09456b74)