### PR TITLE
Strengthen graph-scheme test integrity and storage-level topo tests

### DIFF
--- a/backend/tests/migration_runner.test.js
+++ b/backend/tests/migration_runner.test.js
@@ -4,10 +4,9 @@ const {
     IDENTIFIERS_KEY,
     GRAPH_SCHEME_KEY,
     nodeIdentifierToString,
-    nodeNameToString,
-    deserializeNodeKey,
     buildGraphSchemeFromNodeDefs,
     serializeGraphScheme,
+    isMissingGraphSchemeError,
 } = require("../src/generators/incremental_graph/database");
 const {
     isUndecidedNodes,
@@ -85,51 +84,9 @@ function makeSchemaStorage() {
 
     // Tests use simplified mocks where the "NodeIdentifier" string is the same
     // as the semantic node key JSON string. When identifiers_keys_map is not
-    // explicitly seeded, fall back to an identity mapping derived from the
-    // currently materialized values keys.
-    // When graph_scheme is not explicitly seeded, auto-generate from values + valid.
+    // explicitly seeded, fall back to an identity mapping derived from values.
     const originalGlobalGet = global.get.bind(global);
     global.get = async (key) => {
-        if (key === GRAPH_SCHEME_KEY) {
-            const stored = await originalGlobalGet(key);
-            if (stored !== undefined) return stored;
-            // Build scheme from materialized node keys and the valid sublevel.
-            const headArity = new Map();
-            for await (const k of values.keys()) {
-                try {
-                    const parsed = deserializeNodeKey(k);
-                    const head = nodeNameToString(parsed.head);
-                    if (!headArity.has(head)) {
-                        headArity.set(head, parsed.args.length);
-                    }
-                } catch { /* skip unparseable keys */ }
-            }
-            // valid[D] = [N1, N2, ...] means N1 and N2 list D as a dependency.
-            const depMap = new Map();
-            for await (const depId of valid.keys()) {
-                const dependents = await valid.get(depId) ?? [];
-                for (const dep of dependents) {
-                    try {
-                        const depParsed = deserializeNodeKey(dep);
-                        const depHead = nodeNameToString(depParsed.head);
-                        const depDeps = depMap.get(depHead) ?? new Set();
-                        const depIdParsed = deserializeNodeKey(depId);
-                        depDeps.add(nodeNameToString(depIdParsed.head));
-                        depMap.set(depHead, depDeps);
-                    } catch { /* skip unparseable keys */ }
-                }
-            }
-            const nodes = [...headArity.entries()]
-                .sort(([a], [b]) => a.localeCompare(b))
-                .map(([head, arity]) => {
-                    const deps = depMap.get(head);
-                    const inputTemplates = deps
-                        ? [...deps].sort().map(dh => ({ head: dh, args: [] }))
-                        : [];
-                    return { head, arity, inputTemplates };
-                });
-            return JSON.stringify({ format: 1, nodes });
-        }
         if (key !== IDENTIFIERS_KEY) {
             return await originalGlobalGet(key);
         }
@@ -258,6 +215,20 @@ async function seedGraphScheme(storage, nodeDefs) {
 }
 
 /**
+ * Seed the standard zero-arity A graph scheme used by single-node tests.
+ * @param {import('../src/generators/incremental_graph/database').SchemaStorage} storage
+ */
+async function seedSingleAGraphScheme(storage) {
+    await seedGraphScheme(storage, [{
+        output: "A",
+        inputs: [],
+        computor: async () => ({ type: "all_events", events: [] }),
+        isDeterministic: true,
+        hasSideEffects: false,
+    }]);
+}
+
+/**
  * Builds a minimal but representative migration scenario.
  * The xStorage has one node ("A") that the migration callback can act upon.
  */
@@ -272,7 +243,6 @@ function makeSimpleMigrationSetup({ prevVersion = "1.0.0", currentVersion = "2.0
         isDeterministic: true,
         hasSideEffects: false,
     }];
-    // graph_scheme is auto-generated from values + valid in makeSchemaStorage's global.get
     const { rootDatabase } = makeRootDatabaseMock({
         prevVersion,
         currentVersion,
@@ -289,6 +259,49 @@ beforeEach(() => {
 });
 
 describe("runMigration", () => {
+
+    test("versioned source without graph_scheme fails before activating target", async () => {
+        const capabilities = await getTestCapabilities();
+        const xStorage = makeSchemaStorage();
+        const yStorage = makeSchemaStorage();
+        const nodeKey = toJsonKey("A");
+        const value = { type: "all_events", events: [] };
+
+        await xStorage.values.put(nodeKey, value);
+        await xStorage.freshness.put(nodeKey, "up-to-date");
+        await xStorage.global.put("version", "1.0.0");
+        await xStorage.global.put(IDENTIFIERS_KEY, [[nodeKey, nodeKey]]);
+
+        const mock = makeRootDatabaseMock({
+            prevVersion: "1.0.0",
+            currentVersion: "2.0.0",
+            xStorage,
+            yStorage,
+        });
+        const nodeDefs = [{
+            output: "A",
+            inputs: [],
+            computor: async () => value,
+            isDeterministic: true,
+            hasSideEffects: false,
+        }];
+
+        let caught;
+        try {
+            await runMigration(capabilities, mock.rootDatabase, nodeDefs, async (storage) => {
+                await storage.keep(nodeKey);
+            });
+        } catch (error) {
+            caught = error;
+        }
+
+        expect(caught).toBeDefined();
+        expect(String(caught && caught.message)).toContain("global/graph_scheme");
+        expect(isMissingGraphSchemeError(caught)).toBe(true);
+        expect(mock.setCurrentReplicaPointerCalled).toBe(false);
+        expect(mock.setCurrentReplicaPointerCalledWith).toBeUndefined();
+        expect(await yStorage.global.get("version")).toBeUndefined();
+    });
     test("invalidate preserves counters from previous storage", async () => {
         const capabilities = await getTestCapabilities();
         const previousStorage = makeSchemaStorage();
@@ -315,6 +328,7 @@ describe("runMigration", () => {
             hasSideEffects: false,
         }];
 
+        await seedGraphScheme(previousStorage, nodeDefs);
         await runMigration(capabilities, rootDatabase, nodeDefs, async (storage) => {
             await storage.invalidate(nodeKey);
         });
@@ -436,6 +450,7 @@ describe("runMigration", () => {
                 hasSideEffects: false,
             }];
 
+            await seedGraphScheme(xStorage, nodeDefs);
             await runMigration(capabilities, mock.rootDatabase, nodeDefs, async (storage) => {
                 await storage.keep(nodeKey);
             });
@@ -474,6 +489,7 @@ describe("runMigration", () => {
                 hasSideEffects: false,
             }];
 
+            await seedGraphScheme(xStorage, nodeDefs);
             await runMigration(capabilities, mock.rootDatabase, nodeDefs, async (storage) => {
                 await storage.keep(nodeKey);
             });
@@ -586,6 +602,7 @@ describe("runMigration", () => {
             ];
             // valid[A] = [B] is set above, so auto-generation from valid handles this test.
 
+            await seedGraphScheme(xStorage, nodeDefs);
             await runMigration(capabilities, mock.rootDatabase, nodeDefs, async (storage) => {
                 await storage.keep(aKey);
                 await storage.keep(bKey);
@@ -691,6 +708,7 @@ describe("runMigration", () => {
                 hasSideEffects: false,
             }];
 
+            await seedGraphScheme(xStorage, nodeDefs);
             await runMigration(capabilities, rootDatabase, nodeDefs, async (storage) => {
                 await storage.keep(nodeKey);
             });
@@ -731,6 +749,7 @@ describe("runMigration", () => {
                 hasSideEffects: false,
             }];
 
+            await seedGraphScheme(previousStorage, nodeDefs);
             await runMigration(capabilities, mock.rootDatabase, nodeDefs, async (storage) => {
                 await storage.keep(nodeKey);
             });
@@ -743,6 +762,7 @@ describe("runMigration", () => {
             const { rootDatabase, nodeDefs, nodeKey, xStorage } = makeSimpleMigrationSetup();
             await xStorage.values.put(nodeKey, { type: "all_events", events: [] });
 
+            await seedGraphScheme(xStorage, nodeDefs);
             await runMigration(capabilities, rootDatabase, nodeDefs, async (storage) => {
                 await storage.keep(nodeKey);
             });
@@ -758,6 +778,7 @@ describe("runMigration", () => {
             });
             await xStorage.values.put(nodeKey, { type: "all_events", events: [] });
 
+            await seedGraphScheme(xStorage, nodeDefs);
             await runMigration(capabilities, rootDatabase, nodeDefs, async (storage) => {
                 await storage.keep(nodeKey);
             });
@@ -776,6 +797,7 @@ describe("runMigration", () => {
             });
             await xStorage.values.put(nodeKey, { type: "all_events", events: [] });
 
+            await seedGraphScheme(xStorage, nodeDefs);
             await runMigration(capabilities, rootDatabase, nodeDefs, async (storage) => {
                 await storage.keep(nodeKey);
             });
@@ -824,6 +846,7 @@ describe("runMigration", () => {
                 hasSideEffects: false,
             }];
 
+            await seedGraphScheme(xStorage, nodeDefs);
             await runMigration(capabilities, rootDatabase, nodeDefs, async (storage) => {
                 await storage.keep(nodeKey);
             });
@@ -873,6 +896,7 @@ describe("runMigration", () => {
                 hasSideEffects: false,
             }];
 
+            await seedGraphScheme(xStorage, nodeDefs);
             await runMigration(capabilities, rootDatabase, nodeDefs, async (storage) => {
                 await storage.keep(nodeKey);
             });
@@ -907,6 +931,7 @@ describe("runMigration", () => {
             }];
 
             const callbackError = new Error("callback failure");
+            await seedGraphScheme(xStorage, nodeDefs);
             await expect(
                 runMigration(capabilities, mock.rootDatabase, nodeDefs, async (_storage) => {
                     throw callbackError;
@@ -941,6 +966,7 @@ describe("runMigration", () => {
             // Callback runs but assigns no decision to node A
             let caughtError;
             try {
+                await seedGraphScheme(xStorage, nodeDefs);
                 await runMigration(capabilities, mock.rootDatabase, nodeDefs, async (_storage) => {
                     // intentionally leave A undecided
                 });
@@ -974,6 +1000,7 @@ describe("runMigration", () => {
                 hasSideEffects: false,
             }];
 
+            await seedGraphScheme(xStorage, nodeDefs);
             await expect(
                 runMigration(capabilities, mock.rootDatabase, nodeDefs, async () => {
                     throw new Error("intentional failure");
@@ -995,6 +1022,7 @@ describe("runMigration", () => {
                 callOrder.push(`checkpoint:${postMessage}`);
             });
 
+            await seedGraphScheme(xStorage, nodeDefs);
             await expect(
                 runMigration(capabilities, rootDatabase, nodeDefs, async () => {
                     throw new Error("intentional failure");
@@ -1018,6 +1046,7 @@ describe("runMigration", () => {
             });
 
             // Callback runs but assigns no decision → finalize throws UndecidedNodesError
+            await seedGraphScheme(xStorage, nodeDefs);
             await expect(
                 runMigration(capabilities, rootDatabase, nodeDefs, async (_storage) => {
                     // intentionally leave the node undecided
@@ -1130,6 +1159,7 @@ describe("x-namespace state preserved on migration failure", () => {
         const xStorage = makeSchemaStorage();
         const nodeKey = toJsonKey("A");
         await populateNode(xStorage, nodeKey, { counter: 42, freshness: "up-to-date" });
+        await seedSingleAGraphScheme(xStorage);
 
         const { yStorage } = makeYDb(makeSchemaStorage());
         const { rootDatabase } = makeRootDatabaseMock({ prevVersion: "1", currentVersion: "2", xStorage, yStorage });
@@ -1148,6 +1178,7 @@ describe("x-namespace state preserved on migration failure", () => {
         const xStorage = makeSchemaStorage();
         const nodeKey = toJsonKey("A");
         await populateNode(xStorage, nodeKey, { counter: 11 });
+        await seedSingleAGraphScheme(xStorage);
 
         const { yStorage } = makeYDb(makeSchemaStorage());
         const { rootDatabase } = makeRootDatabaseMock({ prevVersion: "1", currentVersion: "2", xStorage, yStorage });
@@ -1169,6 +1200,7 @@ describe("x-namespace state preserved on migration failure", () => {
         const nkB = toJsonKey("B");
         await populateNode(xStorage, nkA, { counter: 5 });
         await populateNode(xStorage, nkB, { counter: 9, freshness: "potentially-outdated" });
+        await seedGraphScheme(xStorage, makeTwoNodeDefs());
 
         const { yStorage } = makeYDb(makeSchemaStorage());
         const { rootDatabase } = makeRootDatabaseMock({ prevVersion: "v1", currentVersion: "v2", xStorage, yStorage });
@@ -1177,6 +1209,7 @@ describe("x-namespace state preserved on migration failure", () => {
         // Callback only decides A, leaves B undecided → UndecidedNodesError
         let caughtUndecided;
         try {
+            await seedGraphScheme(xStorage, makeTwoNodeDefs());
             await runMigration(capabilities, rootDatabase, makeTwoNodeDefs(), async (storage) => {
                 await storage.keep(nkA);
                 // B intentionally left undecided
@@ -1200,6 +1233,7 @@ describe("x-namespace state preserved on migration failure", () => {
         // Delete only A but keep B → fan-in violation on C
         let caughtFanIn;
         try {
+            await seedGraphScheme(xStorage, makeFanInNodeDefs());
             await runMigration(capabilities, rootDatabase, makeFanInNodeDefs(), async (storage) => {
                 await storage.delete(nkA);
                 await storage.keep(nkB);
@@ -1216,6 +1250,7 @@ describe("x-namespace state preserved on migration failure", () => {
         const xStorage = makeSchemaStorage();
         const nodeKey = toJsonKey("A");
         await populateNode(xStorage, nodeKey, { counter: 3 });
+        await seedSingleAGraphScheme(xStorage);
 
         const { yStorage } = makeYDb(makeSchemaStorage());
         const { rootDatabase } = makeRootDatabaseMock({ prevVersion: "1", currentVersion: "2", xStorage, yStorage });
@@ -1240,6 +1275,7 @@ describe("x-namespace state preserved on migration failure", () => {
         const xStorage = makeSchemaStorage();
         const nodeKey = toJsonKey("A");
         await populateNode(xStorage, nodeKey, { counter: 99 });
+        await seedSingleAGraphScheme(xStorage);
         const snapshotBefore = await captureStorageSnapshot(xStorage);
 
         // Build a yStorage whose noFlushPut throws on all sublevels
@@ -1266,6 +1302,7 @@ describe("x-namespace state preserved on migration failure", () => {
         const xStorage = makeSchemaStorage();
         const nodeKey = toJsonKey("A");
         await populateNode(xStorage, nodeKey, { counter: 7 });
+        await seedSingleAGraphScheme(xStorage);
         const snapshotBefore = await captureStorageSnapshot(xStorage);
 
         const globalWriteError = new Error("global noFlushPut failure");
@@ -1294,6 +1331,7 @@ describe("x-namespace state preserved on migration failure", () => {
         const xStorage = makeSchemaStorage();
         const nodeKey = toJsonKey("A");
         await populateNode(xStorage, nodeKey, { counter: 2 });
+        await seedSingleAGraphScheme(xStorage);
         const snapshotBefore = await captureStorageSnapshot(xStorage);
 
         const swapError = new Error("swap failed");
@@ -1340,6 +1378,7 @@ describe("x-namespace state preserved on migration failure", () => {
         // Only decide A; B is left undecided
         let caughtUndecided2;
         try {
+            await seedGraphScheme(xStorage, makeTwoNodeDefs());
             await runMigration(capabilities, rootDatabase, makeTwoNodeDefs(), async (storage) => {
                 await storage.keep(nkA);
             });
@@ -1359,6 +1398,7 @@ describe("x-namespace state preserved on migration failure", () => {
         const { yStorage } = makeYDb(makeSchemaStorage());
         const { rootDatabase } = makeRootDatabaseMock({ prevVersion: "v1", currentVersion: "v2", xStorage, yStorage });
 
+        await seedGraphScheme(xStorage, makeTwoNodeDefs());
         await expect(
             runMigration(capabilities, rootDatabase, makeTwoNodeDefs(), async (storage) => {
                 await storage.keep(nkA);
@@ -1383,6 +1423,7 @@ describe("x-namespace state preserved on migration failure", () => {
         const { yStorage } = makeYDb(makeSchemaStorage());
         const { rootDatabase } = makeRootDatabaseMock({ prevVersion: "v1", currentVersion: "v2", xStorage, yStorage });
 
+        await seedGraphScheme(xStorage, makeFanInNodeDefs());
         await expect(
             runMigration(capabilities, rootDatabase, makeFanInNodeDefs(), async (storage) => {
                 await storage.delete(nkA);
@@ -1524,6 +1565,7 @@ describe("migration validation", () => {
             { output: "B", inputs: ["A"], computor: async () => ({ type: "all_events", events: [] }), isDeterministic: true, hasSideEffects: false },
         ];
 
+        await seedGraphScheme(xStorage, nodeDefs);
         await runMigration(capabilities, mock.rootDatabase, nodeDefs, async (storage) => {
             await storage.keep(aKey);
             await storage.keep(bKey);
@@ -1562,6 +1604,7 @@ describe("migration validation", () => {
 
         let caughtError;
         try {
+            await seedGraphScheme(xStorage, nodeDefs);
             await runMigration(capabilities, mock.rootDatabase, nodeDefs, async (storage) => {
                 await storage.keep(nodeKey);
             });
@@ -1585,6 +1628,7 @@ describe("x.setGlobalVersion not called on migration failure", () => {
         const xStorage = makeSchemaStorage();
         const nodeKey = toJsonKey("A");
         await xStorage.values.put(nodeKey, { type: "all_events", events: [] });
+        await seedSingleAGraphScheme(xStorage);
 
         const { yStorage } = makeYDb(makeSchemaStorage());
         const mock = makeRootDatabaseMock({ prevVersion: "1", currentVersion: "2", xStorage, yStorage });
@@ -1602,6 +1646,7 @@ describe("x.setGlobalVersion not called on migration failure", () => {
         const xStorage = makeSchemaStorage();
         const nodeKey = toJsonKey("A");
         await xStorage.values.put(nodeKey, { type: "all_events", events: [] });
+        await seedSingleAGraphScheme(xStorage);
 
         const { yStorage } = makeYDb(makeSchemaStorage());
         const mock = makeRootDatabaseMock({ prevVersion: "1", currentVersion: "2", xStorage, yStorage });
@@ -1625,6 +1670,7 @@ describe("x.setGlobalVersion not called on migration failure", () => {
         const { yStorage } = makeYDb(makeSchemaStorage());
         const mock = makeRootDatabaseMock({ prevVersion: "v1", currentVersion: "v2", xStorage, yStorage });
 
+        await seedGraphScheme(xStorage, makeFanInNodeDefs());
         await expect(
             runMigration(capabilities, mock.rootDatabase, makeFanInNodeDefs(), async (storage) => {
                 await storage.delete(nkA);
@@ -1649,6 +1695,7 @@ describe("error identity: exact thrown object propagates", () => {
         const specificError = new Error("unique error " + Math.random());
         let caught;
         try {
+            await seedGraphScheme(xStorage, nodeDefs);
             await runMigration(capabilities, rootDatabase, nodeDefs, async () => {
                 throw specificError;
             });
@@ -1669,6 +1716,7 @@ describe("error identity: exact thrown object propagates", () => {
 
         let caught;
         try {
+            await seedGraphScheme(xStorage, nodeDefs);
             await runMigration(capabilities, rootDatabase, nodeDefs, async (storage) => {
                 await storage.keep(nodeKey);
             });
@@ -1685,13 +1733,16 @@ describe("error identity: exact thrown object propagates", () => {
         const nkA = toJsonKey("A");
         const nkB = toJsonKey("B");
         await populateNode(xStorage, nkA);
+        await seedSingleAGraphScheme(xStorage);
         await populateNode(xStorage, nkB);
+        await seedSingleAGraphScheme(xStorage);
 
         const { yStorage } = makeYDb(makeSchemaStorage());
         const { rootDatabase } = makeRootDatabaseMock({ prevVersion: "v1", currentVersion: "v2", xStorage, yStorage });
 
         let caught;
         try {
+            await seedGraphScheme(xStorage, makeTwoNodeDefs());
             await runMigration(capabilities, rootDatabase, makeTwoNodeDefs(), async (storage) => {
                 await storage.keep(nkA);
                 // B left undecided
@@ -1717,6 +1768,7 @@ describe("error identity: exact thrown object propagates", () => {
 
         let caught;
         try {
+            await seedGraphScheme(xStorage, makeFanInNodeDefs());
             await runMigration(capabilities, rootDatabase, makeFanInNodeDefs(), async (storage) => {
                 await storage.delete(nkA);
                 await storage.keep(nkB);
@@ -1733,6 +1785,7 @@ describe("error identity: exact thrown object propagates", () => {
         const xStorage = makeSchemaStorage();
         const nodeKey = toJsonKey("A");
         await populateNode(xStorage, nodeKey);
+        await seedSingleAGraphScheme(xStorage);
 
         const { yStorage } = makeYDb(makeSchemaStorage());
         const { rootDatabase } = makeRootDatabaseMock({ prevVersion: "1", currentVersion: "2", xStorage, yStorage });
@@ -1824,6 +1877,7 @@ describe("infrastructure failures", () => {
         };
 
         let callbackRan = false;
+        await seedSingleAGraphScheme(xStorage);
         await expect(
             runMigration(capabilities, rootDatabase, [{ output: "A", inputs: [], computor: async () => ({ type: "all_events", events: [] }), isDeterministic: true, hasSideEffects: false }],
                 async (storage) => { callbackRan = true; await storage.keep(nodeKey); })
@@ -1848,6 +1902,7 @@ describe("infrastructure failures", () => {
         const freshMock = makeRootDatabaseMock({ prevVersion: "1", currentVersion: "2", xStorage: freshXStorage, yStorage });
 
         let callbackRan = false;
+        await seedGraphScheme(xStorage, nodeDefs);
         await expect(
             runMigration(capabilities, freshMock.rootDatabase, nodeDefs, async (storage) => {
                 callbackRan = true;
@@ -1867,6 +1922,7 @@ describe("infrastructure failures", () => {
         const xStorage = makeSchemaStorage();
         const nodeKey = toJsonKey("A");
         await populateNode(xStorage, nodeKey, { counter: 55 });
+        await seedSingleAGraphScheme(xStorage);
         const snapshotBefore = await captureStorageSnapshot(xStorage);
 
         const { yStorage } = makeYDb(makeSchemaStorage());
@@ -1901,6 +1957,7 @@ describe("infrastructure failures", () => {
 
         let caught;
         try {
+            await seedGraphScheme(freshXStorage, nodeDefs);
             await runMigration(capabilities, freshMock.rootDatabase, nodeDefs, async (storage) => {
                 await storage.keep(nodeKey);
             });
@@ -1924,6 +1981,7 @@ describe("retry after failure", () => {
         const xStorage = makeSchemaStorage();
         const nodeKey = toJsonKey("A");
         await xStorage.values.put(nodeKey, { type: "all_events", events: [] });
+        await seedSingleAGraphScheme(xStorage);
 
         const { yStorage } = makeYDb(makeSchemaStorage());
         const mock = makeRootDatabaseMock({ prevVersion: "1", currentVersion: "2", xStorage, yStorage });
@@ -1954,6 +2012,8 @@ describe("retry after failure", () => {
 
         const nodeDef = { output: "A", inputs: [], computor: async () => ({ type: "all_events", events: [] }), isDeterministic: true, hasSideEffects: false };
 
+        await seedGraphScheme(xStorage, [nodeDef]);
+
         // First attempt: one checkpointMigration call, but it fails after the pre commit
         await expect(
             runMigration(capabilities, rootDatabase, [nodeDef], async () => { throw new Error("fail"); })
@@ -1983,6 +2043,7 @@ describe("retry after failure", () => {
         // First attempt: only decide A, B undecided → fail
         let caughtRetry;
         try {
+            await seedGraphScheme(xStorage, makeTwoNodeDefs());
             await runMigration(capabilities, mock.rootDatabase, makeTwoNodeDefs(), async (storage) => {
                 await storage.keep(nkA);
                 // B left undecided
@@ -1993,6 +2054,7 @@ describe("retry after failure", () => {
         expect(mock.setCurrentReplicaPointerCalled).toBe(false);
 
         // Second attempt: correct, decides both nodes
+        await seedGraphScheme(xStorage, makeTwoNodeDefs());
         await runMigration(capabilities, mock.rootDatabase, makeTwoNodeDefs(), async (storage) => {
             await storage.keep(nkA);
             await storage.keep(nkB);

--- a/backend/tests/migration_runner_timestamps.test.js
+++ b/backend/tests/migration_runner_timestamps.test.js
@@ -7,12 +7,13 @@
  */
 
 const { runMigration } = require("../src/generators/incremental_graph/migration_runner");
+const { compileNodeDef } = require("../src/generators/incremental_graph/compiled_node");
 const {
     IDENTIFIERS_KEY,
     GRAPH_SCHEME_KEY,
     nodeIdentifierToString,
-    nodeNameToString,
-    deserializeNodeKey,
+    buildGraphSchemeFromNodeDefs,
+    serializeGraphScheme,
 } = require("../src/generators/incremental_graph/database");
 const { toJsonKey } = require("./test_json_key_helper");
 const { getMockedRootCapabilities } = require("./spies");
@@ -85,53 +86,8 @@ function makeSchemaStorage() {
     const counters = makeInMemoryDb("counters");
     const timestamps = makeInMemoryDb("timestamps");
 
-    // Tests use simplified mocks where the "NodeIdentifier" string is the same
-    // as the semantic node key JSON string. When identifiers_keys_map is not
-    // explicitly seeded, fall back to an identity mapping derived from the
-    // currently materialized values keys.
-    // When graph_scheme is not explicitly seeded, auto-generate from values + valid.
     const originalGlobalGet = global.get.bind(global);
     global.get = async (key) => {
-        if (key === GRAPH_SCHEME_KEY) {
-            const stored = await originalGlobalGet(key);
-            if (stored !== undefined) return stored;
-            // Build scheme from materialized node keys and the valid sublevel.
-            const headArity = new Map();
-            for await (const k of values.keys()) {
-                try {
-                    const parsed = deserializeNodeKey(k);
-                    const head = nodeNameToString(parsed.head);
-                    if (!headArity.has(head)) {
-                        headArity.set(head, parsed.args.length);
-                    }
-                } catch { /* skip unparseable keys */ }
-            }
-            // valid[D] = [N1, N2, ...] means N1 and N2 list D as a dependency.
-            const depMap = new Map();
-            for await (const depId of valid.keys()) {
-                const dependents = await valid.get(depId) ?? [];
-                for (const dep of dependents) {
-                    try {
-                        const depParsed = deserializeNodeKey(dep);
-                        const depHead = nodeNameToString(depParsed.head);
-                        const depDeps = depMap.get(depHead) ?? new Set();
-                        const depIdParsed = deserializeNodeKey(depId);
-                        depDeps.add(nodeNameToString(depIdParsed.head));
-                        depMap.set(depHead, depDeps);
-                    } catch { /* skip unparseable keys */ }
-                }
-            }
-            const nodes = [...headArity.entries()]
-                .sort(([a], [b]) => a.localeCompare(b))
-                .map(([head, arity]) => {
-                    const deps = depMap.get(head);
-                    const inputTemplates = deps
-                        ? [...deps].sort().map(dh => ({ head: dh, args: [] }))
-                        : [];
-                    return { head, arity, inputTemplates };
-                });
-            return JSON.stringify({ format: 1, nodes });
-        }
         if (key !== IDENTIFIERS_KEY) {
             return await originalGlobalGet(key);
         }
@@ -234,6 +190,18 @@ async function seedNode(storage, nodeKey, {
     }
 }
 
+
+/**
+ * Seed the stored graph scheme required by versioned migration sources.
+ * @param {ReturnType<typeof makeSchemaStorage>} storage
+ * @param {ReturnType<typeof makeNodeDefs>} nodeDefs
+ */
+async function seedGraphScheme(storage, nodeDefs) {
+    const compiledNodes = nodeDefs.map(compileNodeDef);
+    const scheme = serializeGraphScheme(buildGraphSchemeFromNodeDefs(compiledNodes));
+    await storage.global.put(GRAPH_SCHEME_KEY, JSON.stringify(scheme));
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // keep decision copies timestamps
 // ─────────────────────────────────────────────────────────────────────────────
@@ -250,6 +218,7 @@ describe("keep decision: timestamps copied to new storage", () => {
             prevVersion: "1", currentVersion: "2", xStorage, yStorage,
         });
 
+        await seedGraphScheme(xStorage, makeNodeDefs(["A"]));
         await runMigration(capabilities, rootDatabase, makeNodeDefs(["A"]), async (storage) => {
             await storage.keep(nodeKey);
         });
@@ -268,6 +237,7 @@ describe("keep decision: timestamps copied to new storage", () => {
             prevVersion: "1", currentVersion: "2", xStorage, yStorage,
         });
 
+        await seedGraphScheme(xStorage, makeNodeDefs(["A"]));
         await runMigration(capabilities, rootDatabase, makeNodeDefs(["A"]), async (storage) => {
             await storage.keep(nodeKey);
         });
@@ -287,6 +257,7 @@ describe("keep decision: timestamps copied to new storage", () => {
             prevVersion: "1", currentVersion: "2", xStorage, yStorage,
         });
 
+        await seedGraphScheme(xStorage, makeNodeDefs(["A"]));
         await runMigration(capabilities, rootDatabase, makeNodeDefs(["A"]), async (storage) => {
             await storage.keep(nodeKey);
         });
@@ -306,6 +277,7 @@ describe("keep decision: timestamps copied to new storage", () => {
             prevVersion: "1", currentVersion: "2", xStorage, yStorage,
         });
 
+        await seedGraphScheme(xStorage, makeNodeDefs(["A"]));
         await runMigration(capabilities, rootDatabase, makeNodeDefs(["A"]), async (storage) => {
             await storage.keep(nodeKey);
         });
@@ -330,6 +302,7 @@ describe("keep decision: timestamps copied to new storage", () => {
             prevVersion: "1", currentVersion: "2", xStorage, yStorage,
         });
 
+        await seedGraphScheme(xStorage, makeNodeDefs(["A", "B"]));
         await runMigration(capabilities, rootDatabase, makeNodeDefs(["A", "B"]), async (storage) => {
             await storage.keep(nkA);
             await storage.keep(nkB);
@@ -356,6 +329,7 @@ describe("override decision: timestamps copied to new storage", () => {
             prevVersion: "1", currentVersion: "2", xStorage, yStorage,
         });
 
+        await seedGraphScheme(xStorage, makeNodeDefs(["A"]));
         await runMigration(capabilities, rootDatabase, makeNodeDefs(["A"]), async (storage) => {
             await storage.override(nodeKey, async () => ({ type: "all_events", events: [] }));
         });
@@ -374,6 +348,7 @@ describe("override decision: timestamps copied to new storage", () => {
             prevVersion: "1", currentVersion: "2", xStorage, yStorage,
         });
 
+        await seedGraphScheme(xStorage, makeNodeDefs(["A"]));
         await runMigration(capabilities, rootDatabase, makeNodeDefs(["A"]), async (storage) => {
             await storage.override(nodeKey, async () => ({ type: "all_events", events: [] }));
         });
@@ -393,6 +368,7 @@ describe("override decision: timestamps copied to new storage", () => {
             prevVersion: "1", currentVersion: "2", xStorage, yStorage,
         });
 
+        await seedGraphScheme(xStorage, makeNodeDefs(["A"]));
         await runMigration(capabilities, rootDatabase, makeNodeDefs(["A"]), async (storage) => {
             await storage.override(nodeKey, async () => ({ type: "all_events", events: [] }));
         });
@@ -417,6 +393,7 @@ describe("create decision: timestamps written to new storage", () => {
             prevVersion: "1", currentVersion: "2", xStorage, yStorage,
         });
 
+        await seedGraphScheme(xStorage, makeNodeDefs(["A"]));
         await runMigration(capabilities, rootDatabase, makeNodeDefs(["A"]), async (storage) => {
             await storage.create(nodeKey, async () => ({ type: "all_events", events: [] }));
         });
@@ -443,6 +420,7 @@ describe("create decision: timestamps written to new storage", () => {
             prevVersion: "1", currentVersion: "2", xStorage, yStorage,
         });
 
+        await seedGraphScheme(xStorage, makeNodeDefs(["A"]));
         await runMigration(capabilities, rootDatabase, makeNodeDefs(["A"]), async (storage) => {
             await storage.create(nodeKey, async () => ({ type: "all_events", events: [] }));
         });
@@ -464,6 +442,7 @@ describe("create decision: timestamps written to new storage", () => {
             prevVersion: "1", currentVersion: "2", xStorage, yStorage,
         });
 
+        await seedGraphScheme(xStorage, makeNodeDefs(["A", "B"]));
         await runMigration(capabilities, rootDatabase, makeNodeDefs(["A", "B"]), async (storage) => {
             await storage.create(nkA, async () => ({ type: "all_events", events: [] }));
             await storage.create(nkB, async () => ({ type: "all_events", events: [] }));
@@ -494,6 +473,7 @@ describe("invalidate decision: timestamps copied to new storage", () => {
             prevVersion: "1", currentVersion: "2", xStorage, yStorage,
         });
 
+        await seedGraphScheme(xStorage, makeNodeDefs(["A"]));
         await runMigration(capabilities, rootDatabase, makeNodeDefs(["A"]), async (storage) => {
             await storage.invalidate(nodeKey);
         });
@@ -512,6 +492,7 @@ describe("invalidate decision: timestamps copied to new storage", () => {
             prevVersion: "1", currentVersion: "2", xStorage, yStorage,
         });
 
+        await seedGraphScheme(xStorage, makeNodeDefs(["A"]));
         await runMigration(capabilities, rootDatabase, makeNodeDefs(["A"]), async (storage) => {
             await storage.invalidate(nodeKey);
         });
@@ -531,6 +512,7 @@ describe("invalidate decision: timestamps copied to new storage", () => {
             prevVersion: "1", currentVersion: "2", xStorage, yStorage,
         });
 
+        await seedGraphScheme(xStorage, makeNodeDefs(["A"]));
         await runMigration(capabilities, rootDatabase, makeNodeDefs(["A"]), async (storage) => {
             await storage.invalidate(nodeKey);
         });
@@ -563,6 +545,7 @@ describe("delete decision: timestamps not present in new storage", () => {
         });
 
         // Deleting both; B auto-deleted because A is deleted (fan-out propagation)
+        await seedGraphScheme(xStorage, makeNodeDefs(["A", "B"]));
         await runMigration(capabilities, rootDatabase, makeNodeDefs(["A", "B"]), async (storage) => {
             await storage.delete(nkA);
             await storage.delete(nkB);
@@ -602,6 +585,7 @@ describe("delete decision: sublevels do not retain deleted keys", () => {
             yStorage,
         });
 
+        await seedGraphScheme(xStorage, makeNodeDefs(["A", "B"]));
         await runMigration(capabilities, rootDatabase, makeNodeDefs(["A", "B"]), async (storage) => {
             await storage.delete(nkA);
             await storage.delete(nkB);
@@ -642,6 +626,7 @@ describe("two-node chain: mixed decision timestamp behaviour", () => {
         const { nkA, nkB } = await buildChain(xStorage);
         const { rootDatabase } = makeRootDatabaseMock({ prevVersion: "1", currentVersion: "2", xStorage, yStorage });
 
+        await seedGraphScheme(xStorage, makeNodeDefs(["A", "B"]));
         await runMigration(capabilities, rootDatabase, makeNodeDefs(["A", "B"]), async (storage) => {
             await storage.keep(nkA);
             await storage.keep(nkB);
@@ -658,6 +643,7 @@ describe("two-node chain: mixed decision timestamp behaviour", () => {
         const { nkA, nkB } = await buildChain(xStorage);
         const { rootDatabase } = makeRootDatabaseMock({ prevVersion: "1", currentVersion: "2", xStorage, yStorage });
 
+        await seedGraphScheme(xStorage, makeNodeDefs(["A", "B"]));
         await runMigration(capabilities, rootDatabase, makeNodeDefs(["A", "B"]), async (storage) => {
             await storage.keep(nkA);
             await storage.invalidate(nkB);
@@ -674,6 +660,7 @@ describe("two-node chain: mixed decision timestamp behaviour", () => {
         const { nkA, nkB } = await buildChain(xStorage);
         const { rootDatabase } = makeRootDatabaseMock({ prevVersion: "1", currentVersion: "2", xStorage, yStorage });
 
+        await seedGraphScheme(xStorage, makeNodeDefs(["A", "B"]));
         await runMigration(capabilities, rootDatabase, makeNodeDefs(["A", "B"]), async (storage) => {
             await storage.keep(nkA);
             await storage.override(nkB, async () => ({ type: "all_events", events: [] }));
@@ -692,6 +679,7 @@ describe("two-node chain: mixed decision timestamp behaviour", () => {
         const { rootDatabase } = makeRootDatabaseMock({ prevVersion: "1", currentVersion: "2", xStorage, yStorage });
 
         // Override A; B is automatically invalidated (it depends on A)
+        await seedGraphScheme(xStorage, makeNodeDefs(["A", "B"]));
         await runMigration(capabilities, rootDatabase, makeNodeDefs(["A", "B"]), async (storage) => {
             await storage.override(nkA, async () => ({ type: "all_events", events: [] }));
             // nkB is auto-invalidated by override(nkA)
@@ -708,6 +696,7 @@ describe("two-node chain: mixed decision timestamp behaviour", () => {
         const { nkA, nkB } = await buildChain(xStorage);
         const { rootDatabase } = makeRootDatabaseMock({ prevVersion: "1", currentVersion: "2", xStorage, yStorage });
 
+        await seedGraphScheme(xStorage, makeNodeDefs(["A", "B"]));
         await runMigration(capabilities, rootDatabase, makeNodeDefs(["A", "B"]), async (storage) => {
             await storage.invalidate(nkA);
             await storage.invalidate(nkB);
@@ -732,6 +721,7 @@ describe("failed migration: x-namespace timestamps unchanged", () => {
         await seedNode(xStorage, nodeKey, { timestamps: OLD_TIMESTAMP });
         const { rootDatabase } = makeRootDatabaseMock({ prevVersion: "1", currentVersion: "2", xStorage, yStorage });
 
+        await seedGraphScheme(xStorage, makeNodeDefs(["A"]));
         await expect(
             runMigration(capabilities, rootDatabase, makeNodeDefs(["A"]), async () => {
                 throw new Error("boom");
@@ -752,6 +742,7 @@ describe("failed migration: x-namespace timestamps unchanged", () => {
         await seedNode(xStorage, nkB, { timestamps: NEW_TIMESTAMP });
         const { rootDatabase } = makeRootDatabaseMock({ prevVersion: "v1", currentVersion: "v2", xStorage, yStorage });
 
+        await seedGraphScheme(xStorage, makeNodeDefs(["A", "B"]));
         await expect(
             runMigration(capabilities, rootDatabase, makeNodeDefs(["A", "B"]), async (storage) => {
                 await storage.keep(nkA);

--- a/backend/tests/migration_storage.test.js
+++ b/backend/tests/migration_storage.test.js
@@ -84,26 +84,6 @@ function makeSingleNodeScheme(head) {
 }
 
 /**
- * Empty graph scheme for tests that do not exercise scheme-derived operations.
- * @type {import('../src/generators/incremental_graph/database/graph_scheme').GraphScheme}
- */
-const EMPTY_SCHEME = { format: 1, nodes: [] };
-
-/**
- * Empty identifier lookup for tests that do not exercise lookup-based operations.
- * @type {import('../src/generators/incremental_graph/database/identifier_lookup').IdentifierLookup}
- */
-const EMPTY_LOOKUP = { keyToId: new Map(), idToKey: new Map(), serialized: [] };
-
-/**
- * Create a MigrationStorage with empty scheme/lookup defaults.
- * Tests that need real schemes or lookups should call makeMigrationStorage directly.
- */
-function makeMs(storage, headIndex, materializedNodes) {
-    return makeMigrationStorage(storage, headIndex, materializedNodes, "testfingerprint", 0, EMPTY_SCHEME, EMPTY_SCHEME, EMPTY_LOOKUP);
-}
-
-/**
  * Build an identifier lookup mapping each NodeKeyString to itself.
  * @param {string[]} nodeKeyStrings
  * @returns {import('../src/generators/incremental_graph/database/identifier_lookup').IdentifierLookup}
@@ -213,7 +193,9 @@ describe("MigrationStorage", () => {
             const headIndex = makeHeadIndex(["A"]);
             const A = nk("A");
             await storage.values.put(A, DUMMY_VALUE);
-            const ms = makeMs(storage, headIndex, [A]);
+            const scheme = makeSingleNodeScheme("A");
+            const lookup = makeLookupFromKeys([A]);
+            const ms = makeMigrationStorage(storage, headIndex, [A], "testfingerprint", 0, scheme, scheme, lookup);
 
             await ms.invalidate(A);
             await expect(ms.invalidate(A)).resolves.toBeUndefined();
@@ -223,7 +205,9 @@ describe("MigrationStorage", () => {
             const storage = makeInMemorySchemaStorage();
             const headIndex = makeHeadIndex(["A"]);
             const A = nk("A");
-            const ms = makeMs(storage, headIndex, [A]);
+            const scheme = makeSingleNodeScheme("A");
+            const lookup = makeLookupFromKeys([A]);
+            const ms = makeMigrationStorage(storage, headIndex, [A], "testfingerprint", 0, scheme, scheme, lookup);
 
             await ms.delete(A);
             await expect(ms.delete(A)).resolves.toBeUndefined();
@@ -234,7 +218,9 @@ describe("MigrationStorage", () => {
             const headIndex = makeHeadIndex(["A"]);
             const A = nk("A");
             await storage.values.put(A, DUMMY_VALUE);
-            const ms = makeMs(storage, headIndex, [A]);
+            const scheme = makeSingleNodeScheme("A");
+            const lookup = makeLookupFromKeys([A]);
+            const ms = makeMigrationStorage(storage, headIndex, [A], "testfingerprint", 0, scheme, scheme, lookup);
 
             await ms.override(A, () => Promise.resolve(DUMMY_VALUE));
             const err = await ms.override(A, () => Promise.resolve(DUMMY_VALUE)).catch((e) => e);
@@ -246,7 +232,9 @@ describe("MigrationStorage", () => {
             const headIndex = makeHeadIndex(["A"]);
             const A = nk("A");
             await storage.values.put(A, DUMMY_VALUE);
-            const ms = makeMs(storage, headIndex, [A]);
+            const scheme = makeSingleNodeScheme("A");
+            const lookup = makeLookupFromKeys([A]);
+            const ms = makeMigrationStorage(storage, headIndex, [A], "testfingerprint", 0, scheme, scheme, lookup);
 
             await ms.override(A, () => Promise.resolve(DUMMY_VALUE));
             const err = await ms.override(A, () => Promise.resolve(DUMMY_VALUE_2)).catch((e) => e);
@@ -301,7 +289,9 @@ describe("MigrationStorage", () => {
             const storage = makeInMemorySchemaStorage();
             const headIndex = makeHeadIndex(["A"]);
             const A = nk("A"), B = nk("B");
-            const ms = makeMs(storage, headIndex, [A]);
+            const scheme = makeSingleNodeScheme("A");
+            const lookup = makeLookupFromKeys([A]);
+            const ms = makeMigrationStorage(storage, headIndex, [A], "testfingerprint", 0, scheme, scheme, lookup);
 
             const err = await ms.get(B).catch((e) => e);
             expect(isGetMissingNode(err)).toBe(true);
@@ -311,7 +301,9 @@ describe("MigrationStorage", () => {
             const storage = makeInMemorySchemaStorage();
             const headIndex = makeHeadIndex(["A"]);
             const A = nk("A");
-            const ms = makeMs(storage, headIndex, [A]);
+            const scheme = makeSingleNodeScheme("A");
+            const lookup = makeLookupFromKeys([A]);
+            const ms = makeMigrationStorage(storage, headIndex, [A], "testfingerprint", 0, scheme, scheme, lookup);
 
             const err = await ms.get(A).catch((e) => e);
             expect(isGetMissingValue(err)).toBe(true);
@@ -322,7 +314,9 @@ describe("MigrationStorage", () => {
             const headIndex = makeHeadIndex(["A"]);
             const A = nk("A");
             await storage.values.put(A, DUMMY_VALUE);
-            const ms = makeMs(storage, headIndex, [A]);
+            const scheme = makeSingleNodeScheme("A");
+            const lookup = makeLookupFromKeys([A]);
+            const ms = makeMigrationStorage(storage, headIndex, [A], "testfingerprint", 0, scheme, scheme, lookup);
 
             const result = await ms.get(A);
             expect(result).toEqual(DUMMY_VALUE);
@@ -333,7 +327,9 @@ describe("MigrationStorage", () => {
             const headIndex = makeHeadIndex(["A"]);
             const A = nk("A");
             await storage.values.put(A, DUMMY_VALUE);
-            const ms = makeMs(storage, headIndex, [A]);
+            const scheme = makeSingleNodeScheme("A");
+            const lookup = makeLookupFromKeys([A]);
+            const ms = makeMigrationStorage(storage, headIndex, [A], "testfingerprint", 0, scheme, scheme, lookup);
 
             await ms.override(A, () => Promise.resolve(DUMMY_VALUE_2));
             const result = await ms.get(A);
@@ -581,7 +577,9 @@ describe("MigrationStorage", () => {
             const storage = makeInMemorySchemaStorage();
             const headIndex = makeHeadIndex(["A"]);
             const A = nk("A");
-            const ms = makeMs(storage, headIndex, [A]);
+            const scheme = makeSingleNodeScheme("A");
+            const lookup = makeLookupFromKeys([A]);
+            const ms = makeMigrationStorage(storage, headIndex, [A], "testfingerprint", 0, scheme, scheme, lookup);
 
             expect(await ms.has(A)).toBe(true);
             expect(await ms.has(nk("Z"))).toBe(false);
@@ -721,7 +719,9 @@ describe("MigrationStorage", () => {
             const storage = makeInMemorySchemaStorage();
             const headIndex = makeHeadIndex(["A", "B"]);
             const A = nk("A");
-            const ms = makeMs(storage, headIndex, [A]);
+            const scheme = makeSingleNodeScheme("A");
+            const lookup = makeLookupFromKeys([A]);
+            const ms = makeMigrationStorage(storage, headIndex, [A], "testfingerprint", 0, scheme, scheme, lookup);
 
             const err = await ms.create(nk("NONEXISTENT"), () => Promise.resolve(DUMMY_VALUE)).catch((e) => e);
             expect(isSchemaCompatibility(err)).toBe(true);
@@ -732,7 +732,9 @@ describe("MigrationStorage", () => {
             // "event(e)" has arity 1
             const headIndex = makeHeadIndex(["A", "event(e)"]);
             const A = nk("A");
-            const ms = makeMs(storage, headIndex, [A]);
+            const scheme = makeSingleNodeScheme("A");
+            const lookup = makeLookupFromKeys([A]);
+            const ms = makeMigrationStorage(storage, headIndex, [A], "testfingerprint", 0, scheme, scheme, lookup);
 
             // nk("event") produces arity 0 — mismatch with schema arity 1
             const err = await ms.create(nk("event"), () => Promise.resolve(DUMMY_VALUE)).catch((e) => e);
@@ -743,7 +745,9 @@ describe("MigrationStorage", () => {
             const storage = makeInMemorySchemaStorage();
             const headIndex = makeHeadIndex(["A"]);
             const A = nk("A");
-            const ms = makeMs(storage, headIndex, [A]);
+            const scheme = makeSingleNodeScheme("A");
+            const lookup = makeLookupFromKeys([A]);
+            const ms = makeMigrationStorage(storage, headIndex, [A], "testfingerprint", 0, scheme, scheme, lookup);
 
             const { stringToNodeKeyString } = require("../src/generators/incremental_graph/database");
             const malformedKey = stringToNodeKeyString("not valid json");
@@ -774,7 +778,9 @@ describe("MigrationStorage", () => {
             const headIndex = makeHeadIndex(["A"]);
             const A = nk("A");
             await storage.values.put(A, DUMMY_VALUE);
-            const ms = makeMs(storage, headIndex, [A]);
+            const scheme = makeSingleNodeScheme("A");
+            const lookup = makeLookupFromKeys([A]);
+            const ms = makeMigrationStorage(storage, headIndex, [A], "testfingerprint", 0, scheme, scheme, lookup);
 
             const err = await ms.create(A, () => Promise.resolve(DUMMY_VALUE)).catch((e) => e);
             expect(isCreateExistingNode(err)).toBe(true);
@@ -1030,7 +1036,9 @@ describe("MigrationStorage", () => {
             const headIndex = makeHeadIndex(["A"]);
             const A = nk("A");
             await storage.values.put(A, DUMMY_VALUE);
-            const ms = makeMs(storage, headIndex, [A]);
+            const scheme = makeSingleNodeScheme("A");
+            const lookup = makeLookupFromKeys([A]);
+            const ms = makeMigrationStorage(storage, headIndex, [A], "testfingerprint", 0, scheme, scheme, lookup);
 
             // Pass a function that returns a promise that never resolves; override() should return immediately
             const neverResolves = () => new Promise(() => {});

--- a/backend/tests/regression_cleanup.test.js
+++ b/backend/tests/regression_cleanup.test.js
@@ -4,68 +4,117 @@
  * reappear in backend, docs, or scripts.
  */
 
+const fs = require('fs');
+const path = require('path');
 const { execSync } = require('child_process');
 
 const ROOT = execSync('git rev-parse --show-toplevel', { encoding: 'utf-8' }).trim();
+const SEARCH_PATHS = ['backend/src', 'backend/tests', 'docs', 'scripts'];
+const SKIPPED_DIRS = new Set(['node_modules', 'fixtures', 'rendered', 'dist', 'build', 'coverage']);
 
-const EXCLUDE_GLOB = '--exclude=regression_cleanup.test.js';
+/**
+ * @typedef {object} PatternMatch
+ * @property {string} filePath
+ * @property {number} lineNumber
+ * @property {string} line
+ * @property {string} patternName
+ */
 
-function grepCount(pattern, paths) {
-    try {
-        const result = execSync(
-            `grep -rn ${EXCLUDE_GLOB} "${pattern}" ${paths.join(' ')} 2>/dev/null | wc -l`,
-            { encoding: 'utf-8', cwd: ROOT }
-        );
-        return parseInt(result.trim(), 10);
-    } catch {
-        return 0;
+/**
+ * @param {string} filePath
+ * @returns {boolean}
+ */
+function isTextFile(filePath) {
+    const extension = path.extname(filePath);
+    if (extension === '') return true;
+    return new Set(['.js', '.json', '.md', '.txt', '.sh', '.yml', '.yaml', '.html', '.css']).has(extension);
+}
+
+/**
+ * @param {string} relativePath
+ * @returns {string[]}
+ */
+function collectTextFiles(relativePath) {
+    const absolutePath = path.join(ROOT, relativePath);
+    if (!fs.existsSync(absolutePath)) return [];
+    const stat = fs.statSync(absolutePath);
+    if (stat.isFile()) return isTextFile(absolutePath) ? [relativePath] : [];
+
+    const files = [];
+    for (const entry of fs.readdirSync(absolutePath, { withFileTypes: true })) {
+        if (entry.isDirectory() && SKIPPED_DIRS.has(entry.name)) continue;
+        files.push(...collectTextFiles(path.join(relativePath, entry.name)));
     }
+    return files;
+}
+
+/**
+ * @param {{ name: string, regex: RegExp }} pattern
+ * @param {string[]} searchPaths
+ * @returns {PatternMatch[]}
+ */
+function findMatches(pattern, searchPaths) {
+    const matches = [];
+    const files = searchPaths.flatMap(collectTextFiles);
+    for (const filePath of files) {
+        if (filePath === 'backend/tests/regression_cleanup.test.js') continue;
+        const content = fs.readFileSync(path.join(ROOT, filePath), 'utf-8');
+        const lines = content.split(/\r?\n/u);
+        for (let index = 0; index < lines.length; index += 1) {
+            pattern.regex.lastIndex = 0;
+            if (pattern.regex.test(lines[index])) {
+                matches.push({
+                    filePath,
+                    lineNumber: index + 1,
+                    line: lines[index],
+                    patternName: pattern.name,
+                });
+            }
+        }
+    }
+    return matches;
+}
+
+/**
+ * @param {PatternMatch[]} matches
+ * @returns {string}
+ */
+function formatMatches(matches) {
+    return matches
+        .map((match) => `${match.filePath}:${match.lineNumber} ${match.patternName}: ${match.line.trim()}`)
+        .join('\n');
 }
 
 describe('regression: banned terminology', () => {
-    const SEARCH_PATHS = ['backend/src', 'backend/tests', 'docs', 'scripts'];
-
     const BANNED_PATTERNS = [
-        'readInputRecord',
-        'input_record',
-        'inputsRecord',
-        'InputsRecord',
-        'inputCounters',
-        'inputs record',
-        'input record',
-        'ensureMaterialized',
+        { name: 'storage inputs API', regex: new RegExp('storage' + '\\.' + 'inputs', 'u') },
+        { name: 'batch inputs API', regex: new RegExp('batch' + '\\.' + 'inputs', 'u') },
+        { name: 'inputs get API', regex: new RegExp('\\.' + 'inputs' + '\\.' + 'get', 'u') },
+        { name: 'inputs put API', regex: new RegExp('\\.' + 'inputs' + '\\.' + 'put', 'u') },
+        { name: 'inputs keys API', regex: new RegExp('\\.' + 'inputs' + '\\.' + 'keys', 'u') },
+        { name: 'materialization compatibility helper', regex: new RegExp('ensure' + 'Materialized', 'u') },
+        { name: 'input compatibility getter', regex: new RegExp('get' + 'Inputs', 'u') },
+        { name: 'inputs database factory', regex: new RegExp("makeDatabase" + "\\([\"']" + "inputs" + "[\"']\\)", "u") },
+        { name: 'semantic batch inputs API', regex: new RegExp('semanticBatch' + '\\.' + 'inputs', 'u') },
+        { name: 'const-kind template argument', regex: new RegExp("kind:" + "\\s*" + "[\"']" + "const" + "[\"']", "u") },
+        { name: 'constant dependency argument', regex: new RegExp('constant ' + 'input(?: argument| edge| template| graph| record)?', 'iu') },
+        { name: 'const dependency argument', regex: new RegExp('const ' + 'input(?: argument| edge| template| graph| record)', 'iu') },
+        { name: 'graph scheme template arg type', regex: new RegExp('GraphScheme' + 'TemplateArg', 'u') },
+        { name: 'value based template wording', regex: new RegExp('value-based ' + 'template', 'u') },
+        { name: 'template arg object wording', regex: new RegExp('template arg ' + 'object', 'u') },
+        { name: 'record empty dependency stub', regex: /record = \[\]/u },
+        { name: 'depRecord empty dependency stub', regex: /depRecord = \[\]/u },
+        { name: 'storedInputEdges empty dependency stub', regex: /storedInputEdges = \[\]/u },
+        { name: 'persistedInputEdges empty dependency stub', regex: /persistedInputEdges = \[\]/u },
     ];
 
     for (const pattern of BANNED_PATTERNS) {
-        test(`banned pattern "${pattern}" must not appear in backend, docs, or scripts`, () => {
-            const count = grepCount(pattern, SEARCH_PATHS);
-            expect(count).toBe(0);
+        test(`banned pattern "${pattern.name}" must not appear in backend, docs, or scripts`, () => {
+            const matches = findMatches(pattern, SEARCH_PATHS);
+            if (matches.length !== 0) {
+                throw new Error(formatMatches(matches));
+            }
+            expect(matches).toHaveLength(0);
         });
     }
-
-    test('old object-shaped "{ inputs:" must not appear in stored inputs', () => {
-        const count = grepCount('\\{ *inputs *:', SEARCH_PATHS);
-        expect(count).toBe(0);
-    });
-
-    test('durable inputs sublevel access patterns must not appear in backend/src', () => {
-        for (const pattern of ['storage\\.inputs', 'batch\\.inputs', 'getInputs']) {
-            const count = grepCount(pattern, ['backend/src']);
-            expect(count).toBe(0);
-        }
-    });
-
-    test('graph_scheme constant-style template arg must not appear', () => {
-        // Only match { kind: "const" ... } or {kind:'const'...} patterns
-        const precise = execSync(
-            'grep -rn ' + EXCLUDE_GLOB + " 'kind.*\"const\"\\|kind.*\\x27const\\x27' backend/src backend/tests docs 2>/dev/null | grep -v fixtures | grep -v rendered | wc -l",
-            { encoding: 'utf-8', cwd: ROOT }
-        );
-        expect(parseInt(precise.trim(), 10)).toBe(0);
-    });
-
-    test('fake makeDatabase("inputs") must not appear in test helpers', () => {
-        const count = grepCount('makeDatabase.*inputs', ['backend/tests']);
-        expect(count).toBe(0);
-    });
 });

--- a/backend/tests/sync_merge.test.js
+++ b/backend/tests/sync_merge.test.js
@@ -79,7 +79,7 @@ const TS3 = '2024-01-01T00:00:09.000Z';
 /**
  * Write a node into storage with a modifiedAt timestamp.
  */
-async function writeNode(storage, nodeKey, modifiedAt, _inputKeys, valuePayload) {
+async function writeNode(storage, nodeKey, modifiedAt, valuePayload) {
     await storage.timestamps.put(nodeKey, { createdAt: modifiedAt, modifiedAt });
     await storage.freshness.put(nodeKey, 'up-to-date');
     await storage.values.put(nodeKey, valuePayload ?? {});
@@ -219,12 +219,12 @@ describe('mergeHostIntoReplica', () => {
 
             const L = db.schemaStorageForReplica('x');
             await writeGraphScheme(L);
-            await writeNode(L, nodeA, TS1, [], localValue);
+            await writeNode(L, nodeA, TS1, localValue);
             await writeIdentifierLookup(L, entriesForSameStringNodeKeys([nodeA]));
 
             const H = db.hostnameSchemaStorage(hostname);
             await writeGraphScheme(H);
-            await writeNode(H, nodeA, TS1, [], remoteValue);
+            await writeNode(H, nodeA, TS1, remoteValue);
             await writeIdentifierLookup(H, entriesForSameStringNodeKeys([nodeA]));
 
             db = await mergeAndReopenIfSwitched(capabilities, logger, db, hostname);
@@ -257,15 +257,14 @@ describe('mergeHostIntoReplica', () => {
             const remoteValue = { value: { id: 'remote', type: 'test', description: 'remote value' }, isDirty: false };
 
             const L = db.schemaStorageForReplica('x');
-            await writeNode(L, nodeA, TS1, [], localValue);
+            await writeNode(L, nodeA, TS1, localValue);
             await writeIdentifierLookup(L, entriesForSameStringNodeKeys([nodeA]));
             // Write stale validity flags to L before merge
             await L.valid.put(nodeA, [NODE_B]);
 
             const H = db.hostnameSchemaStorage(hostname);
             await writeGraphScheme(H);
-            await writeGraphScheme(H);
-            await writeNode(H, nodeA, TS2, [], remoteValue);
+            await writeNode(H, nodeA, TS2, remoteValue);
             await writeIdentifierLookup(H, entriesForSameStringNodeKeys([nodeA]));
 
             db = await mergeAndReopenIfSwitched(capabilities, logger, db, hostname);
@@ -306,13 +305,13 @@ describe('mergeHostIntoReplica', () => {
             const remoteValue = { value: { id: 'remote', type: 'test', description: 'remote value' }, isDirty: false };
 
             const L = db.schemaStorageForReplica('x');
-            await writeNode(L, nodeA, TS1, [], localValue);
+            await writeNode(L, nodeA, TS1, localValue);
             await writeIdentifierLookup(L, entriesForSameStringNodeKeys([nodeA]));
             // Write valid flags to L before merge
 
             const H = db.hostnameSchemaStorage(hostname);
             await writeGraphScheme(H);
-            await writeNode(H, nodeA, TS1, [], remoteValue);
+            await writeNode(H, nodeA, TS1, remoteValue);
             await writeIdentifierLookup(H, entriesForSameStringNodeKeys([nodeA]));
 
             db = await mergeAndReopenIfSwitched(capabilities, logger, db, hostname);
@@ -352,14 +351,14 @@ describe('mergeHostIntoReplica', () => {
             const parentKey = stringToNodeKeyString('{"head":"parent","args":[]}');
             const childKey = stringToNodeKeyString('{"head":"child","args":[]}');
             const L = db.schemaStorageForReplica('x');
-            await writeNode(L, targetParent, TS1, [], undefined);
-            await writeNode(L, targetChild, TS1, [targetParent], undefined);
+            await writeNode(L, targetParent, TS1, undefined);
+            await writeNode(L, targetChild, TS1, undefined);
             await writeIdentifierLookup(L, [[targetParent, parentKey], [targetChild, childKey]]);
 
             const H = db.hostnameSchemaStorage(hostname);
             await writeGraphScheme(H);
-            await writeNode(H, hostParent, TS1, [], undefined);
-            await writeNode(H, hostChild, TS2, [hostParent], undefined);
+            await writeNode(H, hostParent, TS1, undefined);
+            await writeNode(H, hostChild, TS2, undefined);
             await writeIdentifierLookup(H, [[hostParent, parentKey], [hostChild, childKey]]);
 
             expect(await mergeHostIntoReplica(logger, db, hostname)).toBe(true);
@@ -394,7 +393,7 @@ describe('mergeHostIntoReplica', () => {
 
             const H = db.hostnameSchemaStorage(hostname);
             await writeGraphScheme(H);
-            await writeNode(H, nodeA, TS1, [], remoteValue);
+            await writeNode(H, nodeA, TS1, remoteValue);
             const L = db.schemaStorageForReplica('x');
             await writeIdentifierLookup(L, []);
             await writeIdentifierLookup(H, entriesForSameStringNodeKeys([nodeA]));
@@ -438,15 +437,15 @@ describe('mergeHostIntoReplica', () => {
 
             const L = db.schemaStorageForReplica('x');
             // P: T has a strictly newer timestamp → force-keep
-            await writeNode(L, nodeP, TS3, [], localPValue);
+            await writeNode(L, nodeP, TS3, localPValue);
             await writeIdentifierLookup(L, [[nodeP, keyP]]);
 
             const H = db.hostnameSchemaStorage(hostname);
             await writeGraphScheme(H);
             // P in H is older
-            await writeNode(H, nodeP, TS1, [], undefined);
+            await writeNode(H, nodeP, TS1, undefined);
             // C is only in H; it depends on P (computed from H's stale P)
-            await writeNode(H, nodeC, TS2, [nodeP], remoteCValue);
+            await writeNode(H, nodeC, TS2, remoteCValue);
             await writeIdentifierLookup(H, [[nodeP, keyP], [nodeC, keyC]]);
 
             db = await mergeAndReopenIfSwitched(capabilities, logger, db, hostname);
@@ -556,16 +555,16 @@ describe('mergeHostIntoReplica', () => {
 
             const L = db.schemaStorageForReplica('x');
             // In T: A is force-kept (T-newer); B has no deps (independent of A).
-            await writeNode(L, nodeA, TS3, [], undefined);
-            await writeNode(L, nodeB, TS1, [], localValueB);
+            await writeNode(L, nodeA, TS3, undefined);
+            await writeNode(L, nodeB, TS1, localValueB);
             await L.counters.put(nodeB, 1);
             await writeIdentifierLookup(L, [[nodeA, keyA], [nodeB, keyB]]);
 
             const H = db.hostnameSchemaStorage(hostname);
             await writeGraphScheme(H);
             // In H: A is older; B is newer AND now depends on A.
-            await writeNode(H, nodeA, TS1, [], undefined);
-            await writeNode(H, nodeB, TS2, [nodeA], remoteValueB);
+            await writeNode(H, nodeA, TS1, undefined);
+            await writeNode(H, nodeB, TS2, remoteValueB);
             await H.counters.put(nodeB, 2);
             await writeIdentifierLookup(H, [[nodeA, keyA], [nodeB, keyB]]);
 
@@ -621,14 +620,14 @@ describe('mergeHostIntoReplica', () => {
             const remoteValueB = { value: { id: 'b-remote', type: 'test', description: 'remote B' }, isDirty: false };
 
             const L = db.schemaStorageForReplica('x');
-            await writeNode(L, nodeA, TS3, [], undefined);
-            await writeNode(L, nodeB, TS1, [], localValueB);
+            await writeNode(L, nodeA, TS3, undefined);
+            await writeNode(L, nodeB, TS1, localValueB);
             await writeIdentifierLookup(L, [[nodeA, keyA], [nodeB, keyB]]);
 
             const H = db.hostnameSchemaStorage(hostname);
             await writeGraphScheme(H);
-            await writeNode(H, nodeA, TS1, [], undefined);
-            await writeNode(H, nodeB, TS2, [nodeA], remoteValueB);
+            await writeNode(H, nodeA, TS1, undefined);
+            await writeNode(H, nodeB, TS2, remoteValueB);
             await writeIdentifierLookup(H, [[nodeA, keyA], [nodeB, keyB]]);
 
             // First merge: B is 'invalidate', modifiedAt advanced to TS2.
@@ -641,8 +640,8 @@ describe('mergeHostIntoReplica', () => {
             await db.setHostnameGlobal(hostname, 'version', appVersionStr);
             const H2 = db.hostnameSchemaStorage(hostname);
             await writeGraphScheme(H2);
-            await writeNode(H2, nodeA, TS1, [], undefined);
-            await writeNode(H2, nodeB, TS2, [nodeA], remoteValueB);
+            await writeNode(H2, nodeA, TS1, undefined);
+            await writeNode(H2, nodeB, TS2, remoteValueB);
             await writeIdentifierLookup(H2, [[nodeA, keyA], [nodeB, keyB]]);
 
             // Second merge: T.B.modifiedAt == H.B.modifiedAt == TS2 → B is 'keep'.
@@ -700,7 +699,7 @@ describe('mergeHostIntoReplica', () => {
             const remoteValue = { value: { id: 'a', type: 'test', description: 'a' }, isDirty: false };
             const H2 = db.hostnameSchemaStorage(hostname2);
             await writeGraphScheme(H2);
-            await writeNode(H2, nodeA, TS1, [], remoteValue);
+            await writeNode(H2, nodeA, TS1, remoteValue);
             await writeIdentifierLookup(H2, entriesForSameStringNodeKeys([nodeA]));
 
             // Should NOT throw HostVersionMismatchError even though the first
@@ -735,7 +734,7 @@ describe('mergeHostIntoReplica', () => {
             const remoteValue = { value: { id: 'remote', type: 'test', description: 'remote value' }, isDirty: false };
             const H = db.hostnameSchemaStorage(hostname);
             await writeGraphScheme(H);
-            await writeNode(H, nodeA, TS2, [], remoteValue);
+            await writeNode(H, nodeA, TS2, remoteValue);
             const L = db.schemaStorageForReplica('x');
             await writeIdentifierLookup(L, entriesForSameStringNodeKeys([nodeA]));
             await writeIdentifierLookup(H, entriesForSameStringNodeKeys([nodeA]));
@@ -805,7 +804,7 @@ describe('mergeHostIntoReplica', () => {
             const remoteValue = { value: { id: 'remote', type: 'test', description: 'remote value' }, isDirty: false };
             const H = db.hostnameSchemaStorage(hostname);
             await writeGraphScheme(H);
-            await writeNode(H, nodeA, TS2, [], remoteValue);
+            await writeNode(H, nodeA, TS2, remoteValue);
             const L = db.schemaStorageForReplica('x');
             await writeIdentifierLookup(L, entriesForSameStringNodeKeys([nodeA]));
             await H.global.put(IDENTIFIERS_KEY, 'not-an-array');
@@ -840,7 +839,7 @@ describe('mergeHostIntoReplica', () => {
             const remoteValue = { value: { id: 'remote', type: 'test', description: 'remote value' }, isDirty: false };
             const H = db.hostnameSchemaStorage(hostname);
             await writeGraphScheme(H);
-            await writeNode(H, nodeA, TS2, [], remoteValue);
+            await writeNode(H, nodeA, TS2, remoteValue);
             const L = db.schemaStorageForReplica('x');
             await writeIdentifierLookup(L, entriesForSameStringNodeKeys([nodeA]));
 
@@ -884,16 +883,16 @@ describe('mergeHostIntoReplica', () => {
             const localValue = { value: { id: 'local', type: 'test', description: 'local' }, isDirty: false };
 
             const L = db.schemaStorageForReplica('x');
-            await writeNode(L, targetId, TS2, [], localValue);
+            await writeNode(L, targetId, TS2, localValue);
             await L.counters.put(targetId, 7);
-            await writeNode(L, dependentId, TS2, [targetId], undefined);
+            await writeNode(L, dependentId, TS2, undefined);
             await writeIdentifierLookup(L, [[targetId, sharedKey], [dependentId, dependentKey]]);
 
             const H = db.hostnameSchemaStorage(hostname);
             await writeGraphScheme(H);
-            await writeNode(H, hostId, TS2, [], { value: { id: 'host', type: 'test', description: 'host' }, isDirty: false });
+            await writeNode(H, hostId, TS2, { value: { id: 'host', type: 'test', description: 'host' }, isDirty: false });
             await H.counters.put(hostId, 9);
-            await writeNode(H, dependentId, TS2, [hostId], undefined);
+            await writeNode(H, dependentId, TS2, undefined);
             await writeIdentifierLookup(H, [[hostId, sharedKey], [dependentId, dependentKey]]);
 
             expect(await mergeHostIntoReplica(logger, db, hostname)).toBe(true);
@@ -925,11 +924,11 @@ describe('mergeHostIntoReplica', () => {
             const hostId = nodeIdentifierFromString('21-abcdefghi');
             const nodeKey = stringToNodeKeyString('{"head":"newer-local","args":[]}');
             const L = db.schemaStorageForReplica('x');
-            await writeNode(L, targetId, TS3, [], undefined);
+            await writeNode(L, targetId, TS3, undefined);
             await writeIdentifierLookup(L, [[targetId, nodeKey]]);
             const H = db.hostnameSchemaStorage(hostname);
             await writeGraphScheme(H);
-            await writeNode(H, hostId, TS1, [], undefined);
+            await writeNode(H, hostId, TS1, undefined);
             await writeIdentifierLookup(H, [[hostId, nodeKey]]);
 
             expect(await mergeHostIntoReplica(logger, db, hostname)).toBe(true);
@@ -956,12 +955,12 @@ describe('mergeHostIntoReplica', () => {
             const hostId = nodeIdentifierFromString('31-abcdefghi');
             const nodeKey = stringToNodeKeyString('{"head":"newer-host","args":[]}');
             const L = db.schemaStorageForReplica('x');
-            await writeNode(L, targetId, TS1, [], undefined);
+            await writeNode(L, targetId, TS1, undefined);
             await L.counters.put(targetId, 1);
             await writeIdentifierLookup(L, [[targetId, nodeKey]]);
             const H = db.hostnameSchemaStorage(hostname);
             await writeGraphScheme(H);
-            await writeNode(H, hostId, TS3, [], undefined);
+            await writeNode(H, hostId, TS3, undefined);
             await H.counters.put(hostId, 3);
             await writeIdentifierLookup(H, [[hostId, nodeKey]]);
 
@@ -995,14 +994,14 @@ describe('mergeHostIntoReplica', () => {
             const keyC = stringToNodeKeyString('{"head":"C","args":[]}');
             const keyA = stringToNodeKeyString('{"head":"A","args":[]}');
             const L = db.schemaStorageForReplica('x');
-            await writeNode(L, bId, TS2, [], undefined);
-            await writeNode(L, targetCId, TS3, [], undefined);
+            await writeNode(L, bId, TS2, undefined);
+            await writeNode(L, targetCId, TS3, undefined);
             await writeIdentifierLookup(L, [[bId, keyB], [targetCId, keyC]]);
             const H = db.hostnameSchemaStorage(hostname);
             await writeGraphScheme(H);
-            await writeNode(H, bId, TS2, [], undefined);
-            await writeNode(H, hostCId, TS1, [], undefined);
-            await writeNode(H, hostAId, TS2, [bId, hostCId], undefined);
+            await writeNode(H, bId, TS2, undefined);
+            await writeNode(H, hostCId, TS1, undefined);
+            await writeNode(H, hostAId, TS2, undefined);
             await writeIdentifierLookup(H, [[bId, keyB], [hostCId, keyC], [hostAId, keyA]]);
 
             expect(await mergeHostIntoReplica(logger, db, hostname)).toBe(true);
@@ -1035,15 +1034,15 @@ describe('mergeHostIntoReplica', () => {
             const staleAValue = { source: 'A computed from host C' };
 
             const L = db.schemaStorageForReplica('x');
-            await writeNode(L, targetCId, TS1, [], targetCValue);
+            await writeNode(L, targetCId, TS1, targetCValue);
             await L.counters.put(targetCId, 1);
             await writeIdentifierLookup(L, [[targetCId, keyC]]);
 
             const H = db.hostnameSchemaStorage(hostname);
             await writeGraphScheme(H);
-            await writeNode(H, hostCId, TS1, [], { source: 'host C' });
+            await writeNode(H, hostCId, TS1, { source: 'host C' });
             await H.counters.put(hostCId, 1);
-            await writeNode(H, hostAId, TS1, [hostCId], staleAValue);
+            await writeNode(H, hostAId, TS1, staleAValue);
             await H.counters.put(hostAId, 1);
             await writeIdentifierLookup(H, [[hostCId, keyC], [hostAId, keyA]]);
 
@@ -1095,17 +1094,17 @@ describe('mergeHostIntoReplica', () => {
             const targetCValue = { source: 'target C' };
 
             const L = db.schemaStorageForReplica('x');
-            await writeNode(L, targetCId, TS1, [], targetCValue);
+            await writeNode(L, targetCId, TS1, targetCValue);
             await L.counters.put(targetCId, 1);
             await writeIdentifierLookup(L, [[targetCId, keyC]]);
 
             const H = db.hostnameSchemaStorage(hostname);
             await writeGraphScheme(H);
-            await writeNode(H, hostCId, TS1, [], { source: 'host C' });
+            await writeNode(H, hostCId, TS1, { source: 'host C' });
             await H.counters.put(hostCId, 1);
-            await writeNode(H, hostAId, TS1, [hostCId], { source: 'stale A' });
+            await writeNode(H, hostAId, TS1, { source: 'stale A' });
             await H.counters.put(hostAId, 1);
-            await writeNode(H, hostDId, TS1, [hostAId], { source: 'stale D' });
+            await writeNode(H, hostDId, TS1, { source: 'stale D' });
             await H.counters.put(hostDId, 1);
             await writeIdentifierLookup(H, [
                 [hostCId, keyC],
@@ -1176,8 +1175,8 @@ describe('mergeHostIntoReplica', () => {
             };
 
             const L = db.schemaStorageForReplica('x');
-            await writeNode(L, targetCId, TS1, [], undefined);
-            await writeNode(L, targetDId, TS2, [targetCId], targetDValue);
+            await writeNode(L, targetCId, TS1, undefined);
+            await writeNode(L, targetDId, TS2, targetDValue);
             await L.counters.put(targetDId, 2);
             await writeIdentifierLookup(L, [
                 [targetCId, keyC],
@@ -1186,7 +1185,7 @@ describe('mergeHostIntoReplica', () => {
 
             const H = db.hostnameSchemaStorage(hostname);
             await writeGraphScheme(H);
-            await writeNode(H, hostCId, TS3, [], undefined);
+            await writeNode(H, hostCId, TS3, undefined);
             await writeIdentifierLookup(H, [[hostCId, keyC]]);
 
             expect(await mergeHostIntoReplica(logger, db, hostname)).toBe(true);
@@ -1227,14 +1226,14 @@ describe('mergeHostIntoReplica', () => {
             const remoteXValue = { source: 'remote X' };
 
             const L = db.schemaStorageForReplica('x');
-            await writeNode(L, nodeAId, TS1, [], valueA);
-            await writeNode(L, nodeBId, TS1, [nodeAId], valueB);
+            await writeNode(L, nodeAId, TS1, valueA);
+            await writeNode(L, nodeBId, TS1, valueB);
             await L.valid.put(nodeAId, [nodeBId]);
             await writeIdentifierLookup(L, [[nodeAId, keyA], [nodeBId, keyB]]);
 
             const H = db.hostnameSchemaStorage(hostname);
             await writeGraphScheme(H);
-            await writeNode(H, nodeXId, TS2, [], remoteXValue);
+            await writeNode(H, nodeXId, TS2, remoteXValue);
             await writeIdentifierLookup(H, [[nodeXId, keyX]]);
 
             expect(await mergeHostIntoReplica(logger, db, hostname)).toBe(true);
@@ -1282,11 +1281,11 @@ describe('mergeHostIntoReplica', () => {
 
             const L = db.schemaStorageForReplica('x');
             // A -> B side: A is taken from H (H has newer timestamp)
-            await writeNode(L, nodeAId, TS1, [], { source: 'A local' });
-            await writeNode(L, nodeBId, TS2, [nodeAId], { source: 'B local' });
+            await writeNode(L, nodeAId, TS1, { source: 'A local' });
+            await writeNode(L, nodeBId, TS2, { source: 'B local' });
             // C -> D side: both are kept locally
-            await writeNode(L, nodeCId, TS3, [], valueC);
-            await writeNode(L, nodeDId, TS3, [nodeCId], valueD);
+            await writeNode(L, nodeCId, TS3, valueC);
+            await writeNode(L, nodeDId, TS3, valueD);
             await L.valid.put(nodeCId, [nodeDId]);
             await writeIdentifierLookup(L, [
                 [nodeAId, keyA], [nodeBId, keyB],
@@ -1295,10 +1294,10 @@ describe('mergeHostIntoReplica', () => {
 
             const H = db.hostnameSchemaStorage(hostname);
             await writeGraphScheme(H);
-            await writeNode(H, nodeAId, TS2, [], { source: 'A remote' });
-            await writeNode(H, nodeBId, TS1, [nodeAId], { source: 'B remote' });
-            await writeNode(H, nodeCId, TS1, [], { source: 'C remote' });
-            await writeNode(H, nodeDId, TS1, [nodeCId], { source: 'D remote' });
+            await writeNode(H, nodeAId, TS2, { source: 'A remote' });
+            await writeNode(H, nodeBId, TS1, { source: 'B remote' });
+            await writeNode(H, nodeCId, TS1, { source: 'C remote' });
+            await writeNode(H, nodeDId, TS1, { source: 'D remote' });
             await writeIdentifierLookup(H, [
                 [nodeAId, keyA], [nodeBId, keyB],
                 [nodeCId, keyC], [nodeDId, keyD],
@@ -1350,15 +1349,15 @@ describe('mergeHostIntoReplica', () => {
             const keyB = stringToNodeKeyString('{"head":"B_stale","args":[]}');
 
             const L = db.schemaStorageForReplica('x');
-            await writeNode(L, nodeAId, TS1, [], { source: 'A' });
-            await writeNode(L, nodeBId, TS2, [nodeAId], { source: 'B' });
+            await writeNode(L, nodeAId, TS1, { source: 'A' });
+            await writeNode(L, nodeBId, TS2, { source: 'B' });
             await writeIdentifierLookup(L, [[nodeAId, keyA], [nodeBId, keyB]]);
 
             const H = db.hostnameSchemaStorage(hostname);
             await writeGraphScheme(H);
             // H has newer A, older B → A is taken, B is kept but tainted → invalidated
-            await writeNode(H, nodeAId, TS2, [], { source: 'A remote' });
-            await writeNode(H, nodeBId, TS1, [nodeAId], { source: 'B remote' });
+            await writeNode(H, nodeAId, TS2, { source: 'A remote' });
+            await writeNode(H, nodeBId, TS1, { source: 'B remote' });
             await writeIdentifierLookup(H, [[nodeAId, keyA], [nodeBId, keyB]]);
 
             expect(await mergeHostIntoReplica(logger, db, hostname)).toBe(true);
@@ -1413,6 +1412,27 @@ describe('mergeHostIntoReplica', () => {
     });
 
     describe('assertValidFinalMergeState', () => {
+        test('rejects materialized node when graph_scheme is missing', async () => {
+            const capabilities = getTestCapabilities();
+            let db;
+            try {
+                db = await getRootDatabase(capabilities);
+
+                const nodeA = NODE_A;
+                const T = db.schemaStorageForReplica('x');
+                await T.values.put(nodeA, { v: 1 });
+                await T.freshness.put(nodeA, 'up-to-date');
+
+                const lookup = makeIdentifierLookup([[nodeA, stringToNodeKeyString('{"head":"test","args":[]}')]]);
+
+                await expect(
+                    assertValidFinalMergeState(T, lookup)
+                ).rejects.toThrow(/graph_scheme/);
+            } finally {
+                if (db) await db.close();
+            }
+        });
+
         test('rejects valid entry referencing unknown identifier', async () => {
             const capabilities = getTestCapabilities();
             let db;
@@ -1523,15 +1543,15 @@ describe('mergeHostIntoReplica', () => {
             const keyX = stringToNodeKeyString('{"head":"X_stale_preserve","args":[]}');
 
             const L = db.schemaStorageForReplica('x');
-            await writeNode(L, nodeAId, TS1, [], { source: 'A' });
-            await writeNode(L, nodeBId, TS1, [nodeAId], { source: 'B' });
+            await writeNode(L, nodeAId, TS1, { source: 'A' });
+            await writeNode(L, nodeBId, TS1, { source: 'B' });
             await L.freshness.put(nodeBId, 'potentially-outdated');
             await L.valid.put(nodeAId, [nodeBId]);
             await writeIdentifierLookup(L, [[nodeAId, keyA], [nodeBId, keyB]]);
 
             const H = db.hostnameSchemaStorage(hostname);
             await writeGraphScheme(H);
-            await writeNode(H, nodeXId, TS2, [], { source: 'remote X' });
+            await writeNode(H, nodeXId, TS2, { source: 'remote X' });
             await writeIdentifierLookup(H, [[nodeXId, keyX]]);
 
             expect(await mergeHostIntoReplica(logger, db, hostname)).toBe(true);
@@ -1567,16 +1587,16 @@ describe('mergeHostIntoReplica', () => {
             const keyB = stringToNodeKeyString('{"head":"B_value_change","args":[]}');
 
             const L = db.schemaStorageForReplica('x');
-            await writeNode(L, nodeAId, TS1, [], { source: 'A old' });
-            await writeNode(L, nodeBId, TS2, [nodeAId], { source: 'B' });
+            await writeNode(L, nodeAId, TS1, { source: 'A old' });
+            await writeNode(L, nodeBId, TS2, { source: 'B' });
             await L.freshness.put(nodeBId, 'potentially-outdated');
             await L.valid.put(nodeAId, [nodeBId]);
             await writeIdentifierLookup(L, [[nodeAId, keyA], [nodeBId, keyB]]);
 
             const H = db.hostnameSchemaStorage(hostname);
             await writeGraphScheme(H);
-            await writeNode(H, nodeAId, TS2, [], { source: 'A new remote' });
-            await writeNode(H, nodeBId, TS1, [nodeAId], { source: 'B old' });
+            await writeNode(H, nodeAId, TS2, { source: 'A new remote' });
+            await writeNode(H, nodeBId, TS1, { source: 'B old' });
             await writeIdentifierLookup(H, [[nodeAId, keyA], [nodeBId, keyB]]);
 
             expect(await mergeHostIntoReplica(logger, db, hostname)).toBe(true);
@@ -1615,16 +1635,16 @@ describe('mergeHostIntoReplica', () => {
             const keyC = stringToNodeKeyString('{"head":"C_extra","args":[]}');
 
             const L = db.schemaStorageForReplica('x');
-            await writeNode(L, nodeAId, TS1, [], { source: 'A' });
-            await writeNode(L, nodeBId, TS1, [nodeAId], { source: 'B' });
+            await writeNode(L, nodeAId, TS1, { source: 'A' });
+            await writeNode(L, nodeBId, TS1, { source: 'B' });
             // valid[A] intentionally missing B
             await writeIdentifierLookup(L, [[nodeAId, keyA], [nodeBId, keyB]]);
 
             const H = db.hostnameSchemaStorage(hostname);
             await writeGraphScheme(H);
-            await writeNode(H, nodeAId, TS1, [], { source: 'A remote' });
-            await writeNode(H, nodeBId, TS1, [nodeAId], { source: 'B remote' });
-            await writeNode(H, nodeCId, TS2, [], { source: 'C remote' });
+            await writeNode(H, nodeAId, TS1, { source: 'A remote' });
+            await writeNode(H, nodeBId, TS1, { source: 'B remote' });
+            await writeNode(H, nodeCId, TS2, { source: 'C remote' });
             await writeIdentifierLookup(H, [
                 [nodeAId, keyA], [nodeBId, keyB], [nodeCId, keyC]
             ]);

--- a/backend/tests/topo_sort.test.js
+++ b/backend/tests/topo_sort.test.js
@@ -13,6 +13,8 @@
 const {
     getRootDatabase,
     nodeIdentifierFromString,
+    GRAPH_SCHEME_KEY,
+    IDENTIFIERS_KEY,
 } = require('../src/generators/incremental_graph/database');
 const {
     topologicalSort,
@@ -22,6 +24,7 @@ const {
 } = require('../src/generators/incremental_graph/database/topo_sort');
 const { getMockedRootCapabilities } = require('./spies');
 const { stubLogger, stubEnvironment } = require('./stubs');
+const { toJsonKey } = require('./test_json_key_helper');
 
 jest.setTimeout(15000);
 
@@ -57,6 +60,38 @@ const NODE_E = makeTestId(4);  // 'eeeeeeeee'  (used as external/unlisted node)
 const NODE_M = makeTestId(12); // 'mmmmmmmmm'
 const NODE_Z = makeTestId(25); // 'z-abcdefghi'
 
+const LINEAR_CHAIN_SCHEME = {
+    format: 1,
+    nodes: [
+        { head: "A", arity: 0, inputTemplates: [] },
+        { head: "B", arity: 0, inputTemplates: [{ head: "A", args: [] }] },
+        { head: "C", arity: 0, inputTemplates: [{ head: "B", args: [] }] },
+    ],
+};
+
+/**
+ * Write the graph scheme and identity lookup for the A -> B -> C test graph.
+ * @param {import('../src/generators/incremental_graph/database').SchemaStorage} storage
+ * @param {Array<[string, string]>} entries
+ * @returns {Promise<void>}
+ */
+async function writeLinearChainMetadata(storage, entries) {
+    await storage.global.put(GRAPH_SCHEME_KEY, JSON.stringify(LINEAR_CHAIN_SCHEME));
+    await storage.global.put(IDENTIFIERS_KEY, entries);
+}
+
+/**
+ * Write materialized values in the requested order.
+ * @param {import('../src/generators/incremental_graph/database').SchemaStorage} storage
+ * @param {string[]} identifiers
+ * @returns {Promise<void>}
+ */
+async function writeValues(storage, identifiers) {
+    for (const identifier of identifiers) {
+        await storage.values.put(identifier, { value: identifier });
+    }
+}
+
 describe('topologicalSort', () => {
     test('returns empty array for an empty graph', async () => {
         const capabilities = getTestCapabilities();
@@ -66,6 +101,77 @@ describe('topologicalSort', () => {
             const storage = db.getSchemaStorage();
             const result = await topologicalSort(storage);
             expect(result).toEqual([]);
+        } finally {
+            if (db) await db.close();
+        }
+    });
+
+    test('orders storage-level linear chain A -> B -> C from graph_scheme', async () => {
+        const capabilities = getTestCapabilities();
+        let db;
+        try {
+            db = await getRootDatabase(capabilities);
+            const storage = db.getSchemaStorage();
+            const idA = NODE_A, idB = NODE_B, idC = NODE_C;
+            await writeLinearChainMetadata(storage, [
+                [idA, toJsonKey('A')],
+                [idB, toJsonKey('B')],
+                [idC, toJsonKey('C')],
+            ]);
+            await writeValues(storage, [idA, idB, idC]);
+
+            expect(await topologicalSort(storage)).toEqual([idA, idB, idC]);
+        } finally {
+            if (db) await db.close();
+        }
+    });
+
+    test('storage-level sort fails when graph_scheme is missing', async () => {
+        const capabilities = getTestCapabilities();
+        let db;
+        try {
+            db = await getRootDatabase(capabilities);
+            const storage = db.getSchemaStorage();
+            await storage.global.put(IDENTIFIERS_KEY, [[NODE_A, toJsonKey('A')]]);
+            await writeValues(storage, [NODE_A]);
+
+            await expect(topologicalSort(storage)).rejects.toThrow(/graph_scheme/);
+        } finally {
+            if (db) await db.close();
+        }
+    });
+
+    test('storage-level sort fails when identifiers_keys_map is missing', async () => {
+        const capabilities = getTestCapabilities();
+        let db;
+        try {
+            db = await getRootDatabase(capabilities);
+            const storage = db.getSchemaStorage();
+            await storage.global.put(GRAPH_SCHEME_KEY, JSON.stringify(LINEAR_CHAIN_SCHEME));
+            await storage.global.del(IDENTIFIERS_KEY);
+            await writeValues(storage, [NODE_A]);
+
+            await expect(topologicalSort(storage)).rejects.toThrow(/identifiers_keys_map/);
+        } finally {
+            if (db) await db.close();
+        }
+    });
+
+    test('storage-level sort follows scheme dependencies instead of insertion order', async () => {
+        const capabilities = getTestCapabilities();
+        let db;
+        try {
+            db = await getRootDatabase(capabilities);
+            const storage = db.getSchemaStorage();
+            const idA = NODE_A, idB = NODE_B, idC = NODE_C;
+            await writeLinearChainMetadata(storage, [
+                [idA, toJsonKey('A')],
+                [idB, toJsonKey('B')],
+                [idC, toJsonKey('C')],
+            ]);
+            await writeValues(storage, [idC, idB, idA]);
+
+            expect(await topologicalSort(storage)).toEqual([idA, idB, idC]);
         } finally {
             if (db) await db.close();
         }


### PR DESCRIPTION
### Motivation
- Prevent tests from masking production behavior by removing test-side auto-generation of `global/graph_scheme` so missing schemes become hard errors as in production. 
- Ensure migration, topo-sort, and final-merge validation exercise the real storage paths and fail appropriately when metadata is missing. 
- Eliminate empty/fake defaults and ignored helper parameters that hide schema/lookup requirements. 
- Replace brittle shell-based regression scanning with a reliable Node-based scanner that reports precise file/line matches.

### Description
- Remove `graph_scheme` auto-generation from the in-memory migration test storage mock so `global.get(GRAPH_SCHEME_KEY)` now behaves like production, while keeping the identity fallback only for `identifiers_keys_map` where appropriate. 
- Add `seedGraphScheme(...)` and `seedSingleAGraphScheme(...)` helpers and update migration tests to explicitly seed `global/graph_scheme` for all valid versioned-source scenarios; leave tests that intentionally cover missing-scheme behavior unseeded. 
- Add focused missing-graph-scheme migration test that asserts `runMigration(...)` fails early with a `MissingGraphSchemeError` (and message mentioning `global/graph_scheme`), and that the inactive/target replica is not activated or partially accepted. 
- Remove `EMPTY_SCHEME`/`EMPTY_LOOKUP` defaults from migration-storage tests and replace `makeMs(...)` usages with explicit `makeMigrationStorage(...)` calls using per-test real schemes and identity-style lookups. 
- Add storage-level `topologicalSort(storage)` tests that cover a linear A→B→C chain, missing `graph_scheme`, missing `identifiers_keys_map`, and reverse insertion order to verify scheme-derived ordering. 
- Clean up sync tests by removing the ignored `_inputKeys` parameter from `writeNode(...)` and updating call sites so dependencies come from `graph_scheme` and `identifiers_keys_map` only. 
- Replace shell `grep | wc -l` based regression cleanup with a Node recursive scanner that walks the repo, skips generated directories, checks precise regexes, and reports matching files/lines in Jest failures. 
- Small test updates across `migration_runner*`, `migration_storage`, `topo_sort`, `sync_merge`, and timestamp tests to seed schemes where required and to use real lookups; no production code redesign was performed.

### Testing
- Ran `npm run static-analysis` and the linter/type checks passed. 
- Ran the full test suite with `npm test` and all tests passed locally. 
- Ran focused suites and modified tests individually with `npx jest --runInBand` for `backend/tests/migration_runner.test.js`, `migration_storage.test.js`, `topo_sort.test.js`, `sync_merge.test.js`, `migration_runner_timestamps.test.js`, and `regression_cleanup.test.js`, and each focused run passed. 
- Performed repository searches for banned patterns and dependency stubs; results are clean for the forbidden durable `inputs` API and auto-generation patterns. 

(Added test hardening and deterministic scanners to make missing `global/graph_scheme` a visible, tested invariant — like swapping a fog lamp for a lighthouse; @ottojung)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34e3552020832ea653f0a75cbcab19)