### PR TITLE
Import validity-only sync metadata

### DIFF
--- a/backend/src/generators/incremental_graph/database/sync_merge.js
+++ b/backend/src/generators/incremental_graph/database/sync_merge.js
@@ -328,11 +328,13 @@ async function commitChangedMerge(
  * - The live database is locked for the duration of this call.
  *
  * Post-conditions on success:
- * - If the merge changed graph data or reconciled identifiers, the inactive
- *   replica contains the merged graph and is made active.
- * - If every node and identifier was kept, the active replica pointer is unchanged. The
- *   inactive replica may still have been refreshed as a copy of the active
- *   replica, but callers must continue reading from the active pointer.
+ * - If the merge changed graph data, reconciled identifiers, or imported new
+ *   validity metadata, the inactive replica contains the merged graph and is
+ *   made active.
+ * - If every node, identifier, and validity relation was kept, the active
+ *   replica pointer is unchanged. The inactive replica may still have been
+ *   refreshed as a copy of the active replica, but callers must continue
+ *   reading from the active pointer.
  * - Hostname staging storage is not cleared here; the caller owns cleanup.
  *
  * @param {Logger} logger
@@ -401,32 +403,31 @@ async function mergeHostIntoReplica(logger, rootDatabase, hostname) {
     );
 
     const summary = summarizeDecisions(decisions.values());
-    const hasChanges = summary.hasChanges || hasIdentifierReconciliation;
-    if (hasChanges) {
-        const targetSourceStorage = rootDatabase.schemaStorageForReplica(fromReplica);
-        const valueOriginByKey = await buildValueOriginByKey(
-            initialDecisions,
-            decisions,
-            targetLookup,
-            hostLookup,
-            directlyReloweredNodes,
-            targetStorage,
-            targetSourceStorage,
-            hostStorage,
-            finalIdentifierForKey
-        );
+    const hasSemanticChanges = summary.hasChanges || hasIdentifierReconciliation;
+    const targetSourceStorage = rootDatabase.schemaStorageForReplica(fromReplica);
+    const valueOriginByKey = await buildValueOriginByKey(
+        initialDecisions,
+        decisions,
+        targetLookup,
+        hostLookup,
+        directlyReloweredNodes,
+        targetStorage,
+        targetSourceStorage,
+        hostStorage,
+        finalIdentifierForKey
+    );
 
-        await rebuildMergedValidity({
-            targetStorage,
-            targetSourceStorage,
-            hostSourceStorage: hostStorage,
-            targetLookup,
-            hostLookup,
-            finalIdentifierForKey,
-            mergedInputsMap,
-            valueOriginByKey,
-        });
-    }
+    const validityChanged = await rebuildMergedValidity({
+        targetStorage,
+        targetSourceStorage,
+        hostSourceStorage: hostStorage,
+        targetLookup,
+        hostLookup,
+        finalIdentifierForKey,
+        mergedInputsMap,
+        valueOriginByKey,
+    });
+    const hasChanges = hasSemanticChanges || validityChanged;
     await assertValidFinalMergeState(targetStorage, finalIdentifierLookup);
 
     if (hasChanges) {

--- a/backend/src/generators/incremental_graph/database/sync_merge_validity.js
+++ b/backend/src/generators/incremental_graph/database/sync_merge_validity.js
@@ -166,6 +166,93 @@ function originMatches(origin, side, sourceId) {
 }
 
 /**
+ * Compare stored graph values by JSON-like structure without observing
+ * prototypes or mutating either value.
+ * @param {*} left
+ * @param {*} right
+ * @returns {boolean}
+ */
+function storageValuesEqual(left, right) {
+    if (Object.is(left, right)) {
+        return true;
+    }
+    if (left === null || right === null) {
+        return false;
+    }
+    if (typeof left !== 'object' || typeof right !== 'object') {
+        return false;
+    }
+    if (Array.isArray(left) || Array.isArray(right)) {
+        if (!Array.isArray(left) || !Array.isArray(right)) {
+            return false;
+        }
+        if (left.length !== right.length) {
+            return false;
+        }
+        for (let index = 0; index < left.length; index += 1) {
+            if (!storageValuesEqual(left[index], right[index])) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    const leftKeys = Object.keys(left).sort();
+    const rightKeys = Object.keys(right).sort();
+    if (leftKeys.length !== rightKeys.length) {
+        return false;
+    }
+    for (let index = 0; index < leftKeys.length; index += 1) {
+        const key = leftKeys[index];
+        const rightKey = rightKeys[index];
+        if (key === undefined || key !== rightKey) {
+            return false;
+        }
+        if (!storageValuesEqual(left[key], right[key])) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/**
+ * Check whether a source-side value can justify transporting a source-side
+ * validity endpoint onto the final endpoint.
+ * @param {object} options
+ * @param {'target' | 'host'} options.side
+ * @param {SchemaStorage} options.sourceStorage
+ * @param {NodeIdentifier} options.sourceId
+ * @param {NodeKeyString} options.sourceKey
+ * @param {NodeIdentifier} options.finalId
+ * @param {Map<NodeKeyString, ValueOrigin>} options.valueOriginByKey
+ * @param {SchemaStorage} options.targetStorage
+ * @returns {Promise<boolean>}
+ */
+async function sourceValueCompatibleWithFinal({
+    side,
+    sourceStorage,
+    sourceId,
+    sourceKey,
+    finalId,
+    valueOriginByKey,
+    targetStorage,
+}) {
+    if (originMatches(valueOriginByKey.get(sourceKey), side, sourceId)) {
+        return true;
+    }
+
+    const sourceValue = await sourceStorage.values.get(sourceId);
+    if (sourceValue === undefined) {
+        return false;
+    }
+    const finalValue = await targetStorage.values.get(finalId);
+    if (finalValue === undefined) {
+        return false;
+    }
+    return storageValuesEqual(sourceValue, finalValue);
+}
+
+/**
  * Check whether a NodeIdentifier is present in a list.
  * @param {NodeIdentifier[]} list
  * @param {NodeIdentifier} id
@@ -174,6 +261,61 @@ function originMatches(origin, side, sourceId) {
 function containsIdentifier(list, id) {
     const idStr = nodeIdentifierToString(id);
     return list.some(item => nodeIdentifierToString(item) === idStr);
+}
+
+/**
+ * @param {Map<string, NodeIdentifier[]>} validMap
+ * @returns {Map<string, string[]>}
+ */
+function canonicalizeValidMap(validMap) {
+    /** @type {Map<string, string[]>} */
+    const canonical = new Map();
+    for (const [depIdStr, dependents] of validMap) {
+        if (dependents.length === 0) {
+            continue;
+        }
+        const dependentStrings = Array.from(new Set(dependents.map(nodeIdentifierToString))).sort();
+        if (dependentStrings.length > 0) {
+            canonical.set(depIdStr, dependentStrings);
+        }
+    }
+    return canonical;
+}
+
+/**
+ * @param {SchemaStorage} targetStorage
+ * @returns {Promise<Map<string, string[]>>}
+ */
+async function readCanonicalValidMap(targetStorage) {
+    /** @type {Map<string, NodeIdentifier[]>} */
+    const validMap = new Map();
+    for await (const depId of targetStorage.valid.keys()) {
+        validMap.set(nodeIdentifierToString(depId), await targetStorage.valid.get(depId) ?? []);
+    }
+    return canonicalizeValidMap(validMap);
+}
+
+/**
+ * @param {Map<string, string[]>} left
+ * @param {Map<string, string[]>} right
+ * @returns {boolean}
+ */
+function canonicalValidMapsEqual(left, right) {
+    if (left.size !== right.size) {
+        return false;
+    }
+    for (const [depIdStr, leftDependents] of left) {
+        const rightDependents = right.get(depIdStr);
+        if (rightDependents === undefined || leftDependents.length !== rightDependents.length) {
+            return false;
+        }
+        for (let index = 0; index < leftDependents.length; index += 1) {
+            if (leftDependents[index] !== rightDependents[index]) {
+                return false;
+            }
+        }
+    }
+    return true;
 }
 
 /**
@@ -197,7 +339,7 @@ function containsIdentifier(list, id) {
  * @param {Map<NodeKeyString, NodeIdentifier>} options.finalIdentifierForKey
  * @param {Map<NodeIdentifier, NodeIdentifier[]>} options.mergedInputsMap
  * @param {Map<NodeKeyString, ValueOrigin>} options.valueOriginByKey
- * @returns {Promise<void>}
+ * @returns {Promise<boolean>} Whether the canonical valid relation changed.
  */
 async function rebuildMergedValidity({
     targetStorage,
@@ -209,6 +351,8 @@ async function rebuildMergedValidity({
     mergedInputsMap,
     valueOriginByKey,
 }) {
+    const oldCanonicalValidMap = await readCanonicalValidMap(targetStorage);
+
     /** @type {Map<string, NodeIdentifier[]>} */
     const validMap = new Map();
     /** @type {Map<string, NodeIdentifier>} */
@@ -231,8 +375,15 @@ async function rebuildMergedValidity({
             const finalDepId = finalIdForKey.get(depKey);
             if (finalDepId === undefined) continue;
 
-            const depOrigin = valueOriginByKey.get(depKey);
-            if (!originMatches(depOrigin, side, sourceDepId)) continue;
+            if (!await sourceValueCompatibleWithFinal({
+                side,
+                sourceStorage,
+                sourceId: sourceDepId,
+                sourceKey: depKey,
+                finalId: finalDepId,
+                valueOriginByKey,
+                targetStorage,
+            })) continue;
 
             for (const sourceDependentId of sourceDependents) {
                 const dependentIdStr = nodeIdentifierToString(sourceDependentId);
@@ -242,8 +393,15 @@ async function rebuildMergedValidity({
                 const finalDependentId = finalIdForKey.get(dependentKey);
                 if (finalDependentId === undefined) continue;
 
-                const dependentOrigin = valueOriginByKey.get(dependentKey);
-                if (!originMatches(dependentOrigin, side, sourceDependentId)) continue;
+                if (!await sourceValueCompatibleWithFinal({
+                    side,
+                    sourceStorage,
+                    sourceId: sourceDependentId,
+                    sourceKey: dependentKey,
+                    finalId: finalDependentId,
+                    valueOriginByKey,
+                    targetStorage,
+                })) continue;
 
                 const finalInputs = mergedInputsMap.get(finalDependentId) ?? [];
                 if (!containsIdentifier(finalInputs, finalDepId)) continue;
@@ -293,10 +451,12 @@ async function rebuildMergedValidity({
         }
     }
     await writer.flush();
+    return !canonicalValidMapsEqual(oldCanonicalValidMap, canonicalizeValidMap(validMap));
 }
 
 module.exports = {
     rebuildMergedValidity,
     buildValueOriginByKey,
     ReplicaBatchWriter,
+    storageValuesEqual,
 };

--- a/backend/tests/sync_merge.test.js
+++ b/backend/tests/sync_merge.test.js
@@ -801,6 +801,174 @@ describe('mergeHostIntoReplica', () => {
         }
     });
 
+    test('metadata-only host validity proof import switches to inactive replica', async () => {
+        const capabilities = getTestCapabilities();
+        let db;
+        try {
+            db = await getRootDatabase(capabilities);
+            await writeGraphScheme(db.schemaStorageForReplica('x'));
+            const logger = makeLogger();
+            const hostname = 'peer';
+            await db.setGlobalVersion(db.version);
+            await db.setHostnameGlobal(hostname, 'version', db.version);
+
+            const nodeA = nodeIdentifierFromString('701-abcdefghi');
+            const nodeB = nodeIdentifierFromString('702-abcdefghi');
+            const keyA = stringToNodeKeyString('{"head":"host_stale_A","args":[]}');
+            const keyB = stringToNodeKeyString('{"head":"host_stale_B","args":[]}');
+            const valueA = { source: 'A', nested: { items: [1, true, null] } };
+            const valueB = { source: 'B', nested: { items: ['same'] } };
+
+            const L = db.schemaStorageForReplica('x');
+            await writeNode(L, nodeA, TS1, valueA);
+            await writeNode(L, nodeB, TS1, valueB);
+            await L.freshness.put(nodeB, 'potentially-outdated');
+            await writeIdentifierLookup(L, [[nodeA, keyA], [nodeB, keyB]]);
+
+            const H = db.hostnameSchemaStorage(hostname);
+            await writeGraphScheme(H);
+            await writeNode(H, nodeA, TS1, { nested: { items: [1, true, null] }, source: 'A' });
+            await writeNode(H, nodeB, TS1, { nested: { items: ['same'] }, source: 'B' });
+            await H.freshness.put(nodeB, 'potentially-outdated');
+            await H.valid.put(nodeA, [nodeB]);
+            await writeIdentifierLookup(H, [[nodeA, keyA], [nodeB, keyB]]);
+
+            expect(db.currentReplicaName()).toBe('x');
+            const switched = await mergeHostIntoReplica(logger, db, hostname);
+
+            expect(switched).toBe(true);
+            expect(db.currentReplicaName()).toBe('y');
+            const T = db.getSchemaStorage();
+            expect(await T.values.get(nodeA)).toEqual(valueA);
+            expect(await T.values.get(nodeB)).toEqual(valueB);
+            expect(await T.freshness.get(nodeA)).toBe('up-to-date');
+            expect(await T.freshness.get(nodeB)).toBe('potentially-outdated');
+            const validA = await T.valid.get(nodeA) ?? [];
+            expect(validA.some(dependent => String(dependent) === String(nodeB))).toBe(true);
+        } finally {
+            if (db) await db.close();
+        }
+    });
+
+    test('metadata-only merge does not switch when host validity adds nothing', async () => {
+        const capabilities = getTestCapabilities();
+        let db;
+        try {
+            db = await getRootDatabase(capabilities);
+            await writeGraphScheme(db.schemaStorageForReplica('x'));
+            const logger = makeLogger();
+            const hostname = 'peer';
+            await db.setGlobalVersion(db.version);
+            await db.setHostnameGlobal(hostname, 'version', db.version);
+
+            const nodeA = nodeIdentifierFromString('703-abcdefghi');
+            const nodeB = nodeIdentifierFromString('704-abcdefghi');
+            const keyA = stringToNodeKeyString('{"head":"host_stale_A","args":[]}');
+            const keyB = stringToNodeKeyString('{"head":"host_stale_B","args":[]}');
+            const valueA = { source: 'A' };
+            const valueB = { source: 'B' };
+
+            const L = db.schemaStorageForReplica('x');
+            await writeNode(L, nodeA, TS1, valueA);
+            await writeNode(L, nodeB, TS1, valueB);
+            await L.freshness.put(nodeB, 'potentially-outdated');
+            await L.valid.put(nodeA, [nodeB]);
+            await writeIdentifierLookup(L, [[nodeA, keyA], [nodeB, keyB]]);
+
+            const H = db.hostnameSchemaStorage(hostname);
+            await writeGraphScheme(H);
+            await writeNode(H, nodeA, TS1, valueA);
+            await writeNode(H, nodeB, TS1, valueB);
+            await H.freshness.put(nodeB, 'potentially-outdated');
+            await H.valid.put(nodeA, [nodeB]);
+            await writeIdentifierLookup(H, [[nodeA, keyA], [nodeB, keyB]]);
+
+            const switched = await mergeHostIntoReplica(logger, db, hostname);
+            expect(switched).toBe(false);
+            expect(db.currentReplicaName()).toBe('x');
+        } finally {
+            if (db) await db.close();
+        }
+    });
+
+    test('host validity proof is not imported when dependent value differs', async () => {
+        const capabilities = getTestCapabilities();
+        let db;
+        try {
+            db = await getRootDatabase(capabilities);
+            await writeGraphScheme(db.schemaStorageForReplica('x'));
+            const logger = makeLogger();
+            const hostname = 'peer';
+            await db.setGlobalVersion(db.version);
+            await db.setHostnameGlobal(hostname, 'version', db.version);
+
+            const nodeA = nodeIdentifierFromString('705-abcdefghi');
+            const nodeB = nodeIdentifierFromString('706-abcdefghi');
+            const keyA = stringToNodeKeyString('{"head":"host_stale_A","args":[]}');
+            const keyB = stringToNodeKeyString('{"head":"host_stale_B","args":[]}');
+
+            const L = db.schemaStorageForReplica('x');
+            await writeNode(L, nodeA, TS1, { source: 'A' });
+            await writeNode(L, nodeB, TS1, { source: 'B local' });
+            await L.freshness.put(nodeB, 'potentially-outdated');
+            await writeIdentifierLookup(L, [[nodeA, keyA], [nodeB, keyB]]);
+
+            const H = db.hostnameSchemaStorage(hostname);
+            await writeGraphScheme(H);
+            await writeNode(H, nodeA, TS1, { source: 'A' });
+            await writeNode(H, nodeB, TS1, { source: 'B host' });
+            await H.freshness.put(nodeB, 'potentially-outdated');
+            await H.valid.put(nodeA, [nodeB]);
+            await writeIdentifierLookup(H, [[nodeA, keyA], [nodeB, keyB]]);
+
+            const switched = await mergeHostIntoReplica(logger, db, hostname);
+            expect(switched).toBe(false);
+            const validA = await db.getSchemaStorage().valid.get(nodeA) ?? [];
+            expect(validA.some(dependent => String(dependent) === String(nodeB))).toBe(false);
+        } finally {
+            if (db) await db.close();
+        }
+    });
+
+    test('host validity proof is not imported when dependency value differs', async () => {
+        const capabilities = getTestCapabilities();
+        let db;
+        try {
+            db = await getRootDatabase(capabilities);
+            await writeGraphScheme(db.schemaStorageForReplica('x'));
+            const logger = makeLogger();
+            const hostname = 'peer';
+            await db.setGlobalVersion(db.version);
+            await db.setHostnameGlobal(hostname, 'version', db.version);
+
+            const nodeA = nodeIdentifierFromString('707-abcdefghi');
+            const nodeB = nodeIdentifierFromString('708-abcdefghi');
+            const keyA = stringToNodeKeyString('{"head":"host_stale_A","args":[]}');
+            const keyB = stringToNodeKeyString('{"head":"host_stale_B","args":[]}');
+
+            const L = db.schemaStorageForReplica('x');
+            await writeNode(L, nodeA, TS1, { source: 'A local' });
+            await writeNode(L, nodeB, TS1, { source: 'B' });
+            await L.freshness.put(nodeB, 'potentially-outdated');
+            await writeIdentifierLookup(L, [[nodeA, keyA], [nodeB, keyB]]);
+
+            const H = db.hostnameSchemaStorage(hostname);
+            await writeGraphScheme(H);
+            await writeNode(H, nodeA, TS1, { source: 'A host' });
+            await writeNode(H, nodeB, TS1, { source: 'B' });
+            await H.freshness.put(nodeB, 'potentially-outdated');
+            await H.valid.put(nodeA, [nodeB]);
+            await writeIdentifierLookup(H, [[nodeA, keyA], [nodeB, keyB]]);
+
+            const switched = await mergeHostIntoReplica(logger, db, hostname);
+            expect(switched).toBe(false);
+            const validA = await db.getSchemaStorage().valid.get(nodeA) ?? [];
+            expect(validA.some(dependent => String(dependent) === String(nodeB))).toBe(false);
+        } finally {
+            if (db) await db.close();
+        }
+    });
+
     test('rejects malformed host identifiers lookup during host merge', async () => {
         const capabilities = getTestCapabilities();
         let db;


### PR DESCRIPTION
### Motivation
- Allow importing useful "valid" metadata from a staged host snapshot even when there are no semantic value/timestamp/identifier changes, so cached validity proofs are not discarded and redundant recomputation is avoided.
- Preserve soundness by requiring either provenance-origin match or deterministic structural stored-value equality before transporting a source-side validity proof.

### Description
- Add a deterministic structural comparator `storageValuesEqual(left, right)` for JSON-like stored values and export it. (`backend/src/generators/incremental_graph/database/sync_merge_validity.js`)
- Introduce `sourceValueCompatibleWithFinal(...)` to accept a source proof when either the existing provenance origin matches or the source and final stored values are structurally equal, and use it for both dependency and dependent endpoints during transport. (`sync_merge_validity.js`)
- Make `rebuildMergedValidity(...)` return `Promise<boolean>` and compare canonicalized `valid` maps to detect whether the canonical validity relation actually changed before committing; keep the write semantics the same but only report change when canonical maps differ. (`sync_merge_validity.js`)
- Always run validity rebuild during `mergeHostIntoReplica`, compute `hasChanges = hasSemanticChanges || validityChanged`, and only call `commitChangedMerge` when semantic data or canonical validity changed. (`backend/src/generators/incremental_graph/database/sync_merge.js`)
- Add unit tests covering metadata-only host validity import, no-op when host adds nothing, and rejection when either endpoint value differs, plus ensure existing provenance-based transports remain intact. (`backend/tests/sync_merge.test.js`)

### Testing
- Ran the sync-merge unit suite: `npx jest backend/tests/sync_merge.test.js` and all tests passed (`53 passed`).
- Ran focused tests: `npx jest backend/tests/sync_merge.test.js --testNamePattern="metadata-only|dependent value differs|dependency value differs|provenance"` and they passed (`4 passed`).
- Ran static checks with `npm run static-analysis` (TypeScript + ESLint) and the checks passed.
- Verified frontend build with `npm run build` and it completed successfully.
- Attempted full `npm test` in this environment but the run was terminated; targeted test suite and static/build checks above completed successfully. 

@ottojung

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37400c5da4832eb86a269c316b37d6)