### PR TITLE
Tighten sync-merge validity provenance and enforce missing timestamps

### DIFF
--- a/backend/src/generators/incremental_graph/database/sync_merge.js
+++ b/backend/src/generators/incremental_graph/database/sync_merge.js
@@ -48,6 +48,7 @@ const { buildMergePlan } = require('./sync_merge_plan');
 const {
     assertValidFinalMergeState,
     assertLookupCoversMaterializedNodes,
+    assertMaterializedNodesHaveTimestamps,
     FinalMergeStateError,
     isFinalMergeStateError,
 } = require('./sync_merge_validation');
@@ -368,7 +369,9 @@ async function mergeHostIntoReplica(logger, rootDatabase, hostname) {
     const targetLookup = await loadTargetLookup(targetStorage);
     assertNoIdentifierCollisions(targetLookup, hostLookup);
     await assertLookupCoversMaterializedNodes(hostStorage, hostLookup, 'staged host snapshot');
+    await assertMaterializedNodesHaveTimestamps(hostStorage, hostLookup, 'staged host snapshot');
     await assertLookupCoversMaterializedNodes(targetStorage, targetLookup, 'merge target replica');
+    await assertMaterializedNodesHaveTimestamps(targetStorage, targetLookup, 'merge target replica');
 
     const targetLastNodeIndex = rootDatabase.getLastNodeIndex();
 

--- a/backend/src/generators/incremental_graph/database/sync_merge_validation.js
+++ b/backend/src/generators/incremental_graph/database/sync_merge_validation.js
@@ -33,9 +33,11 @@ function isFinalMergeStateError(object) {
  * Materialized nodes are identified by values.keys().
  * @param {SchemaStorage} targetStorage
  * @param {IdentifierLookup} finalLookup
+ * @param {{ requireUpToDateTimestamps?: boolean }} [options]
  * @returns {Promise<void>}
  */
-async function assertValidFinalMergeState(targetStorage, finalLookup) {
+async function assertValidFinalMergeState(targetStorage, finalLookup, options = {}) {
+    const requireUpToDateTimestamps = options.requireUpToDateTimestamps !== false;
     const scheme = parseGraphScheme(await targetStorage.global.get(GRAPH_SCHEME_KEY));
     const knownIdentifiers = new Set(finalLookup.idToKey.keys());
     const materializedIdentifiers = new Set();
@@ -50,6 +52,13 @@ async function assertValidFinalMergeState(targetStorage, finalLookup) {
         const freshness = await targetStorage.freshness.get(nodeIdentifierFromString(identifierString));
         if (freshness === 'up-to-date' && !materializedIdentifiers.has(identifierString)) {
             throw new FinalMergeStateError(`up-to-date lookup identifier ${identifierString} has no materialized node`);
+        }
+        if (
+            requireUpToDateTimestamps
+            && freshness === 'up-to-date'
+            && await targetStorage.timestamps.get(nodeIdentifierFromString(identifierString)) === undefined
+        ) {
+            throw new FinalMergeStateError(`up-to-date materialized node ${identifierString} has no timestamps entry`);
         }
     }
     for (const sublevel of [targetStorage.values, targetStorage.freshness, targetStorage.timestamps]) {
@@ -125,9 +134,32 @@ async function assertLookupCoversMaterializedNodes(storage, lookup, context) {
     }
 }
 
+/**
+ * Validate that every materialized node covered by the identifier lookup has
+ * timestamps before sync merge planning compares freshness across replicas.
+ * @param {SchemaStorage} storage
+ * @param {IdentifierLookup} lookup
+ * @param {string} context
+ * @returns {Promise<void>}
+ */
+async function assertMaterializedNodesHaveTimestamps(storage, lookup, context) {
+    for await (const id of storage.values.keys()) {
+        if (!lookup.idToKey.has(nodeIdentifierToString(id))) {
+            continue;
+        }
+        const timestamps = await storage.timestamps.get(id);
+        if (timestamps === undefined) {
+            throw new IdentifierLookupConflictError(
+                `${context}: materialized node ${nodeIdentifierToString(id)} has no timestamps entry`
+            );
+        }
+    }
+}
+
 module.exports = {
     assertValidFinalMergeState,
     assertLookupCoversMaterializedNodes,
+    assertMaterializedNodesHaveTimestamps,
     FinalMergeStateError,
     isFinalMergeStateError,
 };

--- a/backend/src/generators/incremental_graph/database/sync_merge_validity.js
+++ b/backend/src/generators/incremental_graph/database/sync_merge_validity.js
@@ -3,7 +3,7 @@
  *
  * After node decisions are applied and the final graph state is assembled,
  * this module rebuilds the valid relation from the final merged inputs and
- * freshness, while transporting compatible validity entries from both the
+ * freshness, while transporting provenance-backed validity entries from both the
  * original target replica and the staged host replica.
  */
 
@@ -167,93 +167,6 @@ function originMatches(origin, side, sourceId) {
 }
 
 /**
- * Compare stored graph values by JSON-like structure without observing
- * prototypes or mutating either value.
- * @param {*} left
- * @param {*} right
- * @returns {boolean}
- */
-function storageValuesEqual(left, right) {
-    if (Object.is(left, right)) {
-        return true;
-    }
-    if (left === null || right === null) {
-        return false;
-    }
-    if (typeof left !== 'object' || typeof right !== 'object') {
-        return false;
-    }
-    if (Array.isArray(left) || Array.isArray(right)) {
-        if (!Array.isArray(left) || !Array.isArray(right)) {
-            return false;
-        }
-        if (left.length !== right.length) {
-            return false;
-        }
-        for (let index = 0; index < left.length; index += 1) {
-            if (!storageValuesEqual(left[index], right[index])) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    const leftKeys = Object.keys(left).sort();
-    const rightKeys = Object.keys(right).sort();
-    if (leftKeys.length !== rightKeys.length) {
-        return false;
-    }
-    for (let index = 0; index < leftKeys.length; index += 1) {
-        const key = leftKeys[index];
-        const rightKey = rightKeys[index];
-        if (key === undefined || key !== rightKey) {
-            return false;
-        }
-        if (!storageValuesEqual(left[key], right[key])) {
-            return false;
-        }
-    }
-    return true;
-}
-
-/**
- * Check whether a source-side value can justify transporting a source-side
- * validity endpoint onto the final endpoint.
- * @param {object} options
- * @param {'target' | 'host'} options.side
- * @param {SchemaStorage} options.sourceStorage
- * @param {NodeIdentifier} options.sourceId
- * @param {NodeKeyString} options.sourceKey
- * @param {NodeIdentifier} options.finalId
- * @param {Map<NodeKeyString, ValueOrigin>} options.valueOriginByKey
- * @param {SchemaStorage} options.targetStorage
- * @returns {Promise<boolean>}
- */
-async function sourceValueCompatibleWithFinal({
-    side,
-    sourceStorage,
-    sourceId,
-    sourceKey,
-    finalId,
-    valueOriginByKey,
-    targetStorage,
-}) {
-    if (originMatches(valueOriginByKey.get(sourceKey), side, sourceId)) {
-        return true;
-    }
-
-    const sourceValue = await sourceStorage.values.get(sourceId);
-    if (sourceValue === undefined) {
-        return false;
-    }
-    const finalValue = await targetStorage.values.get(finalId);
-    if (finalValue === undefined) {
-        return false;
-    }
-    return storageValuesEqual(sourceValue, finalValue);
-}
-
-/**
  * Check whether a NodeIdentifier is present in a list.
  * @param {NodeIdentifier[]} list
  * @param {NodeIdentifier} id
@@ -323,14 +236,14 @@ function canonicalValidMapsEqual(left, right) {
  * Rebuild the valid relation from provenance-based value origin transport.
  *
  * Algorithm:
- * 1. Transport validity entries from both source sides based on compatible
- *    endpoint values.
+ * 1. Transport validity entries from both source sides based on source
+ *    provenance for both endpoints.
  * 2. Add mandatory flags for every up-to-date node.
  * 3. Clear the existing valid sublevel and write the rebuilt relation.
  *
  * A validity proof valid[D].has(N) is transported from a source side only
- * when D and N have compatible endpoint values (either a provenance-origin
- * match or structural value equality).
+ * when D and N both resolve through the same source side and their final values
+ * preserve those exact source identifiers.
  * - D is still a structural input of N in the merged graph.
  *
  * @param {object} options
@@ -378,15 +291,7 @@ async function rebuildMergedValidity({
             const finalDepId = finalIdForKey.get(depKey);
             if (finalDepId === undefined) continue;
 
-            if (!await sourceValueCompatibleWithFinal({
-                side,
-                sourceStorage,
-                sourceId: sourceDepId,
-                sourceKey: depKey,
-                finalId: finalDepId,
-                valueOriginByKey,
-                targetStorage,
-            })) continue;
+            if (!originMatches(valueOriginByKey.get(depKey), side, sourceDepId)) continue;
 
             for (const sourceDependentId of sourceDependents) {
                 const dependentIdStr = nodeIdentifierToString(sourceDependentId);
@@ -396,15 +301,7 @@ async function rebuildMergedValidity({
                 const finalDependentId = finalIdForKey.get(dependentKey);
                 if (finalDependentId === undefined) continue;
 
-                if (!await sourceValueCompatibleWithFinal({
-                    side,
-                    sourceStorage,
-                    sourceId: sourceDependentId,
-                    sourceKey: dependentKey,
-                    finalId: finalDependentId,
-                    valueOriginByKey,
-                    targetStorage,
-                })) continue;
+                if (!originMatches(valueOriginByKey.get(dependentKey), side, sourceDependentId)) continue;
 
                 const finalInputs = mergedInputsMap.get(finalDependentId) ?? [];
                 if (!containsIdentifier(finalInputs, finalDepId)) continue;
@@ -461,5 +358,4 @@ module.exports = {
     rebuildMergedValidity,
     buildValueOriginByKey,
     ReplicaBatchWriter,
-    storageValuesEqual,
 };

--- a/backend/src/generators/incremental_graph/migration_runner.js
+++ b/backend/src/generators/incremental_graph/migration_runner.js
@@ -544,7 +544,7 @@ async function runMigrationUnsafe(capabilities, rootDatabase, nodeDefs, callback
             const targetLookup = rawIdentifiers === undefined
                 ? makeEmptyIdentifierLookup()
                 : parseIdentifierLookup(rawIdentifiers, 'migration target replica');
-            await assertValidFinalMergeState(toStorage, targetLookup);
+            await assertValidFinalMergeState(toStorage, targetLookup, { requireUpToDateTimestamps: false });
 
             // Persist the new active replica pointer after all writes succeed.
             await rootDatabase.setCurrentReplicaPointer(toReplica);

--- a/backend/tests/migration_runner.test.js
+++ b/backend/tests/migration_runner.test.js
@@ -251,7 +251,7 @@ function makeSimpleMigrationSetup({ prevVersion = "1.0.0", currentVersion = "2.0
 
 beforeEach(() => {
     assertValidFinalMergeState.mockImplementation(
-        (storage, lookup) => validationActual.assertValidFinalMergeState(storage, lookup)
+        (storage, lookup, options) => validationActual.assertValidFinalMergeState(storage, lookup, options)
     );
 });
 
@@ -1530,6 +1530,8 @@ describe("migration validation", () => {
         await storage.values.put(bKey, { type: "all_events", events: [] });
         await storage.freshness.put(aKey, "up-to-date");
         await storage.freshness.put(bKey, "up-to-date");
+        await storage.timestamps.put(aKey, { createdAt: "2024-01-01T00:00:00.000Z", modifiedAt: "2024-01-01T00:00:00.000Z" });
+        await storage.timestamps.put(bKey, { createdAt: "2024-01-01T00:00:00.000Z", modifiedAt: "2024-01-01T00:00:00.000Z" });
         await storage.valid.put(aKey, [bKey]);
 
         const identifiers = await storage.global.get(IDENTIFIERS_KEY);

--- a/backend/tests/sync_merge.test.js
+++ b/backend/tests/sync_merge.test.js
@@ -481,7 +481,7 @@ describe('mergeHostIntoReplica', () => {
         }
     });
 
-    test('missing timestamps in H do not leave stale T timestamps after take', async () => {
+    test('missing timestamps in H reject merge before active replica changes', async () => {
         const capabilities = getTestCapabilities();
         let db;
         try {
@@ -503,14 +503,8 @@ describe('mergeHostIntoReplica', () => {
             await writeIdentifierLookup(L, []);
             await writeIdentifierLookup(H, entriesForSameStringNodeKeys([hOnlyNode]));
 
-            db = await mergeAndReopenIfSwitched(capabilities, logger, db, hostname);
-
-            const newActive = db.currentReplicaName();
-            const T = db.schemaStorageForReplica(newActive);
-
-            // The H-only node was taken; copyNodeOps emits delOp for missing timestamps.
-            const takenTs = await T.timestamps.get(hOnlyNode);
-            expect(takenTs).toBeUndefined();
+            await expect(mergeHostIntoReplica(logger, db, hostname)).rejects.toThrow(IdentifierLookupConflictError);
+            expect(db.currentReplicaName()).toBe('x');
         } finally {
             if (db) await db.close();
         }
@@ -801,7 +795,7 @@ describe('mergeHostIntoReplica', () => {
         }
     });
 
-    test('metadata-only host validity proof import switches to inactive replica', async () => {
+    test('metadata-only host validity proof import switches when endpoints originate from host', async () => {
         const capabilities = getTestCapabilities();
         let db;
         try {
@@ -820,15 +814,15 @@ describe('mergeHostIntoReplica', () => {
             const valueB = { source: 'B', nested: { items: ['same'] } };
 
             const L = db.schemaStorageForReplica('x');
-            await writeNode(L, nodeA, TS1, valueA);
-            await writeNode(L, nodeB, TS1, valueB);
+            await writeNode(L, nodeA, TS1, { source: 'A target' });
+            await writeNode(L, nodeB, TS1, { source: 'B target' });
             await L.freshness.put(nodeB, 'potentially-outdated');
             await writeIdentifierLookup(L, [[nodeA, keyA], [nodeB, keyB]]);
 
             const H = db.hostnameSchemaStorage(hostname);
             await writeGraphScheme(H);
-            await writeNode(H, nodeA, TS1, { nested: { items: [1, true, null] }, source: 'A' });
-            await writeNode(H, nodeB, TS1, { nested: { items: ['same'] }, source: 'B' });
+            await writeNode(H, nodeA, TS2, valueA);
+            await writeNode(H, nodeB, TS2, valueB);
             await H.freshness.put(nodeB, 'potentially-outdated');
             await H.valid.put(nodeA, [nodeB]);
             await writeIdentifierLookup(H, [[nodeA, keyA], [nodeB, keyB]]);
@@ -845,6 +839,47 @@ describe('mergeHostIntoReplica', () => {
             expect(await T.freshness.get(nodeB)).toBe('potentially-outdated');
             const validA = await T.valid.get(nodeA) ?? [];
             expect(validA.some(dependent => String(dependent) === String(nodeB))).toBe(true);
+        } finally {
+            if (db) await db.close();
+        }
+    });
+
+    test('metadata-only host validity proof is not imported from equal values with target provenance', async () => {
+        const capabilities = getTestCapabilities();
+        let db;
+        try {
+            db = await getRootDatabase(capabilities);
+            await writeGraphScheme(db.schemaStorageForReplica('x'));
+            const logger = makeLogger();
+            const hostname = 'peer';
+            await db.setGlobalVersion(db.version);
+            await db.setHostnameGlobal(hostname, 'version', db.version);
+
+            const nodeA = nodeIdentifierFromString('709-abcdefghi');
+            const nodeB = nodeIdentifierFromString('710-abcdefghi');
+            const keyA = stringToNodeKeyString('{"head":"host_stale_A","args":[]}');
+            const keyB = stringToNodeKeyString('{"head":"host_stale_B","args":[]}');
+            const valueA = { v: 1 };
+            const valueB = { v: 2 };
+
+            const L = db.schemaStorageForReplica('x');
+            await writeNode(L, nodeA, TS2, valueA);
+            await writeNode(L, nodeB, TS2, valueB);
+            await L.freshness.put(nodeB, 'potentially-outdated');
+            await writeIdentifierLookup(L, [[nodeA, keyA], [nodeB, keyB]]);
+
+            const H = db.hostnameSchemaStorage(hostname);
+            await writeGraphScheme(H);
+            await writeNode(H, nodeA, TS1, valueA);
+            await writeNode(H, nodeB, TS1, valueB);
+            await H.freshness.put(nodeB, 'potentially-outdated');
+            await H.valid.put(nodeA, [nodeB]);
+            await writeIdentifierLookup(H, [[nodeA, keyA], [nodeB, keyB]]);
+
+            expect(await mergeHostIntoReplica(logger, db, hostname)).toBe(false);
+            expect(db.currentReplicaName()).toBe('x');
+            const validA = await db.getSchemaStorage().valid.get(nodeA) ?? [];
+            expect(validA.some(dependent => String(dependent) === String(nodeB))).toBe(false);
         } finally {
             if (db) await db.close();
         }
@@ -2175,15 +2210,67 @@ describe('mergeHostIntoReplica', () => {
             expect(await T.values.get(targetA)).toEqual(equalValue);
             // hostA is deleted (keep chose targetA)
             expect(await T.values.get(hostA)).toBeUndefined();
-            // B was taken but directly relowered (input changed from hostA to
-            // targetA). The dep check passes via structural equality (A's values
-            // match), but the dependent check fails because B's final value was
-            // deleted by direct relowering. The equality fallback on the dep side
-            // alone is not enough — the dependent must also have a compatible
-            // final value for the proof to transport.
+            // B was taken but directly relowered because its source input uses
+            // hostA and its final input uses targetA. Direct relowering deletes
+            // B's value, so B cannot carry host provenance into the final graph.
             const validA = await T.valid.get(targetA) ?? [];
             const bIdStr = String(hostB);
             expect(validA.some(d => String(d) === bIdStr)).toBe(false);
+        } finally {
+            if (db) await db.close();
+        }
+    });
+
+    test('cross-side equal-value proof is not imported when final dependent remains materialized', async () => {
+        const { rebuildMergedValidity } = require('../src/generators/incremental_graph/database/sync_merge_validity');
+        const capabilities = getTestCapabilities();
+        let db;
+        try {
+            db = await getRootDatabase(capabilities);
+
+            const targetA = nodeIdentifierFromString('130-abcdefghi');
+            const hostA = nodeIdentifierFromString('131-abcdefghi');
+            const hostB = nodeIdentifierFromString('132-abcdefghi');
+            const keyA = stringToNodeKeyString('{"head":"cross_equal_A","args":[]}');
+            const keyB = stringToNodeKeyString('{"head":"cross_equal_B","args":[]}');
+            const equalValue = { v: 1 };
+
+            const targetStorage = db.schemaStorageForReplica('y');
+            await writeGraphScheme(targetStorage);
+            await targetStorage.values.put(targetA, equalValue);
+            await targetStorage.values.put(hostB, { v: 'host B' });
+            await targetStorage.freshness.put(targetA, 'up-to-date');
+            await targetStorage.freshness.put(hostB, 'potentially-outdated');
+
+            const targetSourceStorage = db.schemaStorageForReplica('x');
+            await writeGraphScheme(targetSourceStorage);
+            await targetSourceStorage.values.put(targetA, equalValue);
+            const targetLookup = makeIdentifierLookup([[targetA, keyA]]);
+
+            const hostStorage = db.hostnameSchemaStorage('cross-equal-host');
+            await writeGraphScheme(hostStorage);
+            await hostStorage.values.put(hostA, equalValue);
+            await hostStorage.values.put(hostB, { v: 'host B' });
+            await hostStorage.freshness.put(hostB, 'potentially-outdated');
+            await hostStorage.valid.put(hostA, [hostB]);
+            const hostLookup = makeIdentifierLookup([[hostA, keyA], [hostB, keyB]]);
+
+            await rebuildMergedValidity({
+                targetStorage,
+                targetSourceStorage,
+                hostSourceStorage: hostStorage,
+                targetLookup,
+                hostLookup,
+                finalIdentifierForKey: new Map([[keyA, targetA], [keyB, hostB]]),
+                mergedInputsMap: new Map([[hostB, [targetA]]]),
+                valueOriginByKey: new Map([
+                    [keyA, { kind: 'source', side: 'target', sourceId: targetA }],
+                    [keyB, { kind: 'source', side: 'host', sourceId: hostB }],
+                ]),
+            });
+
+            const validA = await targetStorage.valid.get(targetA) ?? [];
+            expect(validA.some(dependent => String(dependent) === String(hostB))).toBe(false);
         } finally {
             if (db) await db.close();
         }
@@ -2369,6 +2456,79 @@ describe('mergeHostIntoReplica', () => {
             await expect(
                 assertValidFinalMergeState(T, lookup)
             ).rejects.toThrow(FinalMergeStateError);
+        } finally {
+            if (db) await db.close();
+        }
+    });
+
+    test('rejects host materialized node with missing timestamps and keeps active replica', async () => {
+        const capabilities = getTestCapabilities();
+        let db;
+        try {
+            db = await getRootDatabase(capabilities);
+            await writeGraphScheme(db.schemaStorageForReplica('x'));
+            const logger = makeLogger();
+            const hostname = 'peer';
+            await db.setGlobalVersion(db.version);
+            await db.setHostnameGlobal(hostname, 'version', db.version);
+
+            const nodeA = nodeIdentifierFromString('133-abcdefghi');
+            const keyA = stringToNodeKeyString('{"head":"host_stale_A","args":[]}');
+            const H = db.hostnameSchemaStorage(hostname);
+            await writeGraphScheme(H);
+            await H.values.put(nodeA, { v: 'host' });
+            await H.freshness.put(nodeA, 'up-to-date');
+            await writeIdentifierLookup(H, [[nodeA, keyA]]);
+
+            await expect(mergeHostIntoReplica(logger, db, hostname)).rejects.toThrow(IdentifierLookupConflictError);
+            expect(db.currentReplicaName()).toBe('x');
+        } finally {
+            if (db) await db.close();
+        }
+    });
+
+    test('rejects target materialized node with missing timestamps and keeps active replica', async () => {
+        const capabilities = getTestCapabilities();
+        let db;
+        try {
+            db = await getRootDatabase(capabilities);
+            await writeGraphScheme(db.schemaStorageForReplica('x'));
+            const logger = makeLogger();
+            const hostname = 'peer';
+            await db.setGlobalVersion(db.version);
+            await db.setHostnameGlobal(hostname, 'version', db.version);
+
+            const nodeA = nodeIdentifierFromString('134-abcdefghi');
+            const keyA = stringToNodeKeyString('{"head":"host_stale_A","args":[]}');
+            const L = db.schemaStorageForReplica('x');
+            await L.values.put(nodeA, { v: 'target' });
+            await L.freshness.put(nodeA, 'up-to-date');
+            await writeIdentifierLookup(L, [[nodeA, keyA]]);
+
+            const H = db.hostnameSchemaStorage(hostname);
+            await writeGraphScheme(H);
+            await writeIdentifierLookup(H, []);
+
+            await expect(mergeHostIntoReplica(logger, db, hostname)).rejects.toThrow(IdentifierLookupConflictError);
+            expect(db.currentReplicaName()).toBe('x');
+        } finally {
+            if (db) await db.close();
+        }
+    });
+
+    test('final merge validation rejects up-to-date materialized node with missing timestamps', async () => {
+        const capabilities = getTestCapabilities();
+        let db;
+        try {
+            db = await getRootDatabase(capabilities);
+            const nodeA = nodeIdentifierFromString('135-abcdefghi');
+            const keyA = stringToNodeKeyString('{"head":"host_stale_A","args":[]}');
+            const T = db.schemaStorageForReplica('x');
+            await writeGraphScheme(T);
+            await T.values.put(nodeA, { v: 'final' });
+            await T.freshness.put(nodeA, 'up-to-date');
+            const lookup = makeIdentifierLookup([[nodeA, keyA]]);
+            await expect(assertValidFinalMergeState(T, lookup)).rejects.toThrow(FinalMergeStateError);
         } finally {
             if (db) await db.close();
         }


### PR DESCRIPTION
### Motivation
- Prevent provenance-violating validity transport: equal stored values must not be allowed to justify moving validity proofs across source sides.  The synchronization spec requires provenance-only transport.  
- Enforce correctness of timestamped materialized nodes: missing timestamps in materialized snapshots must not be silently treated as oldest and must reject the merge or final state.  
- Add regression coverage to catch previously passing equality-based and missing-timestamp cases before they are fixed.

### Description
- Reworked validity reconstruction to be provenance-only by removing the equality fallback and requiring exact origin matches: removed `storageValuesEqual` and the `sourceValueCompatibleWithFinal` pathway and replaced endpoint compatibility checks with strict `originMatches(...)` calls in `rebuildMergedValidity`. (backend/src/generators/incremental_graph/database/sync_merge_validity.js)
- Added timestamp presence checks for materialized nodes prior to merge planning via `assertMaterializedNodesHaveTimestamps(...)` and call sites in `mergeHostIntoReplica(...)`. (backend/src/generators/incremental_graph/database/sync_merge_validation.js, backend/src/generators/incremental_graph/database/sync_merge.js)
- Strengthened final-state validation so up-to-date materialized nodes require timestamp entries by default, and added an explicit option to relax this for migration code paths that intentionally preserve older behavior. (backend/src/generators/incremental_graph/database/sync_merge_validation.js, backend/src/generators/incremental_graph/migration_runner.js)
- Kept existing good behavior: `valueOriginByKey` still built after `applyNodeDecisions(...)`, `rebuildMergedValidity` still reads validity from both source replicas, and iterative invalidation behavior preserved. (no behavioral regressions to those improvements)
- Tests: updated and added focused regression tests that fail before the change and pass after: provenance-backed positive import, equality-only negative import, cross-side equal-value negative case, and three missing-timestamp rejection tests (host materialized, target materialized, final validation). Also updated migration test fixtures/mocks to pass the new validation option. (backend/tests/sync_merge.test.js, backend/tests/migration_runner.test.js)

### Testing
- Wrote failing regression tests first for equality-only validity import and missing timestamps, then implemented fixes and re-ran tests.  
- Focused tests run: `npx jest backend/tests/sync_merge.test.js --testNamePattern="equal-value proof is not imported when final dependent remains materialized|missing timestamps"` (failed before changes, passed after fixes).  
- Targeted suites: `npx jest backend/tests/sync_merge.test.js`, `npx jest backend/tests/migration_runner.test.js`, and `npx jest backend/tests/migration_runner_timestamps.test.js` all passed after the changes.  
- Full local suite: `npm test` / `npx jest --runInBand` completed with all tests passing in this environment (all backend tests exercised passed).  
- Static analysis: `npm run static-analysis` (TypeScript + ESLint) passed.  

If you'd like, I can split the work into smaller commits (tests-first commit + implementation commit + test adjustments) or open a follow-up to remove any now-unused helpers/imports left in other modules. @ottojung

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a396b9038d8832e954f2c4651f668cb)