### PR TITLE
Redesign migration `override()` and `create()` semantics to preserve proof envelope and require explicit freshness

### DIFF
--- a/backend/src/generators/incremental_graph/migration_errors.js
+++ b/backend/src/generators/incremental_graph/migration_errors.js
@@ -308,8 +308,39 @@ function isCreateExistingNode(object) {
     return object instanceof CreateExistingNode;
 }
 
+/**
+ * Thrown when a migration decision cannot preserve the proof claimed by its API.
+ */
+class InvalidMigrationDecision extends Error {
+    /**
+     * @param {string} message
+     */
+    constructor(message) {
+        super(message);
+        this.name = "InvalidMigrationDecisionError";
+    }
+}
+
+/**
+ * @param {string} message
+ * @returns {InvalidMigrationDecision}
+ */
+function makeInvalidMigrationDecisionError(message) {
+    return new InvalidMigrationDecision(message);
+}
+
+/**
+ * @param {unknown} object
+ * @returns {object is InvalidMigrationDecision}
+ */
+function isInvalidMigrationDecision(object) {
+    return object instanceof InvalidMigrationDecision;
+}
+
 module.exports = {
     makeDecisionConflictError,
+    makeInvalidMigrationDecisionError,
+    isInvalidMigrationDecision,
     isDecisionConflict,
     makeOverrideConflictError,
     isOverrideConflict,

--- a/backend/src/generators/incremental_graph/migration_errors.js
+++ b/backend/src/generators/incremental_graph/migration_errors.js
@@ -45,7 +45,7 @@ function isDecisionConflict(object) {
 }
 
 /**
- * Thrown when override() is called twice with different values on the same node.
+ * Thrown when override() is called more than once on the same node.
  */
 class OverrideConflict extends Error {
     /**
@@ -53,7 +53,7 @@ class OverrideConflict extends Error {
      */
     constructor(nodeKey) {
         super(
-            `Override conflict for node ${nodeKey}: override() called with a different value`
+            `Override conflict for node ${nodeKey}: override() called more than once`
         );
         this.name = "OverrideConflictError";
         this.nodeKey = nodeKey;

--- a/backend/src/generators/incremental_graph/migration_runner.js
+++ b/backend/src/generators/incremental_graph/migration_runner.js
@@ -145,14 +145,12 @@ function makeLazyMigrationSource(prevStorage, decisions, desiredValid, newVersio
             async get(key) {
                 const decision = decisions.get(key);
                 if (!decision || decision.kind === "delete") return undefined;
-                const value = decision.kind === "create" || decision.kind === "override"
-                    ? await decision.value(key)
-                    : await prevStorage.values.get(key);
-                if (value === undefined) return "missing";
-                if (decision.kind === "create" || decision.kind === "override") return "up-to-date";
-                if (decision.kind === "invalidate") return "potentially-outdated";
-                const freshness = await prevStorage.freshness.get(key);
-                return freshness ?? "potentially-outdated";
+                if (decision.kind === "create") return decision.freshness;
+                if (decision.kind === "override") return await prevStorage.freshness.get(key);
+                const oldValue = await prevStorage.values.get(key);
+                if (decision.kind === "invalidate") return oldValue === undefined ? "missing" : "potentially-outdated";
+                if (oldValue === undefined) return "missing";
+                return await prevStorage.freshness.get(key) ?? "missing";
             },
         },
         valid: {
@@ -178,14 +176,15 @@ function makeLazyMigrationSource(prevStorage, decisions, desiredValid, newVersio
                 if (!decision || decision.kind === "delete") return undefined;
                 const nowIso = datetime.now().toISOString();
                 const existing = await prevStorage.timestamps.get(key);
-                if (decision.kind === "create" || existing === undefined) {
+                if (decision.kind === "create") {
                     return { createdAt: nowIso, modifiedAt: nowIso };
                 }
-                if (decision.kind === "override" || decision.kind === "invalidate") {
-                    return { createdAt: existing.createdAt, modifiedAt: nowIso };
+                if (decision.kind === "override" || decision.kind === "keep") {
+                    return existing;
                 }
-                const value = await prevStorage.values.get(key);
-                if (value === undefined) {
+                if (decision.kind === "invalidate") {
+                    const value = await prevStorage.values.get(key);
+                    if (value === undefined || existing === undefined) return existing;
                     return { createdAt: existing.createdAt, modifiedAt: nowIso };
                 }
                 return existing;

--- a/backend/src/generators/incremental_graph/migration_storage.js
+++ b/backend/src/generators/incremental_graph/migration_storage.js
@@ -15,7 +15,8 @@ const { MigrationStorageClass } = require("./migration_storage_class");
  * @typedef {{ kind: 'override', value: (nodeKey: NodeIdentifier) => Promise<ComputedValue> }} OverrideDecision
  * @typedef {{ kind: 'invalidate' }} InvalidateDecision
  * @typedef {{ kind: 'delete' }} DeleteDecision
- * @typedef {{ kind: 'create', nodeKeyString: string, value: (nodeKey: NodeIdentifier) => Promise<ComputedValue> }} CreateDecision
+ * @typedef {"up-to-date" | "potentially-outdated"} CreatedFreshness
+ * @typedef {{ kind: 'create', nodeKeyString: string, value: (nodeKey: NodeIdentifier) => Promise<ComputedValue>, freshness: CreatedFreshness }} CreateDecision
  * @typedef {KeepDecision | OverrideDecision | InvalidateDecision | DeleteDecision | CreateDecision} Decision
 
 /**

--- a/backend/src/generators/incremental_graph/migration_storage_class.js
+++ b/backend/src/generators/incremental_graph/migration_storage_class.js
@@ -15,6 +15,7 @@ const {
     makeGetMissingValueError,
     makeUndecidedNodesError,
     makeCreateExistingNodeError,
+    makeInvalidMigrationDecisionError,
 } = require("./migration_errors");
 const {
     checkSchemaCompatibility,
@@ -39,7 +40,8 @@ const {
  * @typedef {{ kind: 'override', value: (nodeKey: NodeIdentifier) => Promise<ComputedValue> }} OverrideDecision
  * @typedef {{ kind: 'invalidate' }} InvalidateDecision
  * @typedef {{ kind: 'delete' }} DeleteDecision
- * @typedef {{ kind: 'create', nodeKeyString: string, value: (nodeKey: NodeIdentifier) => Promise<ComputedValue> }} CreateDecision
+ * @typedef {"up-to-date" | "potentially-outdated"} CreatedFreshness
+ * @typedef {{ kind: 'create', nodeKeyString: string, value: (nodeKey: NodeIdentifier) => Promise<ComputedValue>, freshness: CreatedFreshness }} CreateDecision
  * @typedef {KeepDecision | OverrideDecision | InvalidateDecision | DeleteDecision | CreateDecision} Decision
  */
 
@@ -185,6 +187,22 @@ class MigrationStorageClass {
         }
         const identifiersKeysIndex = await this._getIdentifiersKeysIndex();
         await checkSchemaCompatibility(nodeKey, this.newHeadIndex, identifiersKeysIndex, this.decisions);
+        await assertKeepInputPositionsCompatible(nodeKey, identifiersKeysIndex, this.oldGraphScheme, this.newGraphScheme);
+        const oldValue = await this.prevStorage.values.get(nodeKey);
+        if (oldValue === undefined) {
+            throw makeInvalidMigrationDecisionError(`Cannot override node ${nodeKey}: materialized node is not cached`);
+        }
+        const oldFreshness = await this.prevStorage.freshness.get(nodeKey);
+        if (oldFreshness === undefined) {
+            throw makeInvalidMigrationDecisionError(`Cannot override node ${nodeKey}: previous freshness is missing`);
+        }
+        if (oldFreshness === "missing") {
+            throw makeInvalidMigrationDecisionError(`Cannot override node ${nodeKey}: previous freshness is missing-state`);
+        }
+        const oldTimestamps = await this.prevStorage.timestamps.get(nodeKey);
+        if (oldTimestamps === undefined) {
+            throw makeInvalidMigrationDecisionError(`Cannot override node ${nodeKey}: previous timestamps are missing`);
+        }
         const existing = this.decisions.get(nodeKey);
         if (existing !== undefined) {
             if (existing.kind === "override") {
@@ -193,15 +211,6 @@ class MigrationStorageClass {
             throw makeDecisionConflictError(nodeKey, existing.kind, "override");
         }
         this.decisions.set(nodeKey, { kind: "override", value });
-        await propagateInvalidate({
-            nodeKey,
-            visited: new Set(),
-            prevStorage: this.prevStorage,
-            materializedNodes: this.materializedNodes,
-            decisions: this.decisions,
-            newHeadIndex: this.newHeadIndex,
-            getIdentifiersKeysIndex: () => this._getIdentifiersKeysIndex(),
-        });
     }
 
     /**
@@ -269,12 +278,16 @@ class MigrationStorageClass {
      * The node must exist in the new schema.
      * The identifier is auto-generated deterministically using the database
      * fingerprint and a monotonic index.
-     * The new node is created as up-to-date with dependencies derived from the new graph scheme.
+     * The caller chooses whether the created cached node is clean or stale.
      * @param {import('./database/types').NodeKeyString} nodeKeyString - The semantic key JSON string
      * @param {(nodeKey: NodeIdentifier) => Promise<ComputedValue>} value
+     * @param {CreatedFreshness} freshness
      * @returns {Promise<void>}
      */
-    async create(nodeKeyString, value) {
+    async create(nodeKeyString, value, freshness) {
+        if (freshness !== "up-to-date" && freshness !== "potentially-outdated") {
+            throw makeInvalidMigrationDecisionError(`Cannot create node ${nodeKeyString}: freshness must be "up-to-date" or "potentially-outdated"`);
+        }
         const keyStr = String(nodeKeyString);
 
         const existingEntries = await this.prevStorage.global.get(IDENTIFIERS_KEY);
@@ -293,7 +306,7 @@ class MigrationStorageClass {
         }
 
         const nodeKey = this._generateIdentifier();
-        this.decisions.set(nodeKey, { kind: "create", nodeKeyString: keyStr, value });
+        this.decisions.set(nodeKey, { kind: "create", nodeKeyString: keyStr, value, freshness });
         const identifiersKeysIndex = await this._getIdentifiersKeysIndex();
         try { await checkSchemaCompatibility(nodeKey, this.newHeadIndex, identifiersKeysIndex, this.decisions); }
         catch (err) { this.decisions.delete(nodeKey); throw err; }

--- a/backend/src/generators/incremental_graph/migration_storage_dependencies.js
+++ b/backend/src/generators/incremental_graph/migration_storage_dependencies.js
@@ -25,7 +25,8 @@ const {
  * @typedef {{ kind: 'override', value: (nodeKey: NodeIdentifier) => Promise<ComputedValue> }} OverrideDecision
  * @typedef {{ kind: 'invalidate' }} InvalidateDecision
  * @typedef {{ kind: 'delete' }} DeleteDecision
- * @typedef {{ kind: 'create', nodeKeyString: string, value: (nodeKey: NodeIdentifier) => Promise<ComputedValue> }} CreateDecision
+ * @typedef {"up-to-date" | "potentially-outdated"} CreatedFreshness
+ * @typedef {{ kind: 'create', nodeKeyString: string, value: (nodeKey: NodeIdentifier) => Promise<ComputedValue>, freshness: CreatedFreshness }} CreateDecision
  * @typedef {KeepDecision | OverrideDecision | InvalidateDecision | DeleteDecision | CreateDecision} Decision
  */
 

--- a/backend/src/generators/incremental_graph/migration_storage_schema.js
+++ b/backend/src/generators/incremental_graph/migration_storage_schema.js
@@ -23,7 +23,8 @@ const { makeSchemaCompatibilityError } = require("./migration_errors");
  * @typedef {{ kind: 'override', value: (nodeKey: NodeIdentifier) => Promise<ComputedValue> }} OverrideDecision
  * @typedef {{ kind: 'invalidate' }} InvalidateDecision
  * @typedef {{ kind: 'delete' }} DeleteDecision
- * @typedef {{ kind: 'create', nodeKeyString: string, value: (nodeKey: NodeIdentifier) => Promise<ComputedValue> }} CreateDecision
+ * @typedef {"up-to-date" | "potentially-outdated"} CreatedFreshness
+ * @typedef {{ kind: 'create', nodeKeyString: string, value: (nodeKey: NodeIdentifier) => Promise<ComputedValue>, freshness: CreatedFreshness }} CreateDecision
  * @typedef {KeepDecision | OverrideDecision | InvalidateDecision | DeleteDecision | CreateDecision} Decision
  */
 

--- a/backend/src/generators/incremental_graph/migration_validity.js
+++ b/backend/src/generators/incremental_graph/migration_validity.js
@@ -8,6 +8,7 @@ const {
     parseIdentifierLookup,
     deriveInputEdges,
 } = require("./database");
+const { makeInvalidMigrationDecisionError } = require("./migration_errors");
 
 /** @typedef {import('./database/root_database').SchemaStorage} SchemaStorage */
 /** @typedef {import('./database/types').NodeIdentifier} NodeIdentifier */
@@ -148,7 +149,7 @@ async function buildDesiredValid(prevStorage, decisions, oldScheme, newScheme, o
         const finalEdges = deriveInputEdges(newScheme, finalLookup, nodeIdentifier);
         for (const edge of finalEdges) {
             if (!materialized.has(nodeIdentifierToString(edge))) {
-                throw new Error(`Migration dependency ${nodeIdentifierToString(edge)} for ${nodeIdentifierToString(nodeIdentifier)} is not materialized in the target replica`);
+                throw makeInvalidMigrationDecisionError(`Migration dependency ${nodeIdentifierToString(edge)} for ${nodeIdentifierToString(nodeIdentifier)} is not materialized in the target replica`);
             }
         }
 
@@ -157,11 +158,11 @@ async function buildDesiredValid(prevStorage, decisions, oldScheme, newScheme, o
             if (decision.freshness === "potentially-outdated") continue;
             for (const input of finalEdges) {
                 if (!await isFinalCached(prevStorage, decisions, input)) {
-                    throw new Error(`Cannot create ${nodeIdentifierToString(nodeIdentifier)} as up-to-date: input ${nodeIdentifierToString(input)} is not cached`);
+                    throw makeInvalidMigrationDecisionError(`Cannot create ${nodeIdentifierToString(nodeIdentifier)} as up-to-date: input ${nodeIdentifierToString(input)} is not cached`);
                 }
                 const inputFreshness = await finalFreshness(prevStorage, decisions, input);
                 if (inputFreshness !== "up-to-date") {
-                    throw new Error(`Cannot create ${nodeIdentifierToString(nodeIdentifier)} as up-to-date: input ${nodeIdentifierToString(input)} is ${inputFreshness ?? "not materialized"}`);
+                    throw makeInvalidMigrationDecisionError(`Cannot create ${nodeIdentifierToString(nodeIdentifier)} as up-to-date: input ${nodeIdentifierToString(input)} is ${inputFreshness ?? "not materialized"}`);
                 }
                 addToValidSet(validSets, input, nodeIdentifier);
             }

--- a/backend/src/generators/incremental_graph/migration_validity.js
+++ b/backend/src/generators/incremental_graph/migration_validity.js
@@ -96,6 +96,37 @@ function materializedDecisionStrings(decisions) {
 }
 
 /**
+ * @param {ReadableMigrationStorage} prevStorage
+ * @param {Map<NodeIdentifier, Decision>} decisions
+ * @param {NodeIdentifier} nodeIdentifier
+ * @returns {Promise<boolean>}
+ */
+async function isFinalCached(prevStorage, decisions, nodeIdentifier) {
+    const decision = decisions.get(nodeIdentifier);
+    if (decision === undefined || decision.kind === "delete") return false;
+    if (decision.kind === "create" || decision.kind === "override") return true;
+    return await prevStorage.values.get(nodeIdentifier) !== undefined;
+}
+
+/**
+ * @param {ReadableMigrationStorage} prevStorage
+ * @param {Map<NodeIdentifier, Decision>} decisions
+ * @param {NodeIdentifier} nodeIdentifier
+ * @returns {Promise<import('./database/types').Freshness | undefined>}
+ */
+async function finalFreshness(prevStorage, decisions, nodeIdentifier) {
+    const decision = decisions.get(nodeIdentifier);
+    if (decision === undefined || decision.kind === "delete") return undefined;
+    if (decision.kind === "create") return decision.freshness;
+    if (decision.kind === "override") return await prevStorage.freshness.get(nodeIdentifier);
+    if (decision.kind === "invalidate") {
+        return await prevStorage.values.get(nodeIdentifier) === undefined ? "missing" : "potentially-outdated";
+    }
+    if (await prevStorage.values.get(nodeIdentifier) === undefined) return "missing";
+    return await prevStorage.freshness.get(nodeIdentifier) ?? "missing";
+}
+
+/**
  * Build validity sets from migration decisions and scheme-derived final edges.
  * @param {ReadableMigrationStorage} prevStorage
  * @param {Map<NodeIdentifier, Decision>} decisions
@@ -109,18 +140,11 @@ async function buildDesiredValid(prevStorage, decisions, oldScheme, newScheme, o
     /** @type {Map<string, Set<NodeIdentifier>>} */
     const validSets = new Map();
     const materialized = materializedDecisionStrings(decisions);
-    const cached = new Set();
-    for (const [nodeIdentifier, decision] of decisions) {
-        if (decision.kind === 'delete') continue;
-        if (decision.kind === 'create' || decision.kind === 'override') {
-            cached.add(nodeIdentifierToString(nodeIdentifier));
-        } else if (await prevStorage.values.get(nodeIdentifier) !== undefined) {
-            cached.add(nodeIdentifierToString(nodeIdentifier));
-        }
-    }
 
     for (const [nodeIdentifier, decision] of decisions) {
         if (decision.kind === "delete" || decision.kind === "invalidate") continue;
+        if (!await isFinalCached(prevStorage, decisions, nodeIdentifier)) continue;
+
         const finalEdges = deriveInputEdges(newScheme, finalLookup, nodeIdentifier);
         for (const edge of finalEdges) {
             if (!materialized.has(nodeIdentifierToString(edge))) {
@@ -128,26 +152,37 @@ async function buildDesiredValid(prevStorage, decisions, oldScheme, newScheme, o
             }
         }
 
-        if (!cached.has(nodeIdentifierToString(nodeIdentifier))) continue;
-
-        const finalFreshness = decision.kind === "keep"
-            ? await prevStorage.freshness.get(nodeIdentifier)
-            : "up-to-date";
-        if (finalFreshness === "up-to-date") {
+        const freshness = await finalFreshness(prevStorage, decisions, nodeIdentifier);
+        if (decision.kind === "create") {
+            if (decision.freshness === "potentially-outdated") continue;
             for (const input of finalEdges) {
-                if (cached.has(nodeIdentifierToString(input))) {
+                if (!await isFinalCached(prevStorage, decisions, input)) {
+                    throw new Error(`Cannot create ${nodeIdentifierToString(nodeIdentifier)} as up-to-date: input ${nodeIdentifierToString(input)} is not cached`);
+                }
+                const inputFreshness = await finalFreshness(prevStorage, decisions, input);
+                if (inputFreshness !== "up-to-date") {
+                    throw new Error(`Cannot create ${nodeIdentifierToString(nodeIdentifier)} as up-to-date: input ${nodeIdentifierToString(input)} is ${inputFreshness ?? "not materialized"}`);
+                }
+                addToValidSet(validSets, input, nodeIdentifier);
+            }
+            continue;
+        }
+
+        if (freshness === "up-to-date") {
+            for (const input of finalEdges) {
+                if (await isFinalCached(prevStorage, decisions, input)) {
                     addToValidSet(validSets, input, nodeIdentifier);
                 }
             }
             continue;
         }
 
-        if (decision.kind !== "keep" || finalFreshness !== "potentially-outdated") continue;
+        if ((decision.kind !== "keep" && decision.kind !== "override") || freshness !== "potentially-outdated") continue;
         const oldEdges = deriveInputEdges(oldScheme, oldLookup, nodeIdentifier);
         for (const input of finalEdges) {
             const inputDecision = decisions.get(input);
-            if (!inputDecision || inputDecision.kind !== "keep") continue;
-            if (!cached.has(nodeIdentifierToString(input))) continue;
+            if (!inputDecision || (inputDecision.kind !== "keep" && inputDecision.kind !== "override")) continue;
+            if (!await isFinalCached(prevStorage, decisions, input)) continue;
             if (!oldEdges.some(edge => nodeIdentifierToString(edge) === nodeIdentifierToString(input))) continue;
             const existingValidForD = await prevStorage.valid.get(input) ?? [];
             if (existingValidForD.some(id => nodeIdentifierToString(id) === nodeIdentifierToString(nodeIdentifier))) {

--- a/backend/tests/migration_runner.test.js
+++ b/backend/tests/migration_runner.test.js
@@ -84,6 +84,17 @@ function makeSchemaStorage() {
     // Tests use simplified mocks where the "NodeIdentifier" string is the same
     // as the semantic node key JSON string. When identifiers_keys_map is not
     // explicitly seeded, fall back to an identity mapping derived from values.
+    const originalValuesPut = values.put.bind(values);
+    values.put = async (key, value) => {
+        await originalValuesPut(key, value);
+        if (await timestamps.get(key) === undefined) {
+            await timestamps.put(key, { createdAt: "2024-01-01T00:00:00.000Z", modifiedAt: "2024-01-01T00:00:00.000Z" });
+        }
+        if (await freshness.get(key) === undefined) {
+            await freshness.put(key, "up-to-date");
+        }
+    };
+
     const originalGlobalGet = global.get.bind(global);
     global.get = async (key) => {
         if (key !== IDENTIFIERS_KEY) {

--- a/backend/tests/migration_runner_timestamps.test.js
+++ b/backend/tests/migration_runner_timestamps.test.js
@@ -2,8 +2,9 @@
  * Tests that verify materialized-node timestamps during database migration.
  *
  * Migration produces total timestamp records over the materialized identifier
- * registry. Identity-preserving decisions keep `createdAt`; decisions that change
- * the materialized record update `modifiedAt` to migration time.
+ * registry. Identity-preserving decisions (keep, override) preserve both `createdAt`
+ * and `modifiedAt`; decisions that semantically change the cache-state
+ * (invalidate) or create new entries (create) update `modifiedAt` to migration time.
  */
 
 const { runMigration } = require("../src/generators/incremental_graph/migration_runner");
@@ -308,11 +309,11 @@ describe("keep decision: timestamps copied to new storage", () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// override decision updates timestamps
+// override decision preserves timestamps
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe("override decision: timestamps update materialized record", () => {
-    test("createdAt is preserved and modifiedAt updates after override", async () => {
+describe("override decision: timestamps are preserved", () => {
+    test("createdAt and modifiedAt are preserved after override", async () => {
         const capabilities = await getTestCapabilities();
         const xStorage = makeSchemaStorage();
         const yStorage = makeSchemaStorage();
@@ -325,10 +326,12 @@ describe("override decision: timestamps update materialized record", () => {
 
         await seedGraphScheme(xStorage, makeNodeDefs(["A"]));
         await runMigration(capabilities, rootDatabase, makeNodeDefs(["A"]), async (storage) => {
-            await storage.override(nodeKey, async () => ({ type: "all_events", events: [] }), "up-to-date");
+            await storage.override(nodeKey, async () => ({ type: "all_events", events: [] }));
         });
 
-        await expect(yGet(yStorage.timestamps, yStorage, nodeKey)).resolves.toEqual(OLD_TIMESTAMP);
+        const result = await yGet(yStorage.timestamps, yStorage, nodeKey);
+        expect(result.createdAt).toBe(OLD_TIMESTAMP.createdAt);
+        expect(result.modifiedAt).toBe(OLD_TIMESTAMP.modifiedAt);
     });
 
     test("override without previous timestamp is rejected", async () => {
@@ -344,11 +347,11 @@ describe("override decision: timestamps update materialized record", () => {
 
         await seedGraphScheme(xStorage, makeNodeDefs(["A"]));
         await expect(runMigration(capabilities, rootDatabase, makeNodeDefs(["A"]), async (storage) => {
-            await storage.override(nodeKey, async () => ({ type: "all_events", events: [] }), "up-to-date");
+            await storage.override(nodeKey, async () => ({ type: "all_events", events: [] }));
         })).rejects.toThrow("previous timestamps are missing");
     });
 
-    test("override createdAt survives when modifiedAt differs", async () => {
+    test("override preserves both createdAt and modifiedAt when they differ", async () => {
         const capabilities = await getTestCapabilities();
         const ts = { createdAt: "2023-05-01T00:00:00.000Z", modifiedAt: "2024-11-30T23:59:59.000Z" };
         const xStorage = makeSchemaStorage();
@@ -362,11 +365,12 @@ describe("override decision: timestamps update materialized record", () => {
 
         await seedGraphScheme(xStorage, makeNodeDefs(["A"]));
         await runMigration(capabilities, rootDatabase, makeNodeDefs(["A"]), async (storage) => {
-            await storage.override(nodeKey, async () => ({ type: "all_events", events: [] }), "up-to-date");
+            await storage.override(nodeKey, async () => ({ type: "all_events", events: [] }));
         });
 
         const result = await yGet(yStorage.timestamps, yStorage, nodeKey);
         expect(result.createdAt).toBe(ts.createdAt);
+        expect(result.modifiedAt).toBe(ts.modifiedAt);
     });
 });
 
@@ -634,7 +638,7 @@ describe("two-node chain: mixed decision timestamp behaviour", () => {
         await expect(yGet(yStorage.timestamps, yStorage, nkB)).resolves.toEqual({ createdAt: NEW_TIMESTAMP.createdAt, modifiedAt: "2024-01-01T00:00:00.000Z" });
     });
 
-    test("keep A, override B: A timestamp preserved; B timestamp preserved (createdAt unchanged)", async () => {
+    test("keep A, override B: both timestamps preserved for both nodes", async () => {
         const capabilities = await getTestCapabilities();
         const xStorage = makeSchemaStorage();
         const yStorage = makeSchemaStorage();
@@ -644,12 +648,11 @@ describe("two-node chain: mixed decision timestamp behaviour", () => {
         await seedGraphScheme(xStorage, makeNodeDefs(["A", "B"]));
         await runMigration(capabilities, rootDatabase, makeNodeDefs(["A", "B"]), async (storage) => {
             await storage.keep(nkA);
-            await storage.override(nkB, async () => ({ type: "all_events", events: [] }), "up-to-date");
+            await storage.override(nkB, async () => ({ type: "all_events", events: [] }));
         });
 
         await expect(yGet(yStorage.timestamps, yStorage, nkA)).resolves.toEqual(OLD_TIMESTAMP);
-        const bResult = await yGet(yStorage.timestamps, yStorage, nkB);
-        expect(bResult.createdAt).toBe(NEW_TIMESTAMP.createdAt);
+        await expect(yGet(yStorage.timestamps, yStorage, nkB)).resolves.toEqual(NEW_TIMESTAMP);
     });
 
     test("override A requires an explicit decision for B", async () => {
@@ -661,7 +664,7 @@ describe("two-node chain: mixed decision timestamp behaviour", () => {
 
         await seedGraphScheme(xStorage, makeNodeDefs(["A", "B"]));
         await expect(runMigration(capabilities, rootDatabase, makeNodeDefs(["A", "B"]), async (storage) => {
-            await storage.override(nkA, async () => ({ type: "all_events", events: [] }), "up-to-date");
+            await storage.override(nkA, async () => ({ type: "all_events", events: [] }));
         })).rejects.toThrow("have no decision");
     });
 

--- a/backend/tests/migration_runner_timestamps.test.js
+++ b/backend/tests/migration_runner_timestamps.test.js
@@ -262,7 +262,7 @@ describe("keep decision: timestamps copied to new storage", () => {
         expect(result.modifiedAt).toBe(OLD_TIMESTAMP.modifiedAt);
     });
 
-    test("node with no previous timestamp receives timestamp after keep", async () => {
+    test("node with no previous timestamp after keep fails final validation", async () => {
         const capabilities = await getTestCapabilities();
         const xStorage = makeSchemaStorage();
         const yStorage = makeSchemaStorage();
@@ -274,11 +274,9 @@ describe("keep decision: timestamps copied to new storage", () => {
         });
 
         await seedGraphScheme(xStorage, makeNodeDefs(["A"]));
-        await runMigration(capabilities, rootDatabase, makeNodeDefs(["A"]), async (storage) => {
+        await expect(runMigration(capabilities, rootDatabase, makeNodeDefs(["A"]), async (storage) => {
             await storage.keep(nodeKey);
-        });
-
-        await expect(yGet(yStorage.timestamps, yStorage, nodeKey)).resolves.toEqual({ createdAt: "2024-01-01T00:00:00.000Z", modifiedAt: "2024-01-01T00:00:00.000Z" });
+        })).rejects.toThrow("has no timestamps entry");
     });
 
     test("multiple nodes: all timestamps copied correctly on keep", async () => {
@@ -327,13 +325,13 @@ describe("override decision: timestamps update materialized record", () => {
 
         await seedGraphScheme(xStorage, makeNodeDefs(["A"]));
         await runMigration(capabilities, rootDatabase, makeNodeDefs(["A"]), async (storage) => {
-            await storage.override(nodeKey, async () => ({ type: "all_events", events: [] }));
+            await storage.override(nodeKey, async () => ({ type: "all_events", events: [] }), "up-to-date");
         });
 
-        await expect(yGet(yStorage.timestamps, yStorage, nodeKey)).resolves.toEqual({ createdAt: OLD_TIMESTAMP.createdAt, modifiedAt: "2024-01-01T00:00:00.000Z" });
+        await expect(yGet(yStorage.timestamps, yStorage, nodeKey)).resolves.toEqual(OLD_TIMESTAMP);
     });
 
-    test("override without previous timestamp receives timestamp", async () => {
+    test("override without previous timestamp is rejected", async () => {
         const capabilities = await getTestCapabilities();
         const xStorage = makeSchemaStorage();
         const yStorage = makeSchemaStorage();
@@ -345,11 +343,9 @@ describe("override decision: timestamps update materialized record", () => {
         });
 
         await seedGraphScheme(xStorage, makeNodeDefs(["A"]));
-        await runMigration(capabilities, rootDatabase, makeNodeDefs(["A"]), async (storage) => {
-            await storage.override(nodeKey, async () => ({ type: "all_events", events: [] }));
-        });
-
-        await expect(yGet(yStorage.timestamps, yStorage, nodeKey)).resolves.toEqual({ createdAt: "2024-01-01T00:00:00.000Z", modifiedAt: "2024-01-01T00:00:00.000Z" });
+        await expect(runMigration(capabilities, rootDatabase, makeNodeDefs(["A"]), async (storage) => {
+            await storage.override(nodeKey, async () => ({ type: "all_events", events: [] }), "up-to-date");
+        })).rejects.toThrow("previous timestamps are missing");
     });
 
     test("override createdAt survives when modifiedAt differs", async () => {
@@ -366,7 +362,7 @@ describe("override decision: timestamps update materialized record", () => {
 
         await seedGraphScheme(xStorage, makeNodeDefs(["A"]));
         await runMigration(capabilities, rootDatabase, makeNodeDefs(["A"]), async (storage) => {
-            await storage.override(nodeKey, async () => ({ type: "all_events", events: [] }));
+            await storage.override(nodeKey, async () => ({ type: "all_events", events: [] }), "up-to-date");
         });
 
         const result = await yGet(yStorage.timestamps, yStorage, nodeKey);
@@ -391,7 +387,7 @@ describe("create decision: timestamps written to new storage", () => {
 
         await seedGraphScheme(xStorage, makeNodeDefs(["A"]));
         await runMigration(capabilities, rootDatabase, makeNodeDefs(["A"]), async (storage) => {
-            await storage.create(nodeKey, async () => ({ type: "all_events", events: [] }));
+            await storage.create(nodeKey, async () => ({ type: "all_events", events: [] }), "up-to-date");
         });
 
         const allKeys = [];
@@ -418,7 +414,7 @@ describe("create decision: timestamps written to new storage", () => {
 
         await seedGraphScheme(xStorage, makeNodeDefs(["A"]));
         await runMigration(capabilities, rootDatabase, makeNodeDefs(["A"]), async (storage) => {
-            await storage.create(nodeKey, async () => ({ type: "all_events", events: [] }));
+            await storage.create(nodeKey, async () => ({ type: "all_events", events: [] }), "up-to-date");
         });
 
         const result = await yGet(yStorage.timestamps, yStorage, nodeKey);
@@ -440,8 +436,8 @@ describe("create decision: timestamps written to new storage", () => {
 
         await seedGraphScheme(xStorage, makeNodeDefs(["A", "B"]));
         await runMigration(capabilities, rootDatabase, makeNodeDefs(["A", "B"]), async (storage) => {
-            await storage.create(nkA, async () => ({ type: "all_events", events: [] }));
-            await storage.create(nkB, async () => ({ type: "all_events", events: [] }));
+            await storage.create(nkA, async () => ({ type: "all_events", events: [] }), "up-to-date");
+            await storage.create(nkB, async () => ({ type: "all_events", events: [] }), "up-to-date");
         });
 
         const aResult = await yGet(yStorage.timestamps, yStorage, nkA);
@@ -477,7 +473,7 @@ describe("invalidate decision: timestamps update materialized record", () => {
         await expect(yGet(yStorage.timestamps, yStorage, nodeKey)).resolves.toEqual({ createdAt: OLD_TIMESTAMP.createdAt, modifiedAt: "2024-01-01T00:00:00.000Z" });
     });
 
-    test("invalidate without previous timestamp receives timestamp", async () => {
+    test("invalidate without previous timestamp fails final validation", async () => {
         const capabilities = await getTestCapabilities();
         const xStorage = makeSchemaStorage();
         const yStorage = makeSchemaStorage();
@@ -489,11 +485,9 @@ describe("invalidate decision: timestamps update materialized record", () => {
         });
 
         await seedGraphScheme(xStorage, makeNodeDefs(["A"]));
-        await runMigration(capabilities, rootDatabase, makeNodeDefs(["A"]), async (storage) => {
+        await expect(runMigration(capabilities, rootDatabase, makeNodeDefs(["A"]), async (storage) => {
             await storage.invalidate(nodeKey);
-        });
-
-        await expect(yGet(yStorage.timestamps, yStorage, nodeKey)).resolves.toEqual({ createdAt: "2024-01-01T00:00:00.000Z", modifiedAt: "2024-01-01T00:00:00.000Z" });
+        })).rejects.toThrow("has no timestamps entry");
     });
 
     test("invalidate preserves createdAt even though value is stale", async () => {
@@ -650,7 +644,7 @@ describe("two-node chain: mixed decision timestamp behaviour", () => {
         await seedGraphScheme(xStorage, makeNodeDefs(["A", "B"]));
         await runMigration(capabilities, rootDatabase, makeNodeDefs(["A", "B"]), async (storage) => {
             await storage.keep(nkA);
-            await storage.override(nkB, async () => ({ type: "all_events", events: [] }));
+            await storage.override(nkB, async () => ({ type: "all_events", events: [] }), "up-to-date");
         });
 
         await expect(yGet(yStorage.timestamps, yStorage, nkA)).resolves.toEqual(OLD_TIMESTAMP);
@@ -658,22 +652,17 @@ describe("two-node chain: mixed decision timestamp behaviour", () => {
         expect(bResult.createdAt).toBe(NEW_TIMESTAMP.createdAt);
     });
 
-    test("override A, B auto-invalidated: createdAt preserved and modifiedAt updates", async () => {
+    test("override A requires an explicit decision for B", async () => {
         const capabilities = await getTestCapabilities();
         const xStorage = makeSchemaStorage();
         const yStorage = makeSchemaStorage();
-        const { nkA, nkB } = await buildChain(xStorage);
+        const { nkA } = await buildChain(xStorage);
         const { rootDatabase } = makeRootDatabaseMock({ prevVersion: "1", currentVersion: "2", xStorage, yStorage });
 
-        // Override A; B is automatically invalidated (it depends on A)
         await seedGraphScheme(xStorage, makeNodeDefs(["A", "B"]));
-        await runMigration(capabilities, rootDatabase, makeNodeDefs(["A", "B"]), async (storage) => {
-            await storage.override(nkA, async () => ({ type: "all_events", events: [] }));
-            // nkB is auto-invalidated by override(nkA)
-        });
-
-        await expect(yGet(yStorage.timestamps, yStorage, nkA)).resolves.toEqual({ createdAt: OLD_TIMESTAMP.createdAt, modifiedAt: "2024-01-01T00:00:00.000Z" });
-        await expect(yGet(yStorage.timestamps, yStorage, nkB)).resolves.toEqual({ createdAt: NEW_TIMESTAMP.createdAt, modifiedAt: "2024-01-01T00:00:00.000Z" });
+        await expect(runMigration(capabilities, rootDatabase, makeNodeDefs(["A", "B"]), async (storage) => {
+            await storage.override(nkA, async () => ({ type: "all_events", events: [] }), "up-to-date");
+        })).rejects.toThrow("have no decision");
     });
 
     test("invalidate A, invalidate B: createdAt preserved and modifiedAt updates", async () => {

--- a/backend/tests/migration_storage.test.js
+++ b/backend/tests/migration_storage.test.js
@@ -225,7 +225,7 @@ describe("MigrationStorage", () => {
             await expect(ms.delete(A)).resolves.toBeUndefined();
         });
 
-        test("override(A, v) twice with same value fails", async () => {
+        test("override(A) twice fails with OverrideConflictError (non-idempotent)", async () => {
             const storage = makeInMemorySchemaStorage();
             const headIndex = makeHeadIndex(["A"]);
             const A = nk("A");
@@ -236,12 +236,12 @@ describe("MigrationStorage", () => {
             const lookup = makeLookupFromKeys([A]);
             const ms = makeMigrationStorage(storage, headIndex, [A], "testfingerprint", 0, scheme, scheme, lookup);
 
-            await ms.override(A, () => Promise.resolve(DUMMY_VALUE), "up-to-date");
-            const err = await ms.override(A, () => Promise.resolve(DUMMY_VALUE), "up-to-date").catch((e) => e);
+            await ms.override(A, () => Promise.resolve(DUMMY_VALUE));
+            const err = await ms.override(A, () => Promise.resolve(DUMMY_VALUE)).catch((e) => e);
             expect(isOverrideConflict(err)).toBe(true);
         });
 
-        test("override(A, v1) then override(A, v2) throws OverrideConflictError", async () => {
+        test("override(A) twice throws OverrideConflictError regardless of value identity", async () => {
             const storage = makeInMemorySchemaStorage();
             const headIndex = makeHeadIndex(["A"]);
             const A = nk("A");
@@ -252,8 +252,8 @@ describe("MigrationStorage", () => {
             const lookup = makeLookupFromKeys([A]);
             const ms = makeMigrationStorage(storage, headIndex, [A], "testfingerprint", 0, scheme, scheme, lookup);
 
-            await ms.override(A, () => Promise.resolve(DUMMY_VALUE), "up-to-date");
-            const err = await ms.override(A, () => Promise.resolve(DUMMY_VALUE_2), "up-to-date").catch((e) => e);
+            await ms.override(A, () => Promise.resolve(DUMMY_VALUE));
+            const err = await ms.override(A, () => Promise.resolve(DUMMY_VALUE_2)).catch((e) => e);
             expect(isOverrideConflict(err)).toBe(true);
         });
 
@@ -353,7 +353,7 @@ describe("MigrationStorage", () => {
             const lookup = makeLookupFromKeys([A]);
             const ms = makeMigrationStorage(storage, headIndex, [A], "testfingerprint", 0, scheme, scheme, lookup);
 
-            await ms.override(A, () => Promise.resolve(DUMMY_VALUE_2), "up-to-date");
+            await ms.override(A, () => Promise.resolve(DUMMY_VALUE_2));
             const result = await ms.get(A);
             expect(result).toEqual(DUMMY_VALUE); // still old value
         });
@@ -715,7 +715,7 @@ describe("MigrationStorage", () => {
             const headIndex = makeHeadIndex(["B", "C", "D"]);
             const ms = await setupStandardGraph(storage, headIndex);
 
-            const err = await ms.override(nk("A"), () => Promise.resolve(DUMMY_VALUE), "up-to-date").catch((e) => e);
+            const err = await ms.override(nk("A"), () => Promise.resolve(DUMMY_VALUE)).catch((e) => e);
             expect(isSchemaCompatibility(err)).toBe(true);
         });
 
@@ -931,7 +931,7 @@ describe("MigrationStorage", () => {
             const [, createDecision] = createDecisions[0];
             expect(createDecision?.kind).toBe("create");
             expect(createDecision?.nodeKeyString).toBe(nk("NEW"));
-            expect(createDecision?.value).toBe(valueFn, "up-to-date");
+            expect(createDecision?.value).toBe(valueFn);
         });
 
         test("create() stores the provided nodeKeyString in the decision", async () => {
@@ -1089,7 +1089,7 @@ describe("MigrationStorage", () => {
 
             // Pass a function that returns a promise that never resolves; override() should return immediately
             const neverResolves = () => new Promise(() => {});
-            await expect(ms.override(A, neverResolves, "up-to-date")).resolves.toBeUndefined();
+            await expect(ms.override(A, neverResolves)).resolves.toBeUndefined();
         });
 
         test("override() passes the nodeKey to the value function", async () => {

--- a/backend/tests/migration_storage.test.js
+++ b/backend/tests/migration_storage.test.js
@@ -41,6 +41,7 @@ function makeInMemorySchemaStorage() {
     const values = makeInMemoryDb();
     const freshness = makeInMemoryDb();
     const valid = makeInMemoryDb();
+    const timestamps = makeInMemoryDb();
     const global = makeInMemoryDb();
     const originalGlobalGet = global.get.bind(global);
     global.get = async (key) => {
@@ -57,6 +58,7 @@ function makeInMemorySchemaStorage() {
         values,
         freshness,
         valid,
+        timestamps,
         global,
         async batch(_ops) {},
     };
@@ -150,6 +152,14 @@ async function setupStandardGraph(storage, newHeadIndex, opts = {}) {
     await storage.values.put(A, DUMMY_VALUE);
     await storage.values.put(B, DUMMY_VALUE);
     await storage.values.put(C, DUMMY_VALUE);
+    await storage.freshness.put(A, "up-to-date");
+    await storage.freshness.put(B, "up-to-date");
+    await storage.freshness.put(C, "up-to-date");
+    await storage.freshness.put(D, opts.noValueForD ? "missing" : "up-to-date");
+    await storage.timestamps.put(A, { createdAt: "2024-01-01T00:00:00.000Z", modifiedAt: "2024-01-01T00:00:00.000Z" });
+    await storage.timestamps.put(B, { createdAt: "2024-01-01T00:00:00.000Z", modifiedAt: "2024-01-01T00:00:00.000Z" });
+    await storage.timestamps.put(C, { createdAt: "2024-01-01T00:00:00.000Z", modifiedAt: "2024-01-01T00:00:00.000Z" });
+    await storage.timestamps.put(D, { createdAt: "2024-01-01T00:00:00.000Z", modifiedAt: "2024-01-01T00:00:00.000Z" });
     if (!opts.noValueForD) {
         await storage.values.put(D, DUMMY_VALUE);
     }
@@ -180,6 +190,8 @@ describe("MigrationStorage", () => {
             const scheme = makeSingleNodeScheme("A");
             const lookup = makeLookupFromKeys([A]);
             await storage.values.put(A, DUMMY_VALUE);
+            await storage.freshness.put(A, "up-to-date");
+            await storage.timestamps.put(A, { createdAt: "2024-01-01T00:00:00.000Z", modifiedAt: "2024-01-01T00:00:00.000Z" });
             const ms = makeMigrationStorage(storage, headIndex, [A], "testfingerprint", 0, scheme, scheme, lookup);
 
             await ms.keep(A);
@@ -191,6 +203,8 @@ describe("MigrationStorage", () => {
             const headIndex = makeHeadIndex(["A"]);
             const A = nk("A");
             await storage.values.put(A, DUMMY_VALUE);
+            await storage.freshness.put(A, "up-to-date");
+            await storage.timestamps.put(A, { createdAt: "2024-01-01T00:00:00.000Z", modifiedAt: "2024-01-01T00:00:00.000Z" });
             const scheme = makeSingleNodeScheme("A");
             const lookup = makeLookupFromKeys([A]);
             const ms = makeMigrationStorage(storage, headIndex, [A], "testfingerprint", 0, scheme, scheme, lookup);
@@ -216,12 +230,14 @@ describe("MigrationStorage", () => {
             const headIndex = makeHeadIndex(["A"]);
             const A = nk("A");
             await storage.values.put(A, DUMMY_VALUE);
+            await storage.freshness.put(A, "up-to-date");
+            await storage.timestamps.put(A, { createdAt: "2024-01-01T00:00:00.000Z", modifiedAt: "2024-01-01T00:00:00.000Z" });
             const scheme = makeSingleNodeScheme("A");
             const lookup = makeLookupFromKeys([A]);
             const ms = makeMigrationStorage(storage, headIndex, [A], "testfingerprint", 0, scheme, scheme, lookup);
 
-            await ms.override(A, () => Promise.resolve(DUMMY_VALUE));
-            const err = await ms.override(A, () => Promise.resolve(DUMMY_VALUE)).catch((e) => e);
+            await ms.override(A, () => Promise.resolve(DUMMY_VALUE), "up-to-date");
+            const err = await ms.override(A, () => Promise.resolve(DUMMY_VALUE), "up-to-date").catch((e) => e);
             expect(isOverrideConflict(err)).toBe(true);
         });
 
@@ -230,12 +246,14 @@ describe("MigrationStorage", () => {
             const headIndex = makeHeadIndex(["A"]);
             const A = nk("A");
             await storage.values.put(A, DUMMY_VALUE);
+            await storage.freshness.put(A, "up-to-date");
+            await storage.timestamps.put(A, { createdAt: "2024-01-01T00:00:00.000Z", modifiedAt: "2024-01-01T00:00:00.000Z" });
             const scheme = makeSingleNodeScheme("A");
             const lookup = makeLookupFromKeys([A]);
             const ms = makeMigrationStorage(storage, headIndex, [A], "testfingerprint", 0, scheme, scheme, lookup);
 
-            await ms.override(A, () => Promise.resolve(DUMMY_VALUE));
-            const err = await ms.override(A, () => Promise.resolve(DUMMY_VALUE_2)).catch((e) => e);
+            await ms.override(A, () => Promise.resolve(DUMMY_VALUE), "up-to-date");
+            const err = await ms.override(A, () => Promise.resolve(DUMMY_VALUE_2), "up-to-date").catch((e) => e);
             expect(isOverrideConflict(err)).toBe(true);
         });
 
@@ -246,6 +264,8 @@ describe("MigrationStorage", () => {
             const scheme = makeSingleNodeScheme("A");
             const lookup = makeLookupFromKeys([A]);
             await storage.values.put(A, DUMMY_VALUE);
+            await storage.freshness.put(A, "up-to-date");
+            await storage.timestamps.put(A, { createdAt: "2024-01-01T00:00:00.000Z", modifiedAt: "2024-01-01T00:00:00.000Z" });
             const ms = makeMigrationStorage(storage, headIndex, [A], "testfingerprint", 0, scheme, scheme, lookup);
 
             await ms.keep(A);
@@ -260,6 +280,8 @@ describe("MigrationStorage", () => {
             const scheme = makeSingleNodeScheme("A");
             const lookup = makeLookupFromKeys([A]);
             await storage.values.put(A, DUMMY_VALUE);
+            await storage.freshness.put(A, "up-to-date");
+            await storage.timestamps.put(A, { createdAt: "2024-01-01T00:00:00.000Z", modifiedAt: "2024-01-01T00:00:00.000Z" });
             const ms = makeMigrationStorage(storage, headIndex, [A], "testfingerprint", 0, scheme, scheme, lookup);
 
             await ms.invalidate(A);
@@ -267,15 +289,13 @@ describe("MigrationStorage", () => {
             expect(isDecisionConflict(err)).toBe(true);
         });
 
-        test("keep(D) then override(A) causes propagation conflict", async () => {
+        test("keep(D) then override(A) does not propagate invalidation", async () => {
             const storage = makeInMemorySchemaStorage();
             const headIndex = makeHeadIndex(["A", "B", "C", "D"]);
             const ms = await setupStandardGraph(storage, headIndex);
 
             await ms.keep(nk("D"));
-            // override(A) propagates INVALIDATE to B and D → D has KEEP → conflict
-            const err = await ms.override(nk("A"), () => Promise.resolve(DUMMY_VALUE)).catch((e) => e);
-            expect(isDecisionConflict(err)).toBe(true);
+            await expect(ms.override(nk("A"), () => Promise.resolve(DUMMY_VALUE))).resolves.toBeUndefined();
         });
     });
 
@@ -312,6 +332,8 @@ describe("MigrationStorage", () => {
             const headIndex = makeHeadIndex(["A"]);
             const A = nk("A");
             await storage.values.put(A, DUMMY_VALUE);
+            await storage.freshness.put(A, "up-to-date");
+            await storage.timestamps.put(A, { createdAt: "2024-01-01T00:00:00.000Z", modifiedAt: "2024-01-01T00:00:00.000Z" });
             const scheme = makeSingleNodeScheme("A");
             const lookup = makeLookupFromKeys([A]);
             const ms = makeMigrationStorage(storage, headIndex, [A], "testfingerprint", 0, scheme, scheme, lookup);
@@ -325,11 +347,13 @@ describe("MigrationStorage", () => {
             const headIndex = makeHeadIndex(["A"]);
             const A = nk("A");
             await storage.values.put(A, DUMMY_VALUE);
+            await storage.freshness.put(A, "up-to-date");
+            await storage.timestamps.put(A, { createdAt: "2024-01-01T00:00:00.000Z", modifiedAt: "2024-01-01T00:00:00.000Z" });
             const scheme = makeSingleNodeScheme("A");
             const lookup = makeLookupFromKeys([A]);
             const ms = makeMigrationStorage(storage, headIndex, [A], "testfingerprint", 0, scheme, scheme, lookup);
 
-            await ms.override(A, () => Promise.resolve(DUMMY_VALUE_2));
+            await ms.override(A, () => Promise.resolve(DUMMY_VALUE_2), "up-to-date");
             const result = await ms.get(A);
             expect(result).toEqual(DUMMY_VALUE); // still old value
         });
@@ -370,30 +394,31 @@ describe("MigrationStorage", () => {
     });
 
     // -----------------------------------------------------------------------
-    // Section 4: OVERRIDE propagation
+    // Section 4: OVERRIDE preserves graph state
     // -----------------------------------------------------------------------
-    describe("Section 4: OVERRIDE propagation", () => {
-        test("override(A) invalidates B and D", async () => {
+    describe("Section 4: OVERRIDE preserves graph state", () => {
+        test("override(A) does not invalidate B and D", async () => {
             const storage = makeInMemorySchemaStorage();
             const headIndex = makeHeadIndex(["A", "B", "C", "D"]);
             const ms = await setupStandardGraph(storage, headIndex);
 
             await ms.override(nk("A"), () => Promise.resolve(DUMMY_VALUE_2));
+            await ms.keep(nk("B"));
             await ms.keep(nk("C"));
+            await ms.keep(nk("D"));
             const decisions = await ms.finalize();
 
-            expect(decisions.get(nk("B"))?.kind).toBe("invalidate");
-            expect(decisions.get(nk("D"))?.kind).toBe("invalidate");
+            expect(decisions.get(nk("B"))?.kind).toBe("keep");
+            expect(decisions.get(nk("D"))?.kind).toBe("keep");
         });
 
-        test("keep(D) then override(A) throws DecisionConflictError via propagation", async () => {
+        test("keep(D) then override(A) is allowed because override does not propagate", async () => {
             const storage = makeInMemorySchemaStorage();
             const headIndex = makeHeadIndex(["A", "B", "C", "D"]);
             const ms = await setupStandardGraph(storage, headIndex);
 
             await ms.keep(nk("D"));
-            const err = await ms.override(nk("A"), () => Promise.resolve(DUMMY_VALUE_2)).catch((e) => e);
-            expect(isDecisionConflict(err)).toBe(true);
+            await expect(ms.override(nk("A"), () => Promise.resolve(DUMMY_VALUE_2))).resolves.toBeUndefined();
         });
     });
 
@@ -626,6 +651,8 @@ describe("MigrationStorage", () => {
             const scheme = makeSingleNodeScheme("A");
             const lookup = makeLookupFromKeys([A]);
             await storage.values.put(A, DUMMY_VALUE);
+            await storage.freshness.put(A, "up-to-date");
+            await storage.timestamps.put(A, { createdAt: "2024-01-01T00:00:00.000Z", modifiedAt: "2024-01-01T00:00:00.000Z" });
             const ms = makeMigrationStorage(storage, headIndex, [A], "testfingerprint", 0, scheme, scheme, lookup);
 
             const err = await ms.getDependencyKeys(nk("Z")).catch((e) => e);
@@ -688,7 +715,7 @@ describe("MigrationStorage", () => {
             const headIndex = makeHeadIndex(["B", "C", "D"]);
             const ms = await setupStandardGraph(storage, headIndex);
 
-            const err = await ms.override(nk("A"), () => Promise.resolve(DUMMY_VALUE)).catch((e) => e);
+            const err = await ms.override(nk("A"), () => Promise.resolve(DUMMY_VALUE), "up-to-date").catch((e) => e);
             expect(isSchemaCompatibility(err)).toBe(true);
         });
 
@@ -721,7 +748,7 @@ describe("MigrationStorage", () => {
             const lookup = makeLookupFromKeys([A]);
             const ms = makeMigrationStorage(storage, headIndex, [A], "testfingerprint", 0, scheme, scheme, lookup);
 
-            const err = await ms.create(nk("NONEXISTENT"), () => Promise.resolve(DUMMY_VALUE)).catch((e) => e);
+            const err = await ms.create(nk("NONEXISTENT"), () => Promise.resolve(DUMMY_VALUE), "up-to-date").catch((e) => e);
             expect(isSchemaCompatibility(err)).toBe(true);
         });
 
@@ -735,7 +762,7 @@ describe("MigrationStorage", () => {
             const ms = makeMigrationStorage(storage, headIndex, [A], "testfingerprint", 0, scheme, scheme, lookup);
 
             // nk("event") produces arity 0 — mismatch with schema arity 1
-            const err = await ms.create(nk("event"), () => Promise.resolve(DUMMY_VALUE)).catch((e) => e);
+            const err = await ms.create(nk("event"), () => Promise.resolve(DUMMY_VALUE), "up-to-date").catch((e) => e);
             expect(isSchemaCompatibility(err)).toBe(true);
         });
 
@@ -749,7 +776,7 @@ describe("MigrationStorage", () => {
 
             const { stringToNodeKeyString } = require("../src/generators/incremental_graph/database");
             const malformedKey = stringToNodeKeyString("not valid json");
-            const err = await ms.create(malformedKey, () => Promise.resolve(DUMMY_VALUE)).catch((e) => e);
+            const err = await ms.create(malformedKey, () => Promise.resolve(DUMMY_VALUE), "up-to-date").catch((e) => e);
             expect(err).toBeDefined();
         });
     });
@@ -765,10 +792,12 @@ describe("MigrationStorage", () => {
             const scheme = makeSingleNodeScheme("A");
             const lookup = makeLookupFromKeys([A]);
             await storage.values.put(A, DUMMY_VALUE);
+            await storage.freshness.put(A, "up-to-date");
+            await storage.timestamps.put(A, { createdAt: "2024-01-01T00:00:00.000Z", modifiedAt: "2024-01-01T00:00:00.000Z" });
             const ms = makeMigrationStorage(storage, headIndex, [A], "testfingerprint", 0, scheme, scheme, lookup);
 
             await ms.keep(A);
-            await expect(ms.create(nk("NEW"), () => Promise.resolve(DUMMY_VALUE))).resolves.toBeUndefined();
+            await expect(ms.create(nk("NEW"), () => Promise.resolve(DUMMY_VALUE), "up-to-date")).resolves.toBeUndefined();
         });
 
         test("create(existingNode) throws CreateExistingNodeError", async () => {
@@ -776,11 +805,13 @@ describe("MigrationStorage", () => {
             const headIndex = makeHeadIndex(["A"]);
             const A = nk("A");
             await storage.values.put(A, DUMMY_VALUE);
+            await storage.freshness.put(A, "up-to-date");
+            await storage.timestamps.put(A, { createdAt: "2024-01-01T00:00:00.000Z", modifiedAt: "2024-01-01T00:00:00.000Z" });
             const scheme = makeSingleNodeScheme("A");
             const lookup = makeLookupFromKeys([A]);
             const ms = makeMigrationStorage(storage, headIndex, [A], "testfingerprint", 0, scheme, scheme, lookup);
 
-            const err = await ms.create(A, () => Promise.resolve(DUMMY_VALUE)).catch((e) => e);
+            const err = await ms.create(A, () => Promise.resolve(DUMMY_VALUE), "up-to-date").catch((e) => e);
             expect(isCreateExistingNode(err)).toBe(true);
         });
 
@@ -795,10 +826,12 @@ describe("MigrationStorage", () => {
             const scheme = makeSingleNodeScheme("A");
             const lookup = makeLookupFromKeys([A]);
             await storage.values.put(A, DUMMY_VALUE);
+            await storage.freshness.put(A, "up-to-date");
+            await storage.timestamps.put(A, { createdAt: "2024-01-01T00:00:00.000Z", modifiedAt: "2024-01-01T00:00:00.000Z" });
             const ms = makeMigrationStorage(storage, headIndex, [A], "testfingerprint", 0, scheme, scheme, lookup);
 
             await ms.keep(A);
-            const err = await ms.create(nk("NEW"), () => Promise.resolve(DUMMY_VALUE)).catch((e) => e);
+            const err = await ms.create(nk("NEW"), () => Promise.resolve(DUMMY_VALUE), "up-to-date").catch((e) => e);
             expect(isCreateExistingNode(err)).toBe(true);
         });
 
@@ -809,11 +842,13 @@ describe("MigrationStorage", () => {
             const scheme = makeSingleNodeScheme("A");
             const lookup = makeLookupFromKeys([A]);
             await storage.values.put(A, DUMMY_VALUE);
+            await storage.freshness.put(A, "up-to-date");
+            await storage.timestamps.put(A, { createdAt: "2024-01-01T00:00:00.000Z", modifiedAt: "2024-01-01T00:00:00.000Z" });
             const ms = makeMigrationStorage(storage, headIndex, [A], "testfingerprint", 0, scheme, scheme, lookup);
 
             await ms.keep(A);
-            await ms.create(nk("NEW"), () => Promise.resolve(DUMMY_VALUE));
-            const err = await ms.create(nk("NEW"), () => Promise.resolve(DUMMY_VALUE_2)).catch((e) => e);
+            await ms.create(nk("NEW"), () => Promise.resolve(DUMMY_VALUE), "up-to-date");
+            const err = await ms.create(nk("NEW"), () => Promise.resolve(DUMMY_VALUE_2), "up-to-date").catch((e) => e);
             expect(isDecisionConflict(err)).toBe(true);
         });
 
@@ -824,10 +859,12 @@ describe("MigrationStorage", () => {
             const scheme = makeSingleNodeScheme("A");
             const lookup = makeLookupFromKeys([A]);
             await storage.values.put(A, DUMMY_VALUE);
+            await storage.freshness.put(A, "up-to-date");
+            await storage.timestamps.put(A, { createdAt: "2024-01-01T00:00:00.000Z", modifiedAt: "2024-01-01T00:00:00.000Z" });
             const ms = makeMigrationStorage(storage, headIndex, [A], "testfingerprint", 0, scheme, scheme, lookup);
 
             await ms.keep(A);
-            await ms.create(nk("NEW"), () => Promise.resolve(DUMMY_VALUE_2));
+            await ms.create(nk("NEW"), () => Promise.resolve(DUMMY_VALUE_2), "up-to-date");
             const decisions = await ms.finalize();
 
             const createDecisions = [...decisions.entries()].filter(([, d]) => d.kind === "create");
@@ -846,10 +883,12 @@ describe("MigrationStorage", () => {
             const scheme = makeSingleNodeScheme("A");
             const lookup = makeLookupFromKeys([A]);
             await storage.values.put(A, DUMMY_VALUE);
+            await storage.freshness.put(A, "up-to-date");
+            await storage.timestamps.put(A, { createdAt: "2024-01-01T00:00:00.000Z", modifiedAt: "2024-01-01T00:00:00.000Z" });
             const ms = makeMigrationStorage(storage, headIndex, [A], "testfingerprint", 0, scheme, scheme, lookup);
 
             // Only create a new node, don't decide A
-            await ms.create(nk("NEW"), () => Promise.resolve(DUMMY_VALUE));
+            await ms.create(nk("NEW"), () => Promise.resolve(DUMMY_VALUE), "up-to-date");
             const err = await ms.finalize().catch((e) => e);
             expect(isUndecidedNodes(err)).toBe(true);
         });
@@ -861,12 +900,14 @@ describe("MigrationStorage", () => {
             const scheme = makeSingleNodeScheme("A");
             const lookup = makeLookupFromKeys([A]);
             await storage.values.put(A, DUMMY_VALUE);
+            await storage.freshness.put(A, "up-to-date");
+            await storage.timestamps.put(A, { createdAt: "2024-01-01T00:00:00.000Z", modifiedAt: "2024-01-01T00:00:00.000Z" });
             const ms = makeMigrationStorage(storage, headIndex, [A], "testfingerprint", 0, scheme, scheme, lookup);
 
             await ms.keep(A);
             // Pass a function that returns a promise that never resolves; create() should return immediately
             const neverResolves = () => new Promise(() => {});
-            await expect(ms.create(nk("NEW"), neverResolves)).resolves.toBeUndefined();
+            await expect(ms.create(nk("NEW"), neverResolves, "up-to-date")).resolves.toBeUndefined();
         });
 
         test("create() stores function and nodeKeyString in decision", async () => {
@@ -876,11 +917,13 @@ describe("MigrationStorage", () => {
             const scheme = makeSingleNodeScheme("A");
             const lookup = makeLookupFromKeys([A]);
             await storage.values.put(A, DUMMY_VALUE);
+            await storage.freshness.put(A, "up-to-date");
+            await storage.timestamps.put(A, { createdAt: "2024-01-01T00:00:00.000Z", modifiedAt: "2024-01-01T00:00:00.000Z" });
             const ms = makeMigrationStorage(storage, headIndex, [A], "testfingerprint", 0, scheme, scheme, lookup);
 
             const valueFn = () => Promise.resolve(DUMMY_VALUE_2);
             await ms.keep(A);
-            await ms.create(nk("NEW"), valueFn);
+            await ms.create(nk("NEW"), valueFn, "up-to-date");
             const decisions = await ms.finalize();
 
             const createDecisions = [...decisions.entries()].filter(([, d]) => d.kind === "create");
@@ -888,7 +931,7 @@ describe("MigrationStorage", () => {
             const [, createDecision] = createDecisions[0];
             expect(createDecision?.kind).toBe("create");
             expect(createDecision?.nodeKeyString).toBe(nk("NEW"));
-            expect(createDecision?.value).toBe(valueFn);
+            expect(createDecision?.value).toBe(valueFn, "up-to-date");
         });
 
         test("create() stores the provided nodeKeyString in the decision", async () => {
@@ -898,11 +941,13 @@ describe("MigrationStorage", () => {
             const scheme = makeSingleNodeScheme("A");
             const lookup = makeLookupFromKeys([A]);
             await storage.values.put(A, DUMMY_VALUE);
+            await storage.freshness.put(A, "up-to-date");
+            await storage.timestamps.put(A, { createdAt: "2024-01-01T00:00:00.000Z", modifiedAt: "2024-01-01T00:00:00.000Z" });
             const ms = makeMigrationStorage(storage, headIndex, [A], "testfingerprint", 0, scheme, scheme, lookup);
 
             await ms.keep(A);
             const semanticKey = nk("NEW");
-            await ms.create(semanticKey, () => Promise.resolve(DUMMY_VALUE));
+            await ms.create(semanticKey, () => Promise.resolve(DUMMY_VALUE), "up-to-date");
             const decisions = await ms.finalize();
 
             const createDecisions = [...decisions.entries()].filter(([, d]) => d.kind === "create");
@@ -923,8 +968,8 @@ describe("MigrationStorage", () => {
             await storage1.values.put(A1, DUMMY_VALUE);
             const ms1 = makeMigrationStorage(storage1, headIndex1, [A1], "testfingerprint", 0, scheme1, scheme1, lookup1);
             await ms1.keep(A1);
-            await ms1.create(nk("NEW1"), () => Promise.resolve(DUMMY_VALUE));
-            await ms1.create(nk("NEW2"), () => Promise.resolve(DUMMY_VALUE_2));
+            await ms1.create(nk("NEW1"), () => Promise.resolve(DUMMY_VALUE), "up-to-date");
+            await ms1.create(nk("NEW2"), () => Promise.resolve(DUMMY_VALUE_2), "up-to-date");
             const decisions1 = await ms1.finalize();
 
             // Second run — same fixture, same decisions
@@ -936,8 +981,8 @@ describe("MigrationStorage", () => {
             await storage2.values.put(A2, DUMMY_VALUE);
             const ms2 = makeMigrationStorage(storage2, headIndex2, [A2], "testfingerprint", 0, scheme2, scheme2, lookup2);
             await ms2.keep(A2);
-            await ms2.create(nk("NEW1"), () => Promise.resolve(DUMMY_VALUE));
-            await ms2.create(nk("NEW2"), () => Promise.resolve(DUMMY_VALUE_2));
+            await ms2.create(nk("NEW1"), () => Promise.resolve(DUMMY_VALUE), "up-to-date");
+            await ms2.create(nk("NEW2"), () => Promise.resolve(DUMMY_VALUE_2), "up-to-date");
             const decisions2 = await ms2.finalize();
 
             // Identifiers must be byte-for-byte identical
@@ -967,8 +1012,8 @@ describe("MigrationStorage", () => {
             await storageA.values.put(A_A, DUMMY_VALUE);
             const msA = makeMigrationStorage(storageA, headIndexA, [A_A], "testfingerprint", 0, schemeA, schemeA, lookupA);
             await msA.keep(A_A);
-            await msA.create(nk("NEW1"), () => Promise.resolve(DUMMY_VALUE));
-            await msA.create(nk("NEW2"), () => Promise.resolve(DUMMY_VALUE_2));
+            await msA.create(nk("NEW1"), () => Promise.resolve(DUMMY_VALUE), "up-to-date");
+            await msA.create(nk("NEW2"), () => Promise.resolve(DUMMY_VALUE_2), "up-to-date");
             const decisionsA = await msA.finalize();
 
             // Run B: identifiers_keys_map has [A, B] — same create sequence, same identifiers
@@ -983,8 +1028,8 @@ describe("MigrationStorage", () => {
             const msB = makeMigrationStorage(storageB, headIndexB, [A_B, B_B], "testfingerprint", 0, schemeB, schemeB, lookupB);
             await msB.keep(A_B);
             await msB.keep(B_B);
-            await msB.create(nk("NEW1"), () => Promise.resolve(DUMMY_VALUE));
-            await msB.create(nk("NEW2"), () => Promise.resolve(DUMMY_VALUE_2));
+            await msB.create(nk("NEW1"), () => Promise.resolve(DUMMY_VALUE), "up-to-date");
+            await msB.create(nk("NEW2"), () => Promise.resolve(DUMMY_VALUE_2), "up-to-date");
             const decisionsB = await msB.finalize();
 
             const createA = [...decisionsA.entries()].filter(([, d]) => d.kind === "create");
@@ -1004,12 +1049,14 @@ describe("MigrationStorage", () => {
             const scheme = makeSingleNodeScheme("A");
             const lookup = makeLookupFromKeys([A]);
             await storage.values.put(A, DUMMY_VALUE);
+            await storage.freshness.put(A, "up-to-date");
+            await storage.timestamps.put(A, { createdAt: "2024-01-01T00:00:00.000Z", modifiedAt: "2024-01-01T00:00:00.000Z" });
             const ms = makeMigrationStorage(storage, headIndex, [A], "testfingerprint", 0, scheme, scheme, lookup);
             await ms.keep(A);
 
             const nodeNames = ["N1", "N2", "N3", "N4", "N5"];
             for (const name of nodeNames) {
-                await ms.create(nk(name), () => Promise.resolve(DUMMY_VALUE));
+                await ms.create(nk(name), () => Promise.resolve(DUMMY_VALUE), "up-to-date");
             }
 
             const decisions = await ms.finalize();
@@ -1034,13 +1081,15 @@ describe("MigrationStorage", () => {
             const headIndex = makeHeadIndex(["A"]);
             const A = nk("A");
             await storage.values.put(A, DUMMY_VALUE);
+            await storage.freshness.put(A, "up-to-date");
+            await storage.timestamps.put(A, { createdAt: "2024-01-01T00:00:00.000Z", modifiedAt: "2024-01-01T00:00:00.000Z" });
             const scheme = makeSingleNodeScheme("A");
             const lookup = makeLookupFromKeys([A]);
             const ms = makeMigrationStorage(storage, headIndex, [A], "testfingerprint", 0, scheme, scheme, lookup);
 
             // Pass a function that returns a promise that never resolves; override() should return immediately
             const neverResolves = () => new Promise(() => {});
-            await expect(ms.override(A, neverResolves)).resolves.toBeUndefined();
+            await expect(ms.override(A, neverResolves, "up-to-date")).resolves.toBeUndefined();
         });
 
         test("override() passes the nodeKey to the value function", async () => {
@@ -1050,6 +1099,8 @@ describe("MigrationStorage", () => {
             const scheme = makeSingleNodeScheme("A");
             const lookup = makeLookupFromKeys([A]);
             await storage.values.put(A, DUMMY_VALUE);
+            await storage.freshness.put(A, "up-to-date");
+            await storage.timestamps.put(A, { createdAt: "2024-01-01T00:00:00.000Z", modifiedAt: "2024-01-01T00:00:00.000Z" });
             const ms = makeMigrationStorage(storage, headIndex, [A], "testfingerprint", 0, scheme, scheme, lookup);
 
             /** @type {string | undefined} */

--- a/docs/specs/migration.md
+++ b/docs/specs/migration.md
@@ -14,7 +14,7 @@ When the application version changes, any computed values stored in the previous
 * **decide** what happens to each previously-materialized node (keep, override, invalidate, or delete),
 * **traverse** the previous version's dependency graph.
 
-All writes are applied atomically.  If anything goes wrong during planning or validation, the new version's namespace remains unmodified.
+A failed migration never activates the target replica.  Failures before unification leave the target replica untouched.  Failures after unification may leave the inactive replica written, but the active replica remains unchanged.
 
 ---
 
@@ -159,4 +159,4 @@ If no previous version is found, the migration is a no-op.
 
 ## Atomicity guarantee
 
-Decisions are collected in memory during the callback.  The single write to the new version's storage happens only after all validation passes.  If any error is thrown before that write, the new version remains empty.
+Decisions are collected in memory during the callback.  The desired state is unified into the target replica's storage, then validated with `assertValidFinalMergeState` before the replica pointer is switched.  A failed migration never activates the target replica.  Failures before unification leave the target replica untouched.  Failures after unification may leave the inactive replica written, but the active replica remains unchanged.

--- a/docs/specs/migration.md
+++ b/docs/specs/migration.md
@@ -87,9 +87,9 @@ Calling the same decision twice (except for `override` and `create`) is allowed 
 
 `override` is a representation rewrite of an existing cached value. It preserves the cache-state proof envelope: freshness, timestamps, and validity are inherited from the old record. It must only be used when the migration author asserts that the new value is semantically equivalent to the old cached value for cache-validity purposes.
 
-`invalidate` preserves the cached value, marks cached nodes as `"potentially-outdated"`, updates `modifiedAt`, and keeps only validity that remains meaningful for stale-cache reuse.
+`invalidate` preserves the cached value if it exists, marks cached nodes as `"potentially-outdated"`, updates `modifiedAt`, and does not preserve incoming or outgoing valid flags for the invalidated node. This is a conservative/hard invalidation: the clean-cache claim for the node is withdrawn.
 
-`create(..., "up-to-date")` is a clean-cache assertion and is validated immediately.
+`create(..., "up-to-date")` is a clean-cache assertion. The migration validates this assertion before writing the migrated state.
 `create(..., "potentially-outdated")` seeds a cached value without claiming it is clean.
 
 ### Propagation rules
@@ -114,7 +114,7 @@ This means that to delete a fan-in node `D = f(B, C)`, both `B` and `C` must be 
 | Error class | When thrown |
 |-------------|------------|
 | `DecisionConflictError` | Two different decisions assigned to the same node. |
-| `OverrideConflictError` | `override()` called twice with different values. |
+| `OverrideConflictError` | `override()` called more than once on the same node. |
 | `CreateExistingNodeError` | `create()` called for a node that already exists in the previous version. |
 | `UndecidedNodesError` | Some nodes in `S` have no decision after the callback. |
 | `PartialDeleteFanInError` | DELETE propagation reaches a fan-in node not all of whose inputs are deleted. |

--- a/docs/specs/migration.md
+++ b/docs/specs/migration.md
@@ -22,7 +22,7 @@ All writes are applied atomically.  If anything goes wrong during planning or va
 
 ### Migration scope `S`
 
-`S` is the set of all nodes materialized in the previous version. A node is materialized if it has an entry in the `values` database.
+`S` is the set of all nodes materialized in the previous version. A node is materialized if its identifier exists in `identifiers_keys_map`. A cached node is a materialized node with an entry in `values`; a missing node is a materialized node with freshness `"missing"` and no value; a fresh node has freshness `"up-to-date"`; a stale node has freshness `"potentially-outdated"`.
 
 After the user-supplied migration callback returns, **every node in `S` must have exactly one decision**.  Missing decisions cause `UndecidedNodesError`.
 
@@ -47,10 +47,10 @@ All methods are `async`.
 |--------|-------------|
 | `get(nodeIdentifier)` | Return the previous-version value. |
 | `keep(nodeIdentifier)` | Preserve node as-is in the new version. |
-| `override(nodeIdentifier, value)` | Replace the node's value with the result of `value(nodeIdentifier)` (a `NodeIdentifier => Promise<ComputedValue>`). |
+| `override(nodeIdentifier, value)` | Rewrite an existing cached value with the result of `value(nodeIdentifier)` (a `NodeIdentifier => Promise<ComputedValue>`), while preserving its cache-state proof envelope. |
 | `invalidate(nodeIdentifier)` | Mark the node for recomputation. |
 | `delete(nodeIdentifier)` | Remove the node from the new version entirely. |
-| `create(nodeKeyString, value)` | Create a new node (not in the previous version) in the new schema with the result of `value(nodeIdentifier)` (a `NodeIdentifier => Promise<ComputedValue>`) as its initial value. `nodeKeyString` is a `NodeKeyString` — the semantic key by which the node will be identified in the new schema. A fresh `NodeIdentifier` is allocated automatically. |
+| `create(nodeKeyString, value, freshness)` | Create a new cached node (not in the previous version) in the new schema with the result of `value(nodeIdentifier)` (a `NodeIdentifier => Promise<ComputedValue>`) as its initial value. `freshness` must be `"up-to-date"` or `"potentially-outdated"`. `nodeKeyString` is a `NodeKeyString` — the semantic key by which the node will be identified in the new schema. A fresh `NodeIdentifier` is allocated automatically. |
 
 ### Traversal methods
 
@@ -81,11 +81,22 @@ Calling the same decision twice (except for `override` and `create`) is allowed 
 
 `keep`, `override`, `invalidate`, and `create` check that the node's functor and arity exist in the new schema.  Incompatible nodes must be explicitly `delete`d.  Violation throws `SchemaCompatibilityError`.
 
+### Operation semantics
+
+`keep` preserves the value, freshness, timestamps, and compatible validity.
+
+`override` is a representation rewrite of an existing cached value. It preserves the cache-state proof envelope: freshness, timestamps, and validity are inherited from the old record. It must only be used when the migration author asserts that the new value is semantically equivalent to the old cached value for cache-validity purposes.
+
+`invalidate` preserves the cached value, marks cached nodes as `"potentially-outdated"`, updates `modifiedAt`, and keeps only validity that remains meaningful for stale-cache reuse.
+
+`create(..., "up-to-date")` is a clean-cache assertion and is validated immediately.
+`create(..., "potentially-outdated")` seeds a cached value without claiming it is clean.
+
 ### Propagation rules
 
-#### OVERRIDE / INVALIDATE → propagate INVALIDATE downstream
+#### INVALIDATE → propagate INVALIDATE downstream
 
-When a node is overridden or invalidated, all its dependents are automatically marked `INVALIDATE` (recursively), unless they are already `DELETE`d.  If a dependent already has a `KEEP` or `OVERRIDE` decision, `DecisionConflictError` is thrown immediately.
+When a node is invalidated, all its dependents are automatically marked `INVALIDATE` (recursively), unless they are already `DELETE`d.  If a dependent already has a `KEEP` or `OVERRIDE` decision, `DecisionConflictError` is thrown immediately.
 
 #### DELETE → propagate DELETE downstream (deferred, fan-in strict)
 
@@ -108,6 +119,7 @@ This means that to delete a fan-in node `D = f(B, C)`, both `B` and `C` must be 
 | `UndecidedNodesError` | Some nodes in `S` have no decision after the callback. |
 | `PartialDeleteFanInError` | DELETE propagation reaches a fan-in node not all of whose inputs are deleted. |
 | `SchemaCompatibilityError` | `keep`/`override`/`invalidate`/`create` on a node absent from the new schema. |
+| `InvalidMigrationDecisionError` | `override` or `create` called without the cache-state proof required by its API. |
 | `GetMissingNodeError` | `get()`/traversal called for a node not in `S`. |
 | `GetMissingValueError` | `get()` called for a node in `S` with no computed value. |
 | `MissingDependencyMetadataError` | A materialized node has missing or corrupted dependency metadata. |


### PR DESCRIPTION
### Motivation
- Make migration decisions explicit and simpler by treating `override()` as a representation rewrite that only replaces a cached value while preserving its cache-state proof envelope.  
- Require callers to choose the freshness for new cached nodes created during migration so `create()` no longer silently mints clean proofs.  
- Avoid accidental invalidation or timestamp/freshness fabrication by enforcing strict preconditions and moving validity decisions into the final validity builder.

### Description
- Change `create(nodeKeyString, value)` to `create(nodeKeyString, value, freshness)` and add the `CreatedFreshness` typedef (`"up-to-date" | "potentially-outdated"`).  
- Make `override(nodeIdentifier, value)` enforce preconditions (materialized + cached, existing freshness present and not `"missing"`, existing timestamps present, and input-position compatibility) and remove downstream invalidation propagation so `override` only writes the new `values[id]`.  
- Add `InvalidMigrationDecisionError` for precise failure messages when `override`/`create` preconditions are violated.  
- Update lazy migration materialization (`makeLazyMigrationSource`) so `values`, `freshness`, and `timestamps` follow the new decision model: `override` inherits old freshness/timestamps, `create` uses caller-provided freshness and fresh timestamps, and `invalidate` maps to `potentially-outdated` (or `missing` when appropriate).  
- Rework validity reconstruction (`buildDesiredValid`) and introduce helpers (`isFinalCached`, `finalFreshness`) so `override` is grouped with `keep` for validity and `create(..., "up-to-date")` is validated immediately against cached up-to-date inputs.  
- Update schema/compatibility helpers and dependency propagation code to use the new `CreateDecision` shape; remove branches that treated `override`/`create` as implicitly up-to-date.  
- Revise migration docs (`docs/specs/migration.md`) to state the new conceptual model and to include the exact wording that `override` is a representation rewrite.  
- Update and extend unit tests to assert the new behaviors (override preserves freshness/timestamps/validity and does not propagate invalidation; `create` requires freshness and enforces clean-cache checks for `"up-to-date"`).

### Testing
- Ran `npm install` and `npm run static-analysis` with no reported static failures.  
- Executed focused migration suites with `npx jest backend/tests/migration_storage.test.js`, `npx jest backend/tests/migration_runner_timestamps.test.js`, and `npx jest backend/tests/migration_runner.test.js`, and fixed test regressions introduced by the API change until all migration suites passed.  
- Ran the full test suite (`npm test` / `npx jest --runInBand`) and observed all tests in the repository passing in this environment.  

@ottojung

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3db50d6218832e89da27a5dee3755f)