### PR TITLE
Make synchronized journals physically canonical and clarify sync/compaction/locking semantics

### DIFF
--- a/docs/incremental-graph-journal.md
+++ b/docs/incremental-graph-journal.md
@@ -83,7 +83,11 @@ docs/specs/incremental-graph-journal-types.md
 
 Journal entries are produced by graph operations that change the observable graph state.
 
-The journal emission rules define which IncrementalGraph operations create journal changes and how those changes are coordinated with graph storage updates. These rules cover recomputation, unchanged results, freshness invalidation (emits `invalidate` entries), creation, deletion, and migration actions.
+The journal emission rules define which IncrementalGraph operations create
+journal changes and how those changes are coordinated with graph storage
+updates. These rules cover recomputation, unchanged results, freshness
+invalidation (`invalidate`), freshness restoration (`validate`), creation,
+deletion, and migration actions.
 
 The detailed emission behavior is specified in:
 
@@ -97,7 +101,10 @@ Synchronization works by reading the current active local replica and the fetche
 
 Journal events are only the events that were already emitted by ordinary graph operations, migration operations, explicit freshness transitions, and actual node deletion operations. Synchronization does not invent new logical journal events. Existing events may be copied into the inactive destination, retained at their existing numeric position, made absent by poisoning or absence propagation, moved to a fresh position when their original position cannot survive, deduplicated when the same logical event already survives elsewhere, or removed when superseded according to the settled compaction or freshness rules.
 
-The journal synchronization model defines how journal histories are compared, merged, appended, deleted, or compacted during sync. It also defines how timestamps and host identities participate in conflict resolution.
+The journal synchronization model defines how existing journal histories are
+compared, copied, repositioned, omitted, and physically compacted during sync.
+It also defines how timestamps and host identities participate in conflict
+resolution.
 
 The detailed synchronization behavior is specified in:
 
@@ -152,7 +159,11 @@ The returned array reflects the logically compacted journal through `H`: for eac
 
 ### Structural journal operations
 
-Compaction and structural synchronization MUST call `closeGarden` to acquire exclusive garden access. These operations hold `closeGarden` for their complete analysis and durable mutation, acquiring darkroom only for the final atomic batch commit inside the garden closure.
+Compaction and structural synchronization MUST call `closeGarden` to acquire
+exclusive garden access. Compaction may overlap ordinary appends. Structural
+synchronization is a holiday operation: it first acquires `holidayActivity`,
+then `closeGarden`, builds the inactive destination, and acquires the destination
+darkroom for final metadata and cutover before releasing locks in reverse order.
 
 ### Lifecycle exclusion
 
@@ -160,7 +171,11 @@ Migration and replica cutover close the garden because of replica lifecycle safe
 
 ### Replica cutover
 
-A holiday closes both the dome and the garden. Replica cutover acquires `holidayActivity` (graph activity exclusion) and then `closeGarden` (garden exclusion) before performing the cutover. This prevents any new journal reader from selecting the old replica.
+A holiday closes both the dome and the garden. Migration, structural
+synchronization, and replica cutover acquire `holidayActivity` (graph activity
+exclusion) and then `closeGarden` (garden exclusion). This prevents ordinary
+appends from overlapping these operations and prevents new journal readers from
+selecting the old replica during cutover.
 
 ### Compatibility
 

--- a/docs/specs/incremental-graph-journal-api.md
+++ b/docs/specs/incremental-graph-journal-api.md
@@ -77,7 +77,12 @@ REQ-JA-04: `graph.possibleMaybeChanges` MUST skip absent journal entries. When s
 
 `graph.possibleMaybeChanges` returns at most two `PossibleNodeChange` values per matching semantic node key: one state/lifecycle entry (`add`, `edit`, or `delete`) and one freshness entry (`invalidate` or `validate`). Older entries for the same key and category are logically suppressed even when still physically present.
 
-REQ-JA-05: A returned `edit` entry describes a graph change or sync reconciliation that produced a journal entry. The entry's presence does not guarantee that the node's value materially changed from the consumer's perspective. Consumers SHOULD re-check the current node value rather than assuming the entry describes a visible state transition.
+REQ-JA-05: A returned `edit` is an existing journal event originally emitted by
+a graph operation or migration and possibly copied or repositioned by
+synchronization. Synchronization never produces an event. The entry's presence
+does not guarantee that the node's value materially changed from the consumer's
+perspective. Consumers SHOULD re-check the current node value rather than
+assuming the entry describes a visible state transition.
 
 ---
 

--- a/docs/specs/incremental-graph-journal-compaction.md
+++ b/docs/specs/incremental-graph-journal-compaction.md
@@ -12,7 +12,9 @@ Compaction relies on the `logicalJournalView(journal, H)` defined in `incrementa
 
 **Compaction scope and stored-cursor safety.** This PR specifies only same-process, in-memory journal tokens (see `incremental-graph-journal-types.md`). Since tokens are not persisted across process restarts, compaction does not need to guarantee long-lived cursor validity. A future spec may define checkpoint/lease-based compaction safety for persistent stored cursors; this PR does not specify such a mechanism.
 
-**Baseline scans and compaction.** A baseline scan starts from the first journal entry, so it returns only surviving journal entries. This is the natural consequence of the baseline being less than any real journal index combined with sparse journal storage after compaction.
+**Baseline scans and compaction.** A baseline scan returns the logical journal
+view through its fixed bound `H`. Entries outside that view are not returned,
+whether or not physical compaction has removed them.
 
 ---
 
@@ -60,7 +62,7 @@ Implementations MAY apply a quota or retention window to limit journal growth, f
 
 - Retain only entries newer than a configurable age threshold.
 - Retain at most `M` entries per node key, keeping only the most recent.
-- Retain at least one entry per still-materialized node to support sync conflict resolution.
+- Retain the entries selected by the two-category logical journal view.
 
 This specification does not mandate a specific quota policy. Any policy is valid as long as it satisfies the requirements in this document.
 
@@ -88,7 +90,9 @@ The logical retention rules replace the older collection of separate retention p
 
 2. **Freshness category** (`invalidate`, `validate`): preserve only the greatest-index entry through `H` (when one exists). Physical compaction may remove older freshness entries.
 
-These categories are independent: a newer state entry does not allow removal of the latest freshness entry; a newer freshness entry does not allow removal of the latest state entry. Neither `invalidate` nor `validate` satisfies the requirement that a materialized node retain `add` or `edit` evidence — those are independent categories.
+These categories are independent: a newer state entry does not allow removal of
+the latest freshness entry; a newer freshness entry does not allow removal of
+the latest state entry.
 
 ### Quotas
 
@@ -120,9 +124,14 @@ Retaining `validate X` does not rematerialize X or assign graph freshness to a d
 
 ### Interaction with synchronization
 
-REQ-JC-09: Compaction MAY remove journal entries even when synchronization is pending. Sync does not use `timestamps` sublevel records as a replacement for missing journal entries. Instead, sync uses only surviving journal entries for conflict comparison. Absent journal entries are treated as "no journal evidence" rather than falling back to node timestamps. See `incremental-graph-journal-sync.md` for the sync conflict-resolution rules.
+REQ-JC-09: Compaction MAY remove entries outside `logicalJournalView(journal,
+H)` even when synchronization is pending. Synchronization selects evidence from
+the source logical view and does not use `timestamps` sublevel records as a
+replacement for journal evidence. See `incremental-graph-journal-sync.md`.
 
-REQ-JC-10: Compaction is safe for synchronization correctness as long as the surviving journal entries (if any) plus the sync conflict rules produce correct convergence. Sync does not require journal entries that do not exist.
+REQ-JC-10: Compaction is safe for synchronization because it preserves every
+entry in the logical journal view used for conflict selection. Synchronization
+does not require entries outside that view.
 
 ---
 
@@ -169,7 +178,10 @@ This is the main reason `possibleMaybeChanges` must perform logical compaction i
 
 ## `graph.possibleMaybeChanges` behavior after compaction
 
-REQ-JC-12: `graph.possibleMaybeChanges` skips absent entries. If an entry's payload was deleted by compaction, it is gone and MUST NOT be reconstructed or included in the returned array.
+REQ-JC-12: `graph.possibleMaybeChanges` skips absent entries. An entry physically
+deleted by conforming compaction was already outside the logical journal view,
+was not returned before deletion, and is not reconstructed after deletion.
+Therefore its removal does not change the returned array.
 
 REQ-JC-13: `graph.possibleMaybeChanges` NEVER reconstructs deleted entries.
 
@@ -189,7 +201,10 @@ index 8 = edit X
 
 A query through `H = 5` may return index 5 as a `PossibleNodeChange`. Later index 8 is appended, and physical compaction may delete indices 1 and 5. A subsequent query with `since = token pointing to index 5` and `H = 8` returns `index 8 = edit X`. The cursor remains usable even though its backing entry is physically absent. Payload reconstruction is not required.
 
-REQ-JC-15: When a `BaselinePossibleNodeChange` is supplied as `since`, scanning starts from the first journal entry. Compaction affects the result only by determining which entries still exist.
+REQ-JC-15: When a `BaselinePossibleNodeChange` is supplied as `since`, the query
+returns the logical journal view through `H`. An entry removed by conforming
+compaction was excluded from that view before deletion and remains absent rather
+than being reconstructed, so physical removal does not change the result.
 
 ---
 
@@ -203,7 +218,9 @@ REQ-JC-18: Compaction MUST NOT change the `action` field of surviving journal en
 
 REQ-JC-19: Compaction MUST NOT merge entries from different `creator` hosts for the same node key. Each surviving entry retains its original `creator`.
 
-REQ-JC-20: Compaction MUST NOT compact a materialized node key into a state where the only surviving journal entries for that key are `invalidate` or `validate` entries. For every materialized node, at least one `add` or `edit` entry must remain. This is guaranteed by the state/lifecycle category of `logicalJournalView`: a materialized node's latest state entry through `H` is its `add` or `edit`; compaction must preserve it.
+REQ-JC-20: Compaction MUST preserve the greatest-index state/lifecycle entry
+through `H` for every semantic key. This follows solely from the captured journal
+prefix; mutable graph state is not an input to compaction analysis.
 
 REQ-JC-21: Compaction MUST NOT delete all surviving entries for a deleted key. The latest state entry (which may be `delete`) and latest freshness entry (when one exists) are logically required and must be preserved through the logical journal view.
 
@@ -213,7 +230,10 @@ REQ-JC-21: Compaction MUST NOT delete all surviving entries for a deleted key. T
 
 A future spec may define checkpoint/lease-based compaction safety for long-lived stored cursors. This PR does not specify such a mechanism.
 
-The precise deletion/tombstone retention policy for deleted nodes (when is a node sufficiently old to compact all its journal entries?) is deferred to a future specification.
+A conforming compaction cannot remove a deleted key's latest state entry or its
+latest freshness entry when one exists, because either removal would change
+`possibleMaybeChanges`. Only an incompatible future API revision could redefine
+that logical view.
 
 ---
 
@@ -227,9 +247,9 @@ A suggested compaction approach:
    - the greatest-index state/lifecycle entry (`add`, `edit`, or `delete`);
    - the greatest-index freshness entry (`invalidate` or `validate`), when one exists.
 2. Preserve every entry in that logical view. Remove all other physically present entries through `H`.
-3. For a materialized node, its latest state entry is its `add` or `edit` — this satisfies value-evidence retention automatically.
-4. For a deleted node, its latest state entry is its `delete` — this remains in the logical view.
-5. A quota policy may decide whether to remove all or some of the currently physically removable entries, or to skip a compaction run entirely. It must not remove logically required entries.
+3. A quota policy may decide whether to remove all or some of the currently
+   physically removable entries, or to skip a compaction run entirely. It must
+   not remove logically required entries.
 
 ---
 
@@ -331,3 +351,17 @@ index 9  = delete X
 ```
 
 Physical compaction may remove indices 2 and 4 but MUST preserve indices 6 and 9. The latest freshness and latest state entries for the deleted key remain in the logical view.
+
+### C8 — Captured prefix is independent of current graph state
+
+```
+H = 5
+index 5 = delete X
+
+later:
+index 6 = add X
+```
+
+A compaction that captured `H = 5` preserves index 5 because it is the latest
+state entry through that bound. It does not consult or reinterpret the prefix
+using the now-materialized graph state after index 6 commits.

--- a/docs/specs/incremental-graph-journal-emission.md
+++ b/docs/specs/incremental-graph-journal-emission.md
@@ -2,7 +2,10 @@
 
 ## Purpose
 
-This document specifies when journal entries are created — the rules for `add`, `edit`, `delete`, `invalidate`, and `validate` emissions triggered by IncrementalGraph operations, synchronization, and migration.
+This document specifies when journal entries are created — the rules for `add`,
+`edit`, `delete`, `invalidate`, and `validate` emissions triggered by
+IncrementalGraph operations and migration. Synchronization only copies,
+repositions, or omits existing events.
 
 Journal emission is always coordinated with the graph storage mutation that caused it: a journal entry MUST NOT be durably committed unless the corresponding graph change is also durably committed.
 
@@ -80,9 +83,14 @@ REQ-JE-07j: Repeating an operation that leaves freshness unchanged emits nothing
 
 ### Deletion: `delete`
 
-REQ-JE-08: A `delete` journal entry represents the removal or supersession of a node. The following circumstances produce `delete` entries:
+REQ-JE-08: A `delete` journal entry represents an actual node deletion. The
+following operation produces `delete` entries:
 
-- **Synchronization**: When synchronization reconciles conflicting identifiers for the same node key or propagates a remote deletion, the existing `delete` entries from the remote host are copied or reappended. Synchronization does not create new `delete` events. See `incremental-graph-journal-sync.md`.
+- **Actual deletion operations**: `storage.delete` and any future graph deletion
+  operation emit a `delete` for the node they delete.
+
+Synchronization may copy or reposition an existing `delete`; it never emits
+one. See `incremental-graph-journal-sync.md`.
 
 REQ-JE-09: Ordinary graph operations (`pull`, `invalidate`, recomputation) MUST NOT emit `delete` entries unless and until the IncrementalGraph system implements a general node deletion API. This specification does not assume such an API exists.
 

--- a/docs/specs/incremental-graph-journal-sync.md
+++ b/docs/specs/incremental-graph-journal-sync.md
@@ -8,48 +8,80 @@ Synchronization does **not** create new logical journal events. It works only wi
 
 ---
 
-## Core conflict resolution
+## Normative synchronization pipeline
 
-Physical compaction may already have removed every event outside the logical journal view. Therefore synchronization MUST NOT depend on raw physical entries that logical compaction would reject.
+Synchronization applies these stages in order. Physical source redundancy never
+participates in conflict selection.
 
-For each source replica and semantic node key, synchronization uses only the source's entries from `logicalJournalView(journal, last_journal_index)`:
+### Stage 1 — Validate event identity
 
-- the source's latest state entry (`add`, `edit`, or `delete`) — the greatest-index entry in the state/lifecycle category;
-- the source's latest freshness entry (`invalidate` or `validate`) — the greatest-index entry in the freshness category.
+For every occurrence in both source journals, the same `eventId` MUST identify
+the same immutable payload. Copies may occupy different physical positions. A
+payload disagreement for one `eventId` is a journal-integrity error:
+synchronization aborts, does not switch replicas, leaves the old active replica
+unchanged, and neither poisons the occurrences nor chooses a payload.
 
-Older physically present entries are redundant and must not affect graph conflict resolution, deletion conflict resolution, freshness conflict resolution, evidence preservation, or fresh reappend decisions.
+### Stage 2 — Compute each source logical view
 
-### Source consistency
+For each source, compute:
 
-REQ-JS-00: For a materialized source node with identifier `W`, the source's latest state entry MUST be `add` or `edit`, and its `id` MUST equal `W`.
+```
+logicalJournalView(sourceJournal, sourceH)
+```
 
-For a deleted source key with retained journal history, the latest state entry MUST be `delete`.
+For each semantic key this produces at most its source state entry and source
+freshness entry. No physically redundant source event may affect conflict
+resolution.
 
-If graph state and latest state evidence contradict one another, synchronization fails with a journal-integrity error and leaves the active replica unchanged.
+### Stage 3 — Select canonical state
 
-Synchronization MUST NOT substitute graph timestamp records for missing or contradictory journal evidence.
+For each semantic key:
 
-### State conflict comparison
+- if neither source has a state entry, the destination has none;
+- if only one source has a state entry, that existing event is canonical;
+- if both have state entries, compare later `time`, then (when identifiers
+  differ and times tie) lexicographically greater `NodeIdentifier`, then (when
+  identifiers and times tie) lexicographically greater `eventId`.
 
-Compare the two source latest-state entries:
+The winning existing event is canonical. `add` or `edit` materializes the key
+using that event's `NodeIdentifier` and associated source graph value. `delete`
+leaves it nonmaterialized. Synchronization creates no event.
 
-1. later `time` wins;
-2. if identifiers differ and times tie, lexicographically greater `NodeIdentifier` wins;
-3. if identifiers are equal and times tie, lexicographically greater `eventId` (string comparison) wins.
+### Stage 4 — Validate source graph consistency
 
-The winner determines:
-- materialized value/incarnation (the winning `add` or `edit`); or
-- deletion (the winning `delete`).
+For each source key:
 
-Synchronization creates no new event. It preserves or reappends the existing winning event.
+- a materialized node with identifier `W` requires a source state entry of
+  `add` or `edit` whose `id === W`;
+- a nonmaterialized key with a source state entry requires `delete`;
+- a key absent from both graph and journal may have no state entry.
 
-REQ-JS-01: When synchronizing two hosts, for each node key that appears in both replicas' graph state, the host whose latest state entry has the later `time` field wins the conflict. The winning host's value is retained; the losing identifier and associated records are removed.
+If one state `eventId` is associated with different stored graph values, or if
+graph state contradicts source state evidence, synchronization fails. Graph
+timestamp records MUST NOT replace journal evidence.
 
-REQ-JS-02: If both hosts have the same `time` for the conflicting latest state entry, tie-breaking is decided via lexicographic comparison of `NodeIdentifier` (converted to string) when identifiers differ. `NodeIdentifier` values are globally unique across hosts, making this a total deterministic tie-breaker. When identifiers are equal, lexicographically greater `eventId` wins.
+### Stage 5 — Select canonical freshness
+
+For a canonically materialized key, let the winning identifier be `W`. Consider
+each source freshness entry only when `entry.id === W`; ignore freshness for
+another identifier. Compare candidates by later `time`, then lexicographically
+greater `eventId` on a tie. The winner is the canonical freshness event:
+`invalidate` makes the graph `potentially-outdated`, while `validate` makes it
+`up-to-date`. If neither source supplies freshness evidence for `W`, use the
+winning source graph state's stored freshness. First materialization without
+freshness evidence is up to date.
+
+For a canonically deleted key, freshness never sets graph state. Preserve no
+freshness event when neither source has one; preserve the sole entry when only
+one source has one; and when both have entries preserve the winner by later
+`time`, then lexicographically greater `eventId`. That winner is canonical
+journal history only: it neither rematerializes the key nor assigns graph
+freshness.
 
 ### Wall-clock resolution
 
-A particular host's wall clock may be incorrect, but this is the best available signal for conflict ordering — the system trusts hosts and does not rely on external time authorities.
+A host's wall clock may be incorrect, but it is the available conflict-ordering
+signal. The system trusts hosts and does not rely on an external time authority.
 
 ---
 
@@ -127,7 +159,20 @@ The existing conflicting events already indicate that the semantic key may have 
 
 ## Journal merge rules
 
-### Published-prefix invariant
+### Physically canonical destination
+
+The completed inactive destination physically contains exactly its logical
+journal view. For each semantic node key it contains at most one state event
+(`add`, `edit`, or `delete`) and at most one freshness event (`invalidate` or
+`validate`). Every noncanonical event is absent. This construction is the
+equivalent of physical compaction and cannot change `possibleMaybeChanges`,
+because noncanonical events are already excluded by `logicalJournalView`.
+
+Synchronization does not preserve obsolete entries merely as physical history,
+and it never reappends a canonical event merely to outrank an obsolete event at
+a greater index. It omits the obsolete event instead.
+
+### Stage 6 — Reconcile physical positions
 
 The merge operates on two source replicas. For the local replica, the established prefix through its committed watermark is finalized. For the remote replica, its established prefix through its committed watermark is finalized.
 
@@ -144,23 +189,37 @@ P       = max(localH, remoteH)
 
    | local[ i ] | remote[ i ] | target[ i ] |
    |---|---|---|
-   | entry E | entry E | preserve E at i |
+   | entry E | entry E | preserve E at i only when E is canonical |
    | absent | absent | preserve absence at i |
    | entry E | absent | absence at i (see evidence preservation) |
    | absent | entry E | absence at i (see evidence preservation) |
-   | entry E | entry F (E ≠ F) | poison: absence at i; queue E and F for fresh reappend |
+   | entry E | entry F (E ≠ F) | poison: absence at i |
 
 2. **Only local has established state at `i`** (i ≤ localH, i > remoteH):
-   Preserve the local state (entry or absence) at `i` in the destination.
+   Preserve a local entry only when it is canonical; otherwise establish
+   absence. Preserve local absence.
 
 3. **Only remote has established state at `i`** (i > localH, i ≤ remoteH):
-   The position is unestablished locally. Replicate the remote state at `i` (copy the remote entry, or establish absence when the remote position is absent).
+   The position is unestablished locally. Preserve a remote entry only when it
+   is canonical; otherwise establish absence. Preserve remote absence.
 
 The entire prefix state through `P` is resolved before fresh entries are allocated.
 
-### Fresh entry allocation
+### Stage 7 — Normalize canonical occurrences
 
-Displaced entries (from poisoning or absence propagation) and evidence that cannot retain its original position are allocated at:
+For every canonical event, gather its surviving destination positions. If the
+same `eventId` survives at several physical positions:
+- retain the occurrence with the greatest `JournalIndex`;
+- make all lower occurrences absent;
+- do not create another fresh copy.
+
+If exactly one occurrence survives, retain it. If none survives, queue that same
+event for fresh placement. Thus a positioned canonical event is never queued,
+and every queued event is canonical and has no surviving positioned copy.
+
+### Stage 8 — Fresh placement
+
+Canonical events that have no surviving positioned occurrence are allocated at:
 
 ```
 P + 1 .. P + n
@@ -168,7 +227,7 @@ P + 1 .. P + n
 
 The final watermark is `P + n`.
 
-### Fresh entry ordering
+#### Fresh-entry ordering
 
 Fresh entries are ordered by:
 
@@ -182,95 +241,31 @@ Fresh entries are ordered by:
 
 Allocate the ordered entries contiguously at `P + 1 .. P + n`.
 
-### Deduplication
-
-If the same `eventId` survives at several physical positions in the merged destination:
-- retain the occurrence with the greatest `JournalIndex`;
-- make all lower occurrences absent;
-- do not create another fresh copy.
-
-An unpositioned event queued for fresh placement does not participate in the "greatest position" comparison.
-
-If the same event already survives at a positioned target entry, remove its queued fresh copy.
-
 ### Destination logical view canonicalization
 
-REQ-JS-07: After physical index reconciliation, the destination's `logicalJournalView(journal, P + n)` must contain exactly:
+REQ-JS-07: After physical index reconciliation, the destination physically
+contains exactly:
 
 - the canonical state event for each key;
 - the canonical freshness event for each key, when one exists.
 
-The canonical event may already occupy the greatest surviving index in its category. If it does not — for example, an obsolete event for the same key and category survives at a greater physical index in the merged prefix — reappend the canonical existing event at a fresh index above `P` (see fresh entry allocation). Preserve its exact action, key, identifier, time, creator, and `eventId`. This makes the canonical event the greatest-index event in its category.
-
-Older redundant entries may remain physically present until separate compaction. They are invisible through `possibleMaybeChanges`.
+Every obsolete or duplicate occurrence is absent. Fresh placement preserves the
+queued event's exact action, identifier, key, time, creator, and `eventId`.
+After allocating `n` queued events contiguously at `P + 1 .. P + n`, set
+`last_journal_index = P + n`. The completed destination therefore has at most
+one physical occurrence of each `eventId` and physically equals
+`logicalJournalView(journal, P + n)`.
 
 Synchronization still does not create any logical event.
 
 #### Required displaced evidence
 
-REQ-JS-08: If physical reconciliation displaces a canonical event because of same-index poisoning or entry-versus-established-absence, reappend it freshly. This applies to canonical state evidence and canonical freshness evidence.
-
-Do not reappend obsolete noncanonical events.
-
----
-
-## Value evidence
-
-REQ-JS-09: For conflicting materialized values, compare the two source latest-state entries (from `logicalJournalView` for each source) using the state conflict comparison rules defined in §State conflict comparison. Use the winning graph state. Preserve or reappend the existing causal events as required. Do not generate an additional event.
-
-For deletion conflict:
-
-REQ-JS-10: Compare the surviving `delete` event against the latest surviving `add` or `edit` using the state conflict comparison rules. Preserve the winning existing evidence. Do not generate an additional event.
-
-Synchronization must never use graph timestamp storage as replacement journal evidence.
-
----
-
-## Freshness evidence reconciliation
-
-Synchronization does not create freshness events. It reconciles existing `validate` and `invalidate` events using the same `logicalJournalView` per source replica.
-
-Freshness belongs to a node incarnation identified by `NodeIdentifier`, not merely to a semantic key. After the canonical graph winner is determined (resolving value conflicts via the state conflict comparison rules), only freshness events matching the winning `NodeIdentifier` may determine the canonical node's freshness.
-
-For each semantic node key whose canonical graph winner has `NodeIdentifier = W`:
-
-1. For each source replica, the source's latest freshness entry for `W` is the greatest-index `validate` or `invalidate` with `id === W` from that source's `logicalJournalView`. If the source has no such event, use the selected graph state's existing freshness (first materialization without a freshness event means up-to-date).
-
-2. If only one source has a candidate event for `W`, use it.
-
-3. If both sources have candidate events for `W`, compare:
-   1. `time`;
-   2. `eventId` (lexicographic string comparison).
-
-   Later time wins. If times tie, lexicographically greater `eventId` wins. `NodeIdentifier` is not used as a freshness tie-breaker here because both candidates are already restricted to `W`, making the identifiers equal.
-
-4. The canonical graph freshness follows the winning event:
-   - winning `invalidate`: `potentially-outdated`
-   - winning `validate`: `up-to-date`
-
-5. In the merged journal destination, preserve exactly one surviving freshness event for `W`: the winner.
-
-6. Make every other surviving `validate` or `invalidate` entry for `W` absent.
-
-7. Remove freshness events for losing node identifiers as obsolete (unless another explicit retention rule requires them — no such rule is currently specified).
-
-8. If the winner cannot remain at its old numeric position because of physical-position reconciliation, reappend the same existing event at a fresh index.
-
-9. Preserve its `eventId`.
-
-### Deleted canonical key
-
-When the canonical graph has no materialized node for the key, no freshness event sets graph state (there is no materialized graph freshness to set). The journal retains the latest freshness entry from `logicalJournalView` when one exists. The retained history does not make the deleted node up-to-date or potentially-outdated.
-
-This guarantees that:
-- the merged graph freshness matches the journal;
-- compaction has one required freshness event to retain;
-- `possibleMaybeChanges` returns the canonical freshness transition;
-- freshness events belonging to losing or obsolete node identifiers cannot affect the winning node's freshness.
-
-### Interaction with physical merge
-
-Run physical position reconciliation first. Then scope freshness normalization to the winning `NodeIdentifier`. The final destination must satisfy both per-position convergence rules and exactly one surviving canonical `validate` or `invalidate` event per winning-identifier incarnation when freshness evidence exists.
+REQ-JS-08: Entry-versus-established-absence reconciliation and same-index
+poisoning use one rule. The destination position is absent. If the removed event
+is canonical and has no other surviving position, queue that same event for
+fresh placement. Otherwise do not queue it. This rule covers canonical `add`,
+`edit`, `delete`, `invalidate`, and `validate` events and excludes every obsolete
+event.
 
 ---
 
@@ -290,17 +285,17 @@ A one-sided synchronization run produces that deterministic destination locally.
 
 ### Resolving divergent indices
 
-If the two source replicas have different `JournalEntry` values at the same `JournalIndex` `i`, the destination poisons that index. Both conflicting entries are deleted from index `i` in the destination. Any still-relevant changes described by the conflicting entries are appended at fresh `JournalIndex` values above `P`.
+If the two source replicas have different `JournalEntry` values at the same `JournalIndex` `i`, the destination poisons that index. Both conflicting entries are deleted from index `i` in the destination. A conflicting event is queued above `P` only when it is canonical and has no other surviving position.
 
 ### Present-versus-absence conflict
 
 If one source replica has an established journal entry at index `i` and the other has an established absence at the same index `i`, the destination establishes absence at index `i`. The present entry is removed in the destination.
 
-If the removed entry still carries relevant journal evidence (it is the only surviving `add` or `edit` for a materialized node), that evidence is reappended at a fresh index before or atomically with removing the established entry from the destination.
+If the removed event is canonical and has no other surviving position, queue the same event for fresh placement. Otherwise do not reappend it. This is the same rule used for same-index poisoning.
 
 ### Remote suffix
 
-A remote suffix position `i` (where `localH < i ≤ remoteH`) MAY be replicated at local position `i` in the destination while `i` is unestablished locally. If the position became established locally before sync finalization, sync reconciles the local and remote states at `i` using the same-index convergence rules.
+For `localH < i ≤ remoteH`, the local source has no established state at `i`. A canonical remote event at `i` may remain at `i` in the destination. A noncanonical remote event is omitted. Because synchronization holds `holidayActivity`, there is no concurrent ordinary append that can claim the position.
 
 ---
 
@@ -326,11 +321,11 @@ A future specification may address general multi-host convergence.
 
 ## Interaction with compaction
 
-Sync operates on the journal storage that exists at sync time. Compaction may have removed entries before sync.
-
-Sync uses only surviving journal entries for conflict comparison. Absent journal entries are treated as "no journal evidence" — sync MUST NOT fall back to graph `timestamps` sublevel as a replacement for missing journal entries.
-
-Compaction MUST NOT remove the only surviving `add` or `edit` entry for a materialized node (see REQ-JC-07). This ensures sync always has at least one journal-backed timestamp per materialized node for conflict comparison.
+Sync operates on each source's `logicalJournalView` at sync time. A conforming
+physical compaction may have removed entries outside that view, but it preserves
+every entry inside it, so source conflict selection is identical before and
+after compaction. Synchronization MUST NOT fall back to graph `timestamps`
+sublevel records as replacement journal evidence.
 
 ---
 
@@ -364,30 +359,24 @@ sync commits H = 6
 
 The remote entry is preserved at its original numeric position because it was unestablished locally.
 
-### T2 — Pre-sync append (before holidayActivity)
+### T2 — Pre-sync same-index conflict
 
-```
-local H = 5
+An ordinary append commits `F` at local index 6 before synchronization acquires
+`holidayActivity`; the remote source has `E` at index 6. Synchronization poisons
+index 6. No ordinary append overlaps synchronization after the holiday begins.
 
-An ordinary append commits F at index 6:
-    local H = 6
+#### Same semantic key and category
 
-Sync then acquires holidayActivity and selects the source:
-    local[6] = F
-    local H = 6
+When `E` and `F` are state events for the same semantic key, only the Stage 3
+winner is canonical. Only that winner is freshly placed above `P`, preserving
+its `eventId`; the loser is omitted.
 
-remote H = 6, remote[6] = E
+#### Different semantic keys or categories
 
-Sync constructs the inactive destination:
-    index 6 is a same-index conflict (F vs E)
-    target[6] = absent (poisoned)
-    F and E are reappended at indices 7 and 8
-    H = 8
-```
-
-This is a pre-synchronization append, not an operation overlapping
-synchronization. After holidayActivity is held, no further ordinary
-appends can occur until synchronization completes.
+When `E` and `F` belong to different semantic keys, or are canonical entries in
+different categories, both may be canonical. Both are freshly placed above `P`
+in the Stage 8 canonical ordering. Their exact positions cannot be stated unless
+all ordering fields are supplied.
 
 ### T3 — Present-versus-absent propagation
 
@@ -396,7 +385,7 @@ Host A: index 5 = E
 Host B: index 5 = absent (compacted)
 ```
 
-Absence wins at index 5. E is reappended at index 6 if still relevant evidence.
+Absence wins at index 5. If E is canonical and has no other surviving position, exactly one copy is freshly placed at index 6. Otherwise E is omitted.
 
 ### T4 — Sparse remote suffix
 
@@ -466,9 +455,15 @@ After the inactive destination is complete:
 - the active pointer switches;
 - later readers select only the new replica.
 
-### T12 — Synchronization canonical state
+### T12 — Canonical lower, obsolete higher
 
-One source's latest state entry is `edit E`; the other's is `edit F`. The conflict winner is E (later time, or tie-breaker). If F remains at a physically greater index in the merged prefix, synchronization reappends E above `P`. The destination logical view returns E, not F.
+```
+index 5 = canonical edit E
+index 8 = obsolete edit F
+```
+
+The destination retains E at index 5, makes index 8 absent, and does not append
+another E.
 
 ### T13 — Canonical freshness displaced by absence
 
@@ -477,3 +472,39 @@ The winning `validate` event is physically displaced during reconciliation (the 
 ### T14 — No obsolete reappend
 
 An older noncanonical `edit` event for a key is displaced during physical reconciliation (e.g., its position is poisoned). It is NOT reappended merely because it existed. Only canonical state and canonical freshness events are preserved.
+
+
+### T15 — One-sided state
+
+Source A has `add X`. Source B has no state event and no graph record for X. The
+existing `add` is canonical and materializes X.
+
+### T16 — Deleted freshness comparison
+
+Source A's latest freshness is `invalidate X` at time 100. Source B's is
+`validate X` at time 200, and canonical graph state is deleted. The destination
+preserves only `validate X` as canonical journal history. It does not
+rematerialize X or assign graph freshness.
+
+### T17 — Canonical duplicate
+
+```
+index 5 = canonical event E
+index 9 = same eventId E
+```
+
+The destination preserves E at index 9, makes index 5 absent, and does not append
+a third copy.
+
+### T18 — Canonical event physically displaced
+
+A canonical `validate`, `delete`, `add`, or `edit` loses every old position
+through established absence or same-index poisoning. Synchronization places
+exactly one fresh copy above `P`, preserving its `eventId` and complete payload.
+The same rule applies to canonical `invalidate`.
+
+### T19 — Repeated synchronization
+
+A completed destination is synchronized again with either original source. The
+same canonical state and freshness events remain. Positioned canonical events
+survive normalization, so no additional copies are appended.

--- a/docs/specs/incremental-graph-journal-types.md
+++ b/docs/specs/incremental-graph-journal-types.md
@@ -97,7 +97,7 @@ If the same event already survives at a positioned target entry, remove its queu
  * @property {NodeIdentifier} id - The node identifier of the affected node.
  * @property {NodeKey} key - The semantic node key at the time of the change.
  * @property {UnixTimestamp} time - When the change was recorded.
- * @property {Hostname} creator - The host that recorded the change.
+ * @property {Hostname} creator - The host that originally emitted the logical event.
  * @property {JournalEventId} eventId - Stable identity of this event.
  */
 ```
@@ -117,7 +117,9 @@ A `JournalEntry` is an internal type. Ordinary users of `graph.possibleMaybeChan
 
 - `'add'` — a node became materialized for the first time.
 - `'edit'` — a node's stored value materially changed.
-- `'delete'` — a node was removed or superseded (by synchronization, conflict resolution, or migration deletion).
+- `'delete'` — a node deletion event originally emitted by `storage.delete` or
+  another actual deletion operation. Synchronization may copy or reposition an
+  existing delete.
 - `'invalidate'` — a node's freshness changed from `up-to-date` to `potentially-outdated`.
 - `'validate'` — a node's freshness changed from `potentially-outdated` to `up-to-date`.
 

--- a/docs/specs/incremental-graph-locking-design.md
+++ b/docs/specs/incremental-graph-locking-design.md
@@ -17,7 +17,7 @@ The target behavior is:
 4. Observations of the same concrete node must not coexist (telescope
    mutex).
 5. Observations of different concrete nodes may coexist.
-6. Migration and replica cutover are exclusive with all graph activity
+6. Migration, structural synchronization, and replica cutover are exclusive with all graph activity
    (daytime, nighttime) and also close the garden.
 7. Transaction commits for the same replica are serialized (the commit
    mutex is per-replica, not global, so commits to different replicas
@@ -98,8 +98,9 @@ uses darkroom as specified. Journal queries use garden, not darkroom.
 | `enterGarden` | daytime activity | yes |
 | `enterGarden` | nighttime activity | yes |
 | `enterGarden` | ordinary journal append | yes |
-| `closeGarden` | ordinary journal append | yes, except that durable commits remain serialized by darkroom |
-| `closeGarden` | holiday / cutover | no, because holiday also closes the garden |
+| generic `closeGarden` (for example, compaction) | ordinary journal append | yes, except that durable commits remain serialized by darkroom |
+| structural synchronization | ordinary journal append | no; synchronization also holds `holidayActivity` |
+| migration | ordinary journal append | no; migration also holds `holidayActivity` |
 
 ## Lock Keys
 
@@ -117,7 +118,8 @@ Three modes are defined on `DOME_ACTIVITY_KEY`:
 
 - `"daytime"` for `invalidate()` and inspection reads;
 - `"nighttime"` for all pull activity;
-- `"holiday"` for migration and replica cutover (exclusive with all other modes).
+- `"holiday"` for migration, structural synchronization, and replica cutover
+  (exclusive with all other modes).
 
 Because same-mode holders are compatible, many invalidates may overlap, and many
 pulls may overlap. Because different modes are incompatible, no pull may overlap
@@ -165,7 +167,7 @@ There is one exclusive mutex per replica, created through the `DARKROOM_FUNCTOR`
 
 It serializes the short finalization step where a finished transaction's batch
 and identifier allocations become part of that replica's settled record.
-Commit-snapshot reads (`listMaterializedNodes()`) also acquire the darkroom
+Commit-stable reads (`listMaterializedNodes()`) also acquire the darkroom
 to observe state between commit finalizations.
 
 ## Operation Protocol
@@ -232,8 +234,9 @@ identical, whether top-level or nested.
 4. Scan through the fixed bound `H` and retain, for every matching semantic key:
    - the greatest-index state entry (`add`, `edit`, or `delete`);
    - the greatest-index freshness entry (`invalidate` or `validate`).
-5. Sort the retained entries by ascending `JournalIndex` and return the array.
-6. Leave the garden and return the array.
+5. Sort the retained entries by ascending `JournalIndex`.
+6. Leave the garden.
+7. Return the array.
 
 This is the logical-compaction-first semantic: compute `logicalJournalView` through `H`, then restrict to entries whose index exceeds `since` and whose key matches `to`. An equivalent implementation may scan only `(since, H]` and retain only the greatest-index matching entry per key and category.
 
@@ -268,17 +271,18 @@ The important requirements are:
 - It must not decrease or overwrite a concurrently advanced `last_journal_index`.
 - Ordinary append-only journal growth may continue while the garden is closed; those appends use indices greater than `H` and are outside the compacted prefix.
 
-### `migration / replica cutover`
+### `migration / structural synchronization / replica cutover`
 
-A holiday closes both the dome and the garden. Migration and replica cutover
-follow this protocol:
+A holiday closes both the dome and the garden. Migration, structural
+synchronization, and replica cutover follow this protocol:
 
 1. Acquire `holidayActivity(...)` (graph activity mode lock, exclusive with
    all other graph activity).
 2. Call `closeGarden` (exclusive garden access).
-3. Perform the migration or cutover while both locks are held.
-4. Acquire darkroom inside those scopes when performing durable replica
-   mutations.
+3. Perform migration, or build the inactive synchronization destination, while
+   both locks are held.
+4. Acquire the destination darkroom inside those scopes for final durable
+   metadata and cutover.
 5. Release darkroom.
 6. Reopen the garden.
 7. Release the holiday lock.
@@ -328,7 +332,13 @@ Journal queries coexist with daytime activity, nighttime activity, and ordinary 
 
 Garden exclusion prevents a query from observing a partially applied physical compaction, but the query result would be the same before and after the compaction anyway — both use the same `logicalJournalView` through the captured bound.
 
-Structural journal maintenance (compaction, sync) acquires exclusive garden access (`closeGarden`) for operations that mutate established journal positions. Replica cutover and migration also acquire `closeGarden`, but for lifecycle safety (preventing `possibleMaybeChanges` from traversing a replica while it is being replaced) rather than for journal mutation. Migration is append-only and does not structurally mutate established journal history.
+Structural journal maintenance acquires exclusive garden access (`closeGarden`)
+for operations that mutate established journal positions. Generic garden
+closure, as used by compaction, can overlap ordinary appends. Structural
+synchronization additionally holds `holidayActivity`, so it cannot overlap
+ordinary appends. Replica cutover and migration also hold `holidayActivity` and
+`closeGarden`; migration is append-only and does not structurally mutate
+established journal history.
 
 ## Lock ordering and deadlock discipline
 
@@ -383,7 +393,11 @@ Cutover acquires `holidayActivity` then `closeGarden`. Because `possibleMaybeCha
 
 ### C6 — Reader overlapping structural sync
 
-Structural sync calls `closeGarden`, which waits for readers and prevents new readers until established-position reconciliation completes. Existing readers complete on their captured journal bound (the fixed `H` they read after entering the garden).
+Structural sync acquires `holidayActivity` and then calls `closeGarden`, which
+waits for readers and prevents new readers until inactive-destination
+construction and cutover complete. Existing readers complete on their captured
+journal bound (the fixed `H` they read after entering the garden), and ordinary
+appends cannot overlap the synchronization.
 
 ### C7 — Compaction overlapping append
 


### PR DESCRIPTION
### Motivation

- Reduce ambiguity and contradictions in synchronization, compaction, and locking by making the logical journal view the single source of truth and ensuring the inactive destination physically equals that logical view. 
- Prevent duplicate canonical events, avoid treating synchronization as a producer of logical events, and remove graph-state dependence from compaction analysis. 
- Unify handling of displaced evidence (entry-versus-absence and same-index poisoning) under one deterministic rule. 
- Make structural synchronization a clearly documented holiday operation with explicit garden/darkroom ordering and corrected query release semantics.

### Description

- Implement the normative eight-stage synchronization pipeline (`Validate event identity`, `Compute each source logical view`, `Select canonical state`, `Validate source graph consistency`, `Select canonical freshness`, `Reconcile physical positions`, `Normalize canonical occurrences`, `Fresh placement`) and require the completed inactive destination to physically contain exactly the logical journal view (at most one state and one freshness event per semantic key). (edited `docs/specs/incremental-graph-journal-sync.md`).
- Make compaction observationally invisible to `possibleMaybeChanges`, remove graph-state-dependent retention rules, and require compaction to reason only over the captured journal prefix `H`; add the captured-prefix scenario. (edited `docs/specs/incremental-graph-journal-compaction.md`).
- Unify displaced-evidence handling so removed/poisoned positions produce absence and queue the canonical event only when it has no surviving position, and correct remote-suffix and same-index conflict scenarios and examples. (edited `docs/specs/incremental-graph-journal-sync.md`).
- Fix locking and protocol wording: classify structural synchronization as a `holidayActivity`, document `holidayActivity → closeGarden → build inactive destination → destination darkroom → release` ordering, replace `commit-snapshot` with `commit-stable` wording, and ensure queries compute/sort retained entries, leave the garden, then return. (edited `docs/specs/incremental-graph-locking-design.md` and `docs/incremental-graph-journal.md`).
- Clean API/type/emission terminology so synchronization only copies/repositions/omits existing events, clarify `JournalEntry.creator` provenance, and attribute `delete` emission to actual deletion operations (e.g., `storage.delete`). (edited `docs/specs/incremental-graph-journal-api.md`, `docs/specs/incremental-graph-journal-types.md`, `docs/specs/incremental-graph-journal-emission.md`, `docs/incremental-graph-journal.md`).
- Add and correct targeted scenarios and examples for canonical duplicates, canonical displacement, deleted-key freshness comparison, one-sided state, repeated synchronization, and prefix-independent compaction. (edited `docs/specs/incremental-graph-journal-sync.md`, `docs/specs/incremental-graph-journal-compaction.md`).

### Testing

- Ran `npm install` and then `npm run static-analysis`; the static checks completed without errors (warnings about environment/peer deps observed but static analysis step finished successfully). 
- Executed `git diff --check` to ensure no whitespace or diff-check issues and confirmed a clean diff. 
- Performed targeted grep audits with `rg` to verify removal of stale phrases and to confirm synchronization no longer described as producing logical events; the grep-based stale-wording audit showed only the intended retained prohibition against reappending to outrank obsolete evidence. 
- Verified repository state with `git status --short --branch` and recorded the sequence of small topic commits implementing the change (all commits created and present in branch history).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a73a0ac48832eb02dd4224009dec4)