### PR TITLE
Resolve journal/graph-sync contradictions: remove modifiedAt selection, add symmetric origins, and tighten freshness/notification rules

### DIFF
--- a/docs/incremental-graph-journal.md
+++ b/docs/incremental-graph-journal.md
@@ -27,7 +27,16 @@ The journal is a graph-level change record. It lets code ask questions of the fo
 
 The answer is expressed as `PossibleNodeChange` values. A `PossibleNodeChange` is the public unit of journal observation and can be passed as `since` to a later `graph.possibleMaybeChanges` call in the same API context.
 
-**This PR specifies only same-process, in-memory journal token usage.** A `PossibleNodeChange` returned during a process session is valid as `since` for subsequent calls within that same session. Within the same process, a cursor remains valid across compaction (the private index survives physical deletion of its backing entry) and across structural synchronization and cutover (notification coverage reports changes through repositioned canonical events). Persistence of these tokens across process restarts, synchronization boundaries involving heterogeneous hosts, or migration/schema boundaries, and the corresponding long-lived validity guarantees, are out of scope for this PR and deferred to a future computor/cursor-persistence specification.
+The journal specifies only same-process, in-memory token usage. A
+`PossibleNodeChange` returned during a process session is valid as `since` for
+subsequent calls within that same session. Within the same process, a cursor
+remains valid across compaction (the private index survives physical deletion
+of its backing entry) and across structural synchronization and cutover
+(notification coverage reports changes through repositioned canonical events).
+Persistence of these tokens across process restarts, synchronization boundaries
+involving heterogeneous hosts, or migration/schema boundaries, and the
+corresponding long-lived validity guarantees, are outside this journal's token
+contract.
 
 The journal is designed for incremental graph maintenance. A caller can pass a previously observed `PossibleNodeChange` as the `since` argument, or use `baselinePossibleNodeChange()` (a position less than any real journal index) to start from the beginning of the journal.
 
@@ -81,7 +90,12 @@ docs/specs/incremental-graph-journal-types.md
 
 ## Journal emission
 
-Journal entries are produced by graph operations that change the observable graph state.
+Journal entries are produced by ordinary graph and migration operations under
+the emission rules. `validate` records successful recomputation of an already
+materialized node from a non-up-to-date state, including restoration of a
+missing cached value. Structural synchronization may select stale or missing
+graph state without creating a logical event; it repositions existing
+canonical events when cursor notification is required.
 
 The journal emission rules define which IncrementalGraph operations create
 journal changes and how those changes are coordinated with graph storage

--- a/docs/specs/incremental-graph-journal-emission.md
+++ b/docs/specs/incremental-graph-journal-emission.md
@@ -11,18 +11,20 @@ Journal emission is always coordinated with the graph storage mutation that caus
 
 ---
 
-## Universal freshness-transition invariant
+## Freshness emission invariant
 
-Every actual transition from `up-to-date` to `potentially-outdated` emits an
-`invalidate` journal entry. Every actual transition from `potentially-outdated`
-to `up-to-date` emits a `validate` journal entry. Operations that leave
-freshness unchanged emit nothing.
+Every ordinary graph or migration operation that transitions an existing
+cached node from `up-to-date` to `potentially-outdated` emits `invalidate`.
+Every successful graph recomputation that transitions an already materialized
+node from a non-up-to-date state to `up-to-date` emits `validate`. The latter
+includes both `potentially-outdated → up-to-date` and
+`missing → up-to-date`.
 
-This invariant applies to every system path that performs one of these
-transitions: ordinary invalidation, cascading invalidation, migration
-`storage.invalidate`, pull recomputation, and any other future path.
-The source journal is therefore authoritative evidence of every freshness
-transition for the current node incarnation.
+Structural synchronization may conservatively select a different final
+freshness or remove a cached value without emitting a logical event. It uses
+notification-aware repositioning of an existing canonical event instead. The
+journal is authoritative evidence of operation-emitted freshness transitions;
+it is not a complete command log of synchronization-selected graph freshness.
 
 ---
 
@@ -67,13 +69,23 @@ REQ-JE-07b: An `invalidate` entry is NOT a value change — it signals that the 
 
 ### Freshness transition: `validate`
 
-REQ-JE-07c: When a node's freshness changes from `potentially-outdated` to `up-to-date`, the system MUST emit a journal entry with `action: "validate"`. This transition may occur through:
+REQ-JE-07c: When successful graph recomputation makes an already materialized
+node `up-to-date` from any non-up-to-date state, the system MUST emit a journal
+entry with `action: "validate"`. This includes both
+`potentially-outdated → up-to-date` and `missing → up-to-date`. The
+transition may occur through:
 
 - A `pull(nodeName, bindings)` that recomputes a node and returns an unchanged value (recalculating does not change the value, but the freshness transition from `potentially-outdated` to `up-to-date` is a real event).
 - A `pull(nodeName, bindings)` that recomputes a node and returns a changed value: this emits both an `edit` and a `validate` (see below for the ordering).
 - Explicit validation paths that transition a node from `potentially-outdated` to `up-to-date` outside the ordinary pull path.
+- A successful pull of a missing materialized node, which emits `edit` followed
+  contiguously by `validate`.
 
-REQ-JE-07d: A `validate` entry is NOT a value change — it signals that the node's freshness has been restored. The node's stored value and `NodeIdentifier` are unchanged by this entry alone.
+REQ-JE-07d: A `validate` entry is NOT by itself a value change — it signals
+that an already materialized node's freshness has been restored from a
+non-up-to-date state. The preceding contiguous `edit` establishes the cached
+value when the old state was missing; `validate` records the restoration to
+`up-to-date`. The `NodeIdentifier` is unchanged.
 
 REQ-JE-07e: The `validate` entry MUST be emitted in the same durable transaction as the freshness state change.
 
@@ -145,7 +157,9 @@ Migration actions have their own journal-emission rules, specified fully in `inc
 - `storage.keep` produces no journal entry.
 - `storage.override` produces no journal entry. It is a semantic-preserving representation rewrite that inherits freshness from the old record and does not propagate invalidation.
 - `storage.delete` emits a `delete` journal entry for the deleted node (but does not remove older journal entries—see `incremental-graph-journal-migrations.md`).
-- `storage.invalidate` produces a conditional `invalidate` journal entry: emitted only when it causes the target node's freshness to transition from `up-to-date` to `potentially-outdated`. An already potentially outdated node emits nothing.
+- `storage.invalidate` preserves a cached value and emits `invalidate` only for
+  `up-to-date → potentially-outdated`. An already stale cached node and a
+  missing node remain unchanged and emit nothing.
 
 ---
 
@@ -182,7 +196,6 @@ REQ-JE-18: During darkroom finalization, after assigning the event its initial `
 
 ```
 const eventId = JSON.stringify([
-    'journal-event-v1',
     hostnameToString(entry.creator),
     journalIndexToNumber(i),
 ]);
@@ -220,9 +233,13 @@ Transitioning a node's freshness from `up-to-date` to `potentially-outdated` pro
 
 ### P5a — Entry on freshness transition (validate)
 
-Transitioning a node's freshness from `potentially-outdated` to `up-to-date` produces a journal entry with `action: "validate"`. This occurs when:
+Successful recomputation that transitions an already materialized node from a
+non-up-to-date state to `up-to-date` produces a journal entry with
+`action: "validate"`. This occurs when:
 - An unchanged recomputation returns the existing value (only `validate` emitted).
 - A changed recomputation emits `edit` and `validate` in that order (contiguous indices).
+- A missing-node recomputation emits `edit` and `validate` in that order
+  (contiguous indices); the missing node cannot return `Unchanged`.
 - A cache hit emits nothing (no freshness transition occurred).
 - First materialization emits only `add` (first materialization is not a transition from `potentially-outdated`).
 
@@ -258,7 +275,7 @@ If a transaction prepares an unindexed entry, but then fails during darkroom fin
 A new ordinary or migration event assigned initial position `7` receives:
 
 ```
-eventId = JSON.stringify(['journal-event-v1', hostnameToString(host), 7])
+eventId = JSON.stringify([hostnameToString(host), 7])
 ```
 
 Entry, event ID, graph writes, and watermark `7` commit atomically. A reader that sees the entry at index 7 also sees its complete `eventId`. A reader that does not see index 7 sees no part of the event.

--- a/docs/specs/incremental-graph-journal-migrations.md
+++ b/docs/specs/incremental-graph-journal-migrations.md
@@ -91,9 +91,15 @@ nothing in either case.
 
 ### `storage.invalidate`
 
-Marks a node for recomputation in the new version by setting its freshness to `potentially-outdated`.
+Marks a cached node for recomputation in the new version by preserving its
+value and setting its freshness to `potentially-outdated`. A missing node
+remains missing.
 
-REQ-JM-03: `storage.invalidate` MUST emit an `invalidate` journal entry when it causes a node in the target migrated state to transition from `up-to-date` to `potentially-outdated`. This mirrors REQ-JE-07 and REQ-JE-07b for runtime freshness transitions. If the node was already `potentially-outdated`, no journal entry is emitted (mirroring the same rule for runtime cascading invalidation).
+REQ-JM-03: `storage.invalidate` MUST emit an `invalidate` journal entry when it
+causes a cached node in the target migrated state to transition from
+`up-to-date` to `potentially-outdated`. It preserves that cached value. If the
+node was already `potentially-outdated`, or if it was missing, no journal entry
+is emitted and its state is unchanged.
 
 ### `storage.create`
 
@@ -124,10 +130,11 @@ The journal distinguishes migration-originated state from ordinary graph changes
 | `pull` (first materialization) | `add` entry | New graph node |
 | `pull` (value change) | `edit` + `validate` entries | Graph recomputation changed value + freshness restored |
 | `pull` (unchanged recomputation) | `validate` entry | Freshness restored, value unchanged |
+| `pull` (missing-node recomputation) | contiguous `edit` + `validate` entries | Cached value established for the existing identifier, then freshness restored |
 | `invalidate` (standalone) | `invalidate` entry | Freshness downgrade |
 | `storage.keep` | no entry | Identity-preserving copy |
 | `storage.override` | no entry | Semantic-preserving representation rewrite; preserves freshness and does not emit a journal entry |
-| `storage.invalidate` | conditional `invalidate` entry | Emitted only when freshness changes from `up-to-date` to `potentially-outdated`. An already potentially outdated node emits nothing. |
+| `storage.invalidate` | conditional `invalidate` entry | Preserves a cached value and emits only for `up-to-date` → `potentially-outdated`; an already stale cached node or a missing node remains unchanged and emits nothing. |
 | `storage.create` | `add` entry | Intentional new node creation |
 | `storage.delete` | `delete` entry | Node deleted by migration |
 | Synchronization | existing events copied/reappended | Cross-host reconciliation (no new events created) |

--- a/docs/specs/incremental-graph-journal-sync.md
+++ b/docs/specs/incremental-graph-journal-sync.md
@@ -72,10 +72,9 @@ For each semantic key:
   identifiers and times tie) lexicographically greater `eventId`.
 
 The winning existing event is canonical. `add` or `edit` materializes the key
-using that event's `NodeIdentifier`. The associated graph value is the cached
-value from whichever source supplies the event as its latest state event; if
-that source has no cached value (missing), the destination is materialized but
-missing. `delete` leaves it nonmaterialized. Synchronization creates no event.
+using that event's `NodeIdentifier`; every source satisfying the canonical
+event consistency conditions may contribute to `candidateValueOrigins(K)`.
+`delete` leaves the key nonmaterialized. Synchronization creates no event.
 
 The canonical state event does not override a graph-synchronization requirement
 to delete the candidate cached value, make the node missing, or downgrade it to
@@ -87,49 +86,6 @@ rules (value provenance, dependency relowering, conservative freshness).
 For each source key, let S be its source state entry and F its source freshness
 entry from `logicalJournalView(sourceJournal, sourceH)`.
 
-#### Materialized source node
-
-Suppose a source has a materialized node with identifier `W`. The node may be
-**cached** (has a stored value, freshness is `up-to-date` or
-`potentially-outdated`) or **missing** (has no stored value, freshness is
-`"missing"`). Require:
-
-1. S exists.
-2. S.action is `add` or `edit`.
-3. S.id === W.
-
-Then validate state and freshness.
-
-**Cached source node.** When a source has a cached value for `W`, the
-following consistency checks apply.
-
-_Matching freshness event._ If F exists and F.id === W, the source graph's
-stored freshness MUST agree with F.action:
-
-```
-F.action === "invalidate" → graph freshness === "potentially-outdated"
-F.action === "validate"   → graph freshness === "up-to-date"
-```
-
-Any disagreement is a journal-integrity error.
-
-_No matching freshness event._ If F does not exist or F.id !== W, the
-current node incarnation has no recorded freshness transition. The validity
-depends on S.action:
-
-- If S.action is `add`, the stored freshness may be either `up-to-date` or
-  `potentially-outdated` — it is the node incarnation's initial freshness
-  inherited from its first materialization. Examples include ordinary first
-  materialization (normally up to date), `storage.create(..., "up-to-date")`,
-  and `storage.create(..., "potentially-outdated")`. No synthetic freshness
-  event is required.
-
-- If S.action is `edit`, the source is inconsistent. Every conforming
-  value-changing recomputation emits both `edit` and `validate`. A
-  materialized node whose latest state entry is `edit` but lacks matching
-   freshness evidence cannot establish its stored freshness under this
-   specification. Synchronization must fail.
-
 ### Source consistency matrix
 
 For each source semantic key, let:
@@ -140,66 +96,20 @@ F = source latest freshness entry
 W = source materialized NodeIdentifier (from graph storage)
 ```
 
-The following table defines whether a source is internally consistent for a
-given combination of state action, cached-value presence, and graph freshness.
+This matrix is the sole normative source-consistency rule:
 
-| State action | Cached? | Graph freshness | F exists? | F.id? | Valid? |
-|---|---|---|---|---|---|
-| `add`/`edit` | yes | `up-to-date` | yes | == W | valid (F must be `validate`) |
-| `add`/`edit` | yes | `up-to-date` | no | — | valid (S must be `add`) |
-| `add`/`edit` | yes | `up-to-date` | yes | != W | valid (older-incarnation history) |
-| `add`/`edit` | yes | `potentially-outdated` | yes | == W | valid (any F action) |
-| `add`/`edit` | yes | `potentially-outdated` | no | — | valid (S must be `add`) |
-| `add`/`edit` | yes | `potentially-outdated` | yes | != W | valid (older-incarnation history) |
-| `edit` | yes | `up-to-date` | no | — | **INVALID** |
-| `edit` | yes | `potentially-outdated` | no | — | **INVALID** |
-| `add`/`edit` | no | `missing` | any | any | valid (F is historical) |
-| `delete` | no | n/a | any | any | valid (F is historical) |
-| none | — | n/a | yes | any | **INVALID** (orphan) |
+| Source graph state | Required graph/value shape | Valid freshness-history cases | Invalid cases |
+|---|---|---|---|
+| Cached and `up-to-date` | value present; `S.action` is `add` or `edit`; `S.id === W` | matching `F.id === W` with `F.action === validate`; or no matching F when `S.action === add`; or older-incarnation F when `S.action === add` | matching latest `invalidate`; or `S.action === edit` without matching freshness history |
+| Cached and `potentially-outdated` | value present; `S.action` is `add` or `edit`; `S.id === W` | matching `invalidate`; matching `validate` followed by conservative synchronization downgrade; or no matching F / older-incarnation F when `S.action === add` | `S.action === edit` without matching freshness history |
+| Missing | value absent; freshness is `missing`; `S.action` is `add` or `edit`; `S.id === W` | F is historical only: matching `validate`, matching `invalidate`, older-incarnation F, and no F are all permitted | any violation of the required graph/value shape |
+| Nonmaterialized | no identifier or cached value | if state evidence exists, latest S is `delete`; F is historical only | materialized state evidence without materialized graph state |
+| Orphan freshness | no state event exists for the semantic key | none | any F is invalid |
 
-Additional rules:
-
-- When a cached node's graph freshness is `up-to-date` and a matching `F`
-  exists and `F.id === W`, `F.action` MUST be `validate`. A matching
-  latest `invalidate` with current graph state `up-to-date` is an integrity
-  error.
-- When a cached node's graph freshness is `potentially-outdated` and a
-  matching `F` exists and `F.id === W`, `F.action` may be `invalidate` or
-  `validate` (the latter followed by a conservative graph-freshness
-  downgrade).
-- When graph freshness is `missing`, F is historical only and does not assign
-  current freshness. A matching `validate` or `invalidate` may remain from
-  before synchronization removed the cached value.
-- When `F.id !== W`, F is history for an older incarnation and does not
-  describe W.
-- A freshness event with no state event for the semantic key (orphan
-  freshness) remains invalid.
-
-**Missing source node.** When a source has a missing node for `W`
-(freshness `"missing"`, no value), the source is consistent only if:
-
-1. S exists and S.action is `add` or `edit`.
-2. S.id === W.
-3. The missing state arose from a prior conservative synchronization or
-   other valid structural removal — not from event evidence.
-
-A missing source node with freshness `"missing"` is valid. F is historical
-only and does not assign current freshness. A matching `validate` or
-`invalidate` may remain from before the cached value was removed; that is
-permitted journal history.
-
-#### Nonmaterialized source key
-
-If the source has state evidence for the key, its latest state entry MUST be
-`delete`. A retained freshness event is historical only and does not assign
-graph freshness.
-
-#### Orphan freshness history
-
-A source freshness entry for a semantic key with no source state entry is
-invalid. Every legitimate freshness event originates from an existing node
-incarnation, and `logicalJournalView` never removes that incarnation's latest
-state entry.
+In particular, a matching `validate` does not require current graph freshness
+to remain `up-to-date`: synchronization may have conservatively downgraded it.
+Freshness history is retained operation evidence, not a complete record of
+structurally selected current freshness.
 
 #### On any consistency failure
 
@@ -277,9 +187,9 @@ another identifier. Compare candidates by later `time`, then lexicographically
 greater `eventId` on a tie. The winner is the canonical freshness history event.
 
 If neither source supplies freshness evidence for `W`, canonical freshness
-history is absent. The node's initial freshness (which may be `up-to-date` or
-`potentially-outdated`) is stored graph state, not journal history; it is
-preserved as part of the canonical graph state.
+history is absent. Graph synchronization alone evaluates candidate origins,
+source cache states, final inputs, and validity proofs to select final graph
+freshness.
 
 For a canonically deleted key, freshness never sets graph state. Preserve no
 freshness event when neither source has one; preserve the sole entry when only
@@ -482,6 +392,10 @@ event:
 
 - One absent and the other exists;
 - Both exist with different `eventId`.
+
+When final canonical freshness history is absent but a source had freshness
+history, there is no freshness event available to carry that notification; use
+the canonical state event for that source instead.
 
 When graph freshness changes from up-to-date to stale or missing but the
 canonical freshness event itself is unchanged (e.g., conservative downgrade
@@ -707,7 +621,8 @@ journal logical view: state = add W, no matching freshness event
 
 This is valid. The `add` without matching freshness evidence uses its
 associated stored initial freshness, which is `potentially-outdated`.
-Synchronization preserves this freshness.
+Graph synchronization evaluates that cached origin and may preserve stale
+freshness or conservatively make the node missing.
 
 ### T3a — Missing freshness after edit
 
@@ -795,8 +710,10 @@ This is valid. Cross-source current-freshness equality is not an integrity
 rule — two conforming sources may contain the same `add` event with no
 matching freshness event while one is up to date and the other is potentially
 outdated. The canonical freshness history is absent; final graph freshness
-follows the winning source's stored initial freshness (determined by the
-graph synchronization rules).
+is selected conservatively by graph synchronization from both source cache
+states, candidate origins, final inputs, and validity proofs. If either
+source's graph-observable result differs from the final result, the canonical
+state event is its notification carrier.
 
 ### T5d — Identical state event, consistent freshness
 
@@ -847,8 +764,9 @@ Graph values are `isEqual`. Source A stores `up-to-date` and source B stores
 `potentially-outdated` as the initial freshness (after conservative
 downgrade). This is not corruption. Graph-value equality and initial-freshness
 agreement are independent concerns — the journal does not enforce cross-source
-freshness equality. Final graph freshness follows the winning source's stored
-initial freshness as determined by the graph synchronization rules.
+freshness equality. Graph synchronization selects final freshness
+conservatively; the canonical state event provides notification to each source
+whose graph-observable result differs.
 
 ### T5h — Missing and cached copies of the same event
 
@@ -1093,8 +1011,8 @@ again. No new logical event is created.
 ### T28 — Conservative missing-state notification
 
 ```
-Source A: H = 5, E at index 5
-Source B: H = 5, E at index 5 (same canonical event)
+Source A: localH = 5, E at index 5
+Source B: remoteH = 5, E at index 5 (same canonical event)
 ```
 
 Both sources contain the same canonical state event E at index 5 and cached

--- a/docs/specs/incremental-graph-journal-types.md
+++ b/docs/specs/incremental-graph-journal-types.md
@@ -18,13 +18,14 @@ The ID is created during the event's first durable commit:
 
 ```js
 const eventId = JSON.stringify([
-    'journal-event-v1',
     hostnameToString(creator),
     journalIndexToNumber(originIndex),
 ]);
 ```
 
-Use exactly a fixed-order array passed to `JSON.stringify`. No custom serialization format. No multiple event-ID variants. No optional event-ID fields.
+Use exactly the fixed-order `[creator, originIndex]` tuple passed to
+`JSON.stringify`. No version tag, custom serialization format, multiple
+event-ID variants, or optional event-ID fields.
 
 ```js
 /**
@@ -121,7 +122,9 @@ A `JournalEntry` is an internal type. Ordinary users of `graph.possibleMaybeChan
   another actual deletion operation. Synchronization may copy or reposition an
   existing delete.
 - `'invalidate'` — a node's freshness changed from `up-to-date` to `potentially-outdated`.
-- `'validate'` — a node's freshness changed from `potentially-outdated` to `up-to-date`.
+- `'validate'` — successful recomputation made an already materialized node
+  `up-to-date` from a non-up-to-date state. This includes both
+  `potentially-outdated → up-to-date` and `missing → up-to-date`.
 
 ---
 
@@ -657,7 +660,7 @@ The journal implementation internally uses `PrivatePossibleNodeChange` (which in
 └──────────────────────────────────────────────┘
 ```
 
-`privatePossibleNodeChangeToPossibleNodeChange` is a nominal narrowing of the same runtime value. It MUST NOT discard the private fields (`id`, `key`, `creator`, `index`) required for later journal-module widening. The runtime value retains both the public projection fields (`nodeName`, `bindings`, `action`, `time`) and the private journal-module fields.
+`privatePossibleNodeChangeToPossibleNodeChange` is a nominal narrowing of the same runtime value. It MUST NOT discard the private fields (`id`, `key`, `creator`, `eventId`, `index`) required for later journal-module widening. The runtime value retains both the public projection fields (`nodeName`, `bindings`, `action`, `time`) and the private journal-module fields.
 
 `possibleNodeChangeToPrivatePossibleNodeChangeUnsafe` reverses this narrowing. It is valid only because values returned by `graph.possibleMaybeChanges` were originally created from `PrivatePossibleNodeChange` via the narrowing operation above.
 

--- a/docs/specs/incremental-graph-synchronization.md
+++ b/docs/specs/incremental-graph-synchronization.md
@@ -305,23 +305,23 @@ synchronization specification:
 The final identifier lookup maps final storage identifiers to semantic keys.
 It must be bijective.
 
-**DEF-SYNC-08 (Direct relowering):** A final node is directly relowered when
-the source-side dependency identifiers used by its stored value differ from the
-final lowered dependency identifiers. This occurs when the node's structural
-source side uses different storage identifiers for its inputs than the final
-merged graph.
+**DEF-SYNC-08 (Direct relowering):** A candidate value origin is directly
+relowered when the dependency identifiers used by that source's cached value
+differ from the canonical final identifiers in the lowered graph. Relowering is
+evaluated independently for every member of `candidateValueOrigins(K)`.
 
 **REQ-SYNC-10 (Direct relowering rules):**
 
-1. Directly relowered nodes MUST NOT remain `up-to-date`.
-2. Directly relowered nodes MUST NOT preserve their stored value as a valid
-   value for final freshness.
-3. Directly relowered nodes SHOULD have their stored value deleted, because the
-   system does not have a provenance proof that the stored value is valid for
-   the final lowered inputs.
-4. All materialized descendants of a directly relowered node MUST become
-   `potentially-outdated` unless independently recomputed later outside
-   synchronization (by `pull()`).
+1. A directly relowered origin is removed from the candidate's surviving
+   origin set and cannot support final freshness or validity proofs.
+2. If no valid origin remains, the candidate cached value MUST be removed and
+   its canonical identifier becomes a materialized missing node.
+3. If another valid origin for the same canonical event remains, that origin
+   may preserve the shared candidate semantic value subject to all other graph
+   eligibility rules.
+4. Materialized descendants lacking valid proofs after relowering become
+   `potentially-outdated` when cached or `missing` when no safe cached value can
+   be retained.
 5. Synchronization MUST NOT invoke computors to repair directly relowered
    nodes.
 
@@ -351,8 +351,7 @@ only if all of the following hold:
 5. Every direct input has a validity flag for this node in the final validity
    relation.
 6. The stored value's provenance and final dependency structure justify
-   preserving it (the node was not invalidated by conflict propagation or
-   relowering).
+   preserving it (at least one candidate source origin survives relowering).
 7. No applicable latest `invalidate` exists for the winning identifier.
    Either:
    * the canonical freshness history for the winning identifier is `validate`;
@@ -392,31 +391,25 @@ event.
 
 ## 9. Value Origin and Provenance
 
-**DEF-SYNC-09 (Final value origin rules):** For each final semantic key whose
-canonical state event is `add` or `edit`:
+**DEF-SYNC-09 (Candidate and surviving value origins):** For every final
+semantic key K whose canonical state event is `add` or `edit`,
+`candidateValueOrigins(K)` is the internal, nonpersisted proof set defined in
+`incremental-graph-journal-sync.md`: it contains one source origin for each
+source whose latest state event is that exact canonical event, whose current
+identifier is the event's identifier, and which has a cached value.
 
-- Origin is `{ kind: "source", side: "target", sourceId }` only if:
-  - the final stored value exists;
-  - the canonical state event's `NodeIdentifier` maps to the local source
-    identifier for the same semantic key;
-  - the local source provided the cached value (its latest state event is
-    the canonical event);
-  - the node is not directly relowered in a way that deletes or invalidates
-    its value provenance.
-- Origin is `{ kind: "source", side: "host", sourceId }` only if:
-  - the final stored value exists;
-  - the canonical state event's `NodeIdentifier` maps to the host source
-    identifier for the same semantic key;
-  - the host source provided the cached value (its latest state event is
-    the canonical event);
-  - the node is not directly relowered in a way that deletes or invalidates
-    its value provenance.
-- Origin is `{ kind: "none" }` otherwise.
+`survivingValueOrigins(K)` is the subset whose source dependency identifiers
+match the canonical final identifiers and whose provenance remains eligible
+under all graph rules. The set may contain the target origin, the host origin,
+both origins, or no origin. It is not persisted.
 
-When both sources supply the canonical event as their latest state event
-and both have cached values, those values must be `isEqual` (see
-`incremental-graph-journal-sync.md` §Graph-value consistency). If they differ
-the merge must fail as an integrity error.
+When both sources contribute candidates, their cached values must be
+`isEqual`; otherwise synchronization fails with an integrity error. Equal
+values denote the same candidate semantic value, but equality does not create
+an origin. A missing source contributes no origin and is not compared with the
+cached value. If every canonical-event source is missing, or if no candidate
+origin survives, the canonical identifier remains materialized but missing;
+no cached value is invented and no losing state event or identifier is chosen.
 
 **REQ-SYNC-13 (Equality does not create origin):**
 
@@ -461,10 +454,10 @@ only if ALL of the following hold:
    identifier lookup.
 2. Those semantic keys both have final identifiers in
    `finalIdentifierForKey`.
-3. `valueOrigin(finalD)` is exactly `{ kind: "source", side: S, sourceId:
-   sourceD }`.
-4. `valueOrigin(finalN)` is exactly `{ kind: "source", side: S, sourceId:
-   sourceN }`.
+3. `survivingValueOrigins(key(finalD))` contains the exact origin
+   `{ kind: "source", side: S, sourceId: sourceD }`.
+4. `survivingValueOrigins(key(finalN))` contains the exact origin
+   `{ kind: "source", side: S, sourceId: sourceN }`.
 5. `finalD` is a direct structural input of `finalN` in the final lowered
    graph per `mergedInputsMap`.
 6. The final dependency edge is derived from the final graph scheme and

--- a/docs/specs/incremental-graph.md
+++ b/docs/specs/incremental-graph.md
@@ -114,7 +114,7 @@ The schema implicitly defines infinitely many dependency edges—one set for eac
 The public API requires both the `nodeName` (functor) and bindings to address a specific node:
 
 * `pull(nodeName, bindings)` — Evaluates the node instance identified by `NodeName` and `BindingEnvironment`
-* `invalidate(nodeName, bindings)` — Marks the node instance as potentially-outdated, triggering recomputation on next pull
+* `invalidate(nodeName, bindings)` — Marks a cached node instance as potentially-outdated, triggering recomputation on next pull; a missing node remains missing
 
 **For arity-0 nodes** (nodes with no arguments like `all_events`):
 * `pull("all_events", [])` and `pull("all_events")` are equivalent
@@ -430,8 +430,10 @@ Implementations MAY use any strategy to achieve property PROP-03 (e.g., memoizat
 
 **Effects:**
 1. Create `NodeKey` from `nodeName@bindings`
-2. Mark that node instance as `potentially-outdated`
-3. Mark all materialized transitive dependents as `potentially-outdated`
+2. If that node has a cached value, preserve the value and mark it
+   `potentially-outdated`; if it is missing, leave it missing
+3. Mark cached materialized transitive dependents as `potentially-outdated`;
+   skip missing dependents, which remain missing
 
 **Important:** `invalidate()` does NOT write a value. Values are provided by computors when nodes are pulled.
 
@@ -510,9 +512,16 @@ interface IncrementalGraph {
 **REQ-IFACE-03:** For compound-expressions (arity > 0), `bindings` MUST be provided with length matching the expression arity.
 
 **REQ-IFACE-04 (Inspection API):** Implementations MUST provide the inspection interface methods:
-* `getFreshness(nodeName, bindings?)` — Returns the freshness state of a specific node instance. Returns `"missing"` for unmaterialized nodes.
-* `getValue(nodeName, bindings?)` — Returns the currently stored value for a node instance without triggering recomputation, or `undefined` if the node has never been materialized.
-* `listMaterializedNodes()` — Returns an array of tuples `[NodeName, BindingEnvironment]` for all materialized node instances.
+* `getFreshness(nodeName, bindings?)` — Returns the freshness state of a
+  specific node instance. It returns `"missing"` both for an unmaterialized
+  semantic key and for a materialized identifier whose cached value is absent.
+* `getValue(nodeName, bindings?)` — Returns the currently stored value without
+  triggering recomputation, or `undefined` for both an unmaterialized key and a
+  materialized node whose cached value is absent.
+* `listMaterializedNodes()` — Returns an array of tuples
+  `[NodeName, BindingEnvironment]` for all identifier-registry entries. It
+  therefore distinguishes a materialized missing node from an unmaterialized
+  semantic key when used with the two inspection methods above.
 * `getSchemas()` — Returns the list of compiled node schemas registered with this graph.
 * `getSchemaByHead(nodeName)` — Returns the compiled schema for the given node name, or `null` if no such schema exists.
 * `getDbVersion()` — Returns the version string used for storage namespacing.
@@ -671,7 +680,10 @@ graph state across host branches is specified in a separate document:
 
 ### 4.2 Invariants
 
-**INV-01 (Outdated Downstream):** If node instance `N@B` is `potentially-outdated`, all transitive dependents of `N@B` that have been previously materialized (pulled or invalidated) are also `potentially-outdated`.
+**INV-01 (Outdated Downstream):** If node instance `N@B` is
+`potentially-outdated`, every cached transitive dependent of `N@B` that has
+been materialized is also `potentially-outdated`. A materialized dependent
+without a cached value remains `missing`.
 
 **INV-02 (Up-to-Date Upstream):** If node instance `N@B` is `up-to-date`, all transitive dependencies of `N@B` are also `up-to-date`.
 
@@ -764,4 +776,3 @@ Dynamically-pulled nodes are not part of the flag-based validity algorithm. They
 performed during a computor's execution and do not affect the structural dependency graph.
 
 ---
-

--- a/docs/specs/migration.md
+++ b/docs/specs/migration.md
@@ -91,7 +91,12 @@ Calling the same decision twice (except for `override` and `create`) is allowed 
 
 The intended use case is format migration: the database version changes the serialization format but the represented value is still meaningfully the same value. In that scenario missing invalidation in `override()` is correct by design — not a bug.
 
-`invalidate` preserves the cached value if it exists, marks cached nodes as `"potentially-outdated"`, preserves `modifiedAt`, and does not preserve incoming or outgoing valid flags for the invalidated node. This is a conservative/hard invalidation: the clean-cache claim for the node is withdrawn.
+`invalidate` preserves the cached value if it exists, marks cached nodes as
+`"potentially-outdated"`, preserves `modifiedAt`, and does not preserve
+incoming or outgoing valid flags for the invalidated node. A missing node
+remains missing: invalidation does not create a value or rewrite its freshness.
+This is a conservative/hard invalidation: an existing clean-cache claim is
+withdrawn.
 
 `create(..., "up-to-date")` is a clean-cache assertion. The migration validates this assertion before writing the migrated state.
 `create(..., "potentially-outdated")` seeds a cached value without claiming it is clean.
@@ -100,7 +105,11 @@ The intended use case is format migration: the database version changes the seri
 
 #### INVALIDATE → propagate INVALIDATE downstream
 
-When a node is invalidated, all its dependents are automatically marked `INVALIDATE` (recursively), unless they are already `DELETE`d.  If a dependent already has a `KEEP` or `OVERRIDE` decision, `DecisionConflictError` is thrown immediately.
+When a node is invalidated, its cached dependents are automatically marked
+`INVALIDATE` (recursively), unless they are already `DELETE`d. Missing
+dependents are skipped and remain missing; propagation does not create cached
+values for them. If a cached dependent already has a `KEEP` or `OVERRIDE`
+decision, `DecisionConflictError` is thrown immediately.
 
 #### DELETE → propagate DELETE downstream (deferred, fan-in strict)
 


### PR DESCRIPTION
### Motivation
- Remove a legacy modifiedAt-driven source-selection path and resolve contradictory freshness and provenance rules so canonical journal state alone determines candidate incarnations. 
- Make provenance symmetric and explicit so identical canonical events from multiple sources can contribute origins without arbitrary local/remote preference. 
- Narrow what emits freshness events and make notification carriers precise so structural synchronization can conservatively change graph state without inventing logical events (think: the journal is the compass, graph sync is the weather report). @ottojung

### Description
- Removed the obsolete modifiedAt/keep|take|invalidate machinery and made journal-based canonical state selection authoritative so canonical `add|edit|delete` events determine final identifiers. 
- Introduced `candidateValueOrigins(K)` and `survivingValueOrigins(K)` to represent symmetric, nonpersisted source origins and to require `isEqual` for multi-origin cached values while treating missing copies as absence, not corruption. 
- Replaced prior freshness prose with a single source-consistency matrix and limited Stage 5 to selecting canonical freshness-history only, while making final graph freshness the responsibility of graph synchronization. 
- Completed missing-node semantics so a successful missing-node recompute emits contiguous ``edit`` + ``validate``, tightened invalidation to preserve cached values and skip missing nodes, and clarified `getFreshness`/`getValue`/`listMaterializedNodes` distinctions. 
- Made notification-carrier rules explicit by splitting state- and freshness-notification source sets and computing `notificationBound(E)` to decide when to reposition existing canonical events for cursor notification. 
- Updated documentation and types across the journal and sync specs (notably: `docs/incremental-graph-journal.md`, `docs/specs/incremental-graph-journal-*.md`, `docs/specs/incremental-graph-synchronization.md`, `docs/specs/incremental-graph.md`, and `docs/specs/migration.md`) and made `eventId` the unversioned `[creator, originIndex]` tuple. 

### Testing
- Ran `npm install` and `npm run static-analysis` with success to validate docs/types coherence and lint/type checks. 
- Executed `git diff --check` and repository scans (`rg`) to confirm removal of obsolete terms and presence/absence of `journal-event-v1` and modified selection keywords, all passing with no errors. 
- This is a documentation/spec change only; no runtime test-suite changes were required and no JavaScript behavior was modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5abfc240b4832e8d84c87d78778504)