### PR TITLE
Fix freshness and delete propagation closures

### DIFF
--- a/backend/src/generators/incremental_graph/database/sync_merge_validity.js
+++ b/backend/src/generators/incremental_graph/database/sync_merge_validity.js
@@ -310,6 +310,7 @@ async function rebuildMergedValidity({
     }
 
     const writer = new ReplicaBatchWriter(targetStorage);
+    let freshnessChanged = false;
 
     // Traverse in topological order so that a node's inputs have their
     // validity entries built before the node's own entries are written.
@@ -319,6 +320,13 @@ async function rebuildMergedValidity({
         if (freshness !== 'up-to-date') continue;
 
         const requiredInputs = mergedInputsMap.get(nodeIdentifier) ?? [];
+        const hasStaleInput = requiredInputs.some((depId) => finalFreshness.get(nodeIdentifierToString(depId)) !== 'up-to-date');
+        if (hasStaleInput) {
+            finalFreshness.set(nodeIdStr, 'potentially-outdated');
+            freshnessChanged = true;
+            await writer.push(targetStorage.freshness.putOp(nodeIdentifier, 'potentially-outdated'));
+            continue;
+        }
         for (const depId of requiredInputs) {
             const depIdStr = nodeIdentifierToString(depId);
             depIdCache.set(depIdStr, depId);
@@ -340,7 +348,7 @@ async function rebuildMergedValidity({
     }
     await writer.flush();
     const validityChanged = !canonicalValidMapsEqual(oldCanonicalValidMap, canonicalizeValidMap(validMap));
-    return validityChanged;
+    return validityChanged || freshnessChanged;
 }
 
 module.exports = {

--- a/backend/src/generators/incremental_graph/migration_storage_class.js
+++ b/backend/src/generators/incremental_graph/migration_storage_class.js
@@ -38,7 +38,7 @@ const {
 /**
  * @typedef {{ kind: 'keep' }} KeepDecision
  * @typedef {{ kind: 'override', value: (nodeKey: NodeIdentifier) => Promise<ComputedValue> }} OverrideDecision
- * @typedef {{ kind: 'invalidate' }} InvalidateDecision
+ * @typedef {{ kind: 'invalidate', provenance: 'explicit' | 'propagated' }} InvalidateDecision
  * @typedef {{ kind: 'delete' }} DeleteDecision
  * @typedef {"up-to-date" | "potentially-outdated"} CreatedFreshness
  * @typedef {{ kind: 'create', nodeKeyString: string, value: (nodeKey: NodeIdentifier) => Promise<ComputedValue>, freshness: CreatedFreshness }} CreateDecision
@@ -228,10 +228,13 @@ class MigrationStorageClass {
         await checkSchemaCompatibility(nodeKey, this.newHeadIndex, identifiersKeysIndex, this.decisions);
         const existing = this.decisions.get(nodeKey);
         if (existing !== undefined) {
-            if (existing.kind === "invalidate") return;
+            if (existing.kind === "invalidate") {
+                existing.provenance = "explicit";
+                return;
+            }
             throw makeDecisionConflictError(nodeKey, existing.kind, "invalidate");
         }
-        this.decisions.set(nodeKey, { kind: "invalidate" });
+        this.decisions.set(nodeKey, { kind: "invalidate", provenance: "explicit" });
         await propagateInvalidate({
             nodeKey,
             visited: new Set(),
@@ -257,6 +260,10 @@ class MigrationStorageClass {
         const existing = this.decisions.get(nodeKey);
         if (existing !== undefined) {
             if (existing.kind === "delete") return;
+            if (existing.kind === "invalidate" && existing.provenance === "propagated") {
+                this.decisions.set(nodeKey, { kind: "delete" });
+                return;
+            }
             throw makeDecisionConflictError(nodeKey, existing.kind, "delete");
         }
         this.decisions.set(nodeKey, { kind: "delete" });

--- a/backend/src/generators/incremental_graph/migration_storage_dependencies.js
+++ b/backend/src/generators/incremental_graph/migration_storage_dependencies.js
@@ -26,7 +26,7 @@ const {
 /**
  * @typedef {{ kind: 'keep' }} KeepDecision
  * @typedef {{ kind: 'override', value: (nodeKey: NodeIdentifier) => Promise<ComputedValue> }} OverrideDecision
- * @typedef {{ kind: 'invalidate' }} InvalidateDecision
+ * @typedef {{ kind: 'invalidate', provenance: 'explicit' | 'propagated' }} InvalidateDecision
  * @typedef {{ kind: 'delete' }} DeleteDecision
  * @typedef {"up-to-date" | "potentially-outdated"} CreatedFreshness
  * @typedef {{ kind: 'create', nodeKeyString: string, value: (nodeKey: NodeIdentifier) => Promise<ComputedValue>, freshness: CreatedFreshness }} CreateDecision
@@ -72,7 +72,7 @@ async function propagateInvalidate(ctx) {
         }
         const identifiersKeysIndex = await getIdentifiersKeysIndex();
         await checkSchemaCompatibility(dep, newHeadIndex, identifiersKeysIndex, decisions);
-        decisions.set(dep, { kind: "invalidate" });
+        decisions.set(dep, { kind: "invalidate", provenance: "propagated" });
         await propagateInvalidate({
             nodeKey: dep,
             visited,
@@ -164,6 +164,11 @@ async function propagateDeletes(ctx) {
             const existing = decisions.get(dep);
             if (existing?.kind === "delete") continue;
             if (existing !== undefined) {
+                if (existing.kind === "invalidate" && existing.provenance === "propagated") {
+                    decisions.set(dep, { kind: "delete" });
+                    queue.push(dep);
+                    continue;
+                }
                 throw makeDecisionConflictError(dep, existing.kind, "delete");
             }
             if (!materializedNodes.has(dep)) {

--- a/backend/tests/migration_storage.test.js
+++ b/backend/tests/migration_storage.test.js
@@ -575,6 +575,33 @@ describe("MigrationStorage", () => {
             expect(decisions.get(D)?.kind).toBe("delete");
         });
 
+        test("delete propagation replaces automatically propagated invalidation", async () => {
+            const storage = makeInMemorySchemaStorage();
+            const headIndex = makeHeadIndex(["A", "C", "D"]);
+            const A = nk("A");
+            const C = nk("C");
+            const D = nk("D");
+            const scheme = {
+                format: 1,
+                nodes: [
+                    { head: "A", arity: 0, inputTemplates: [] },
+                    { head: "C", arity: 0, inputTemplates: [] },
+                    { head: "D", arity: 0, inputTemplates: [{ head: "A", args: [] }, { head: "C", args: [] }] },
+                ],
+            };
+            const lookup = makeLookupFromKeys([A, C, D]);
+            await storage.values.put(A, DUMMY_VALUE);
+            await storage.values.put(C, DUMMY_VALUE);
+            await storage.values.put(D, DUMMY_VALUE);
+            await storage.valid.put(C, [D]);
+            const ms = makeMigrationStorage(storage, headIndex, [A, C, D], "testfingerprint", 0, scheme, scheme, lookup);
+
+            await ms.invalidate(C);
+            await ms.delete(A);
+            const decisions = await ms.finalize();
+            expect(decisions.get(D)?.kind).toBe("delete");
+        });
+
 
         test("delete propagation follows removed target dependency", async () => {
             const storage = makeInMemorySchemaStorage();

--- a/backend/tests/sync_merge.test.js
+++ b/backend/tests/sync_merge.test.js
@@ -2042,6 +2042,46 @@ describe('mergeHostIntoReplica', () => {
         }
     });
 
+    test('equal-version invalidation propagates stale freshness to newer dependents', async () => {
+        const capabilities = getTestCapabilities();
+        let db;
+        try {
+            db = await getRootDatabase(capabilities);
+            await writeGraphScheme(db.schemaStorageForReplica('x'));
+            const logger = makeLogger();
+            const hostname = 'equal-version-peer';
+            await db.setGlobalVersion(db.version);
+            await db.setHostnameGlobal(hostname, 'version', db.version);
+
+            const nodeA = nodeIdentifierFromString('138-abcdefghi');
+            const nodeB = nodeIdentifierFromString('139-abcdefghi');
+            const keyA = stringToNodeKeyString('{"head":"stale_input_A","args":[]}');
+            const keyB = stringToNodeKeyString('{"head":"stale_input_B","args":[]}');
+
+            const target = db.schemaStorageForReplica('x');
+            await writeNode(target, nodeA, TS1, { source: 'A' });
+            await writeNode(target, nodeB, TS3, { source: 'B target' });
+            await target.valid.put(nodeA, [nodeB]);
+            await writeIdentifierLookup(target, [[nodeA, keyA], [nodeB, keyB]]);
+
+            const host = db.hostnameSchemaStorage(hostname);
+            await writeGraphScheme(host);
+            await writeNode(host, nodeA, TS1, { source: 'A' });
+            await writeNode(host, nodeB, TS2, { source: 'B host' });
+            await host.freshness.put(nodeA, 'potentially-outdated');
+            await host.freshness.put(nodeB, 'potentially-outdated');
+            await writeIdentifierLookup(host, [[nodeA, keyA], [nodeB, keyB]]);
+
+            db = await mergeAndReopenIfSwitched(capabilities, logger, db, hostname);
+
+            const storage = db.getSchemaStorage();
+            expect(await storage.freshness.get(nodeA)).toBe('potentially-outdated');
+            expect(await storage.freshness.get(nodeB)).toBe('potentially-outdated');
+        } finally {
+            if (db) await db.close();
+        }
+    });
+
     test('4. identifier lowering transports valid proofs to final identifiers', async () => {
         const { rebuildMergedValidity } = require('../src/generators/incremental_graph/database/sync_merge_validity');
         const capabilities = getTestCapabilities();


### PR DESCRIPTION
Downgrade merged up-to-date nodes when any input is stale during validity rebuilding, and report that freshness change as a merge change.

Track explicit versus propagated migration invalidations so propagated invalidations can be replaced by delete propagation without masking explicit callback conflicts.