### PR TITLE
Propagate freshness during merge and add provenance-aware migration decisions

### DIFF
--- a/backend/src/generators/incremental_graph/database/sync_merge.js
+++ b/backend/src/generators/incremental_graph/database/sync_merge.js
@@ -324,7 +324,7 @@ async function mergeHostIntoReplica(logger, rootDatabase, hostname) {
         finalIdentifierForKey
     );
 
-    const validityChanged = await rebuildMergedValidity({
+    const graphStateChanged = await rebuildMergedValidity({
         targetStorage,
         targetSourceStorage,
         hostSourceStorage: hostStorage,
@@ -334,7 +334,7 @@ async function mergeHostIntoReplica(logger, rootDatabase, hostname) {
         mergedInputsMap,
         valueOriginByKey,
     });
-    const hasChanges = hasSemanticChanges || validityChanged;
+    const hasChanges = hasSemanticChanges || graphStateChanged;
     await assertValidFinalMergeState(targetStorage, finalIdentifierLookup);
 
     if (hasChanges) {

--- a/backend/src/generators/incremental_graph/database/sync_merge_validity.js
+++ b/backend/src/generators/incremental_graph/database/sync_merge_validity.js
@@ -207,13 +207,16 @@ function canonicalValidMapsEqual(left, right) {
 }
 
 /**
- * Rebuild the valid relation from provenance-based value origin transport.
+ * Rebuild the valid relation and propagate freshness downgrades from merged inputs.
  *
  * Algorithm:
  * 1. Transport validity entries from both source sides based on source
  *    provenance for both endpoints.
- * 2. Add mandatory flags for every up-to-date node.
- * 3. Clear the existing valid sublevel and write the rebuilt relation.
+ * 2. Traverse merged nodes in topological order and downgrade an up-to-date
+ *    node when any input is not up-to-date.
+ * 3. Add mandatory validity flags for every up-to-date node whose inputs are
+ *    also up-to-date.
+ * 4. Clear the existing valid sublevel and write the rebuilt relation.
  *
  * A validity proof valid[D].has(N) is transported from a source side only
  * when D and N both resolve through the same source side and their final values
@@ -229,7 +232,7 @@ function canonicalValidMapsEqual(left, right) {
  * @param {Map<NodeKeyString, NodeIdentifier>} options.finalIdentifierForKey
  * @param {Map<NodeIdentifier, NodeIdentifier[]>} options.mergedInputsMap
  * @param {Map<NodeKeyString, ValueOrigin>} options.valueOriginByKey
- * @returns {Promise<boolean>} Whether the canonical valid relation changed.
+ * @returns {Promise<boolean>} Whether the canonical valid relation or any freshness record changed.
  */
 async function rebuildMergedValidity({
     targetStorage,
@@ -310,6 +313,7 @@ async function rebuildMergedValidity({
     }
 
     const writer = new ReplicaBatchWriter(targetStorage);
+    let freshnessChanged = false;
 
     // Traverse in topological order so that a node's inputs have their
     // validity entries built before the node's own entries are written.
@@ -319,6 +323,13 @@ async function rebuildMergedValidity({
         if (freshness !== 'up-to-date') continue;
 
         const requiredInputs = mergedInputsMap.get(nodeIdentifier) ?? [];
+        const hasStaleInput = requiredInputs.some((depId) => finalFreshness.get(nodeIdentifierToString(depId)) !== 'up-to-date');
+        if (hasStaleInput) {
+            finalFreshness.set(nodeIdStr, 'potentially-outdated');
+            freshnessChanged = true;
+            await writer.push(targetStorage.freshness.putOp(nodeIdentifier, 'potentially-outdated'));
+            continue;
+        }
         for (const depId of requiredInputs) {
             const depIdStr = nodeIdentifierToString(depId);
             depIdCache.set(depIdStr, depId);
@@ -340,7 +351,7 @@ async function rebuildMergedValidity({
     }
     await writer.flush();
     const validityChanged = !canonicalValidMapsEqual(oldCanonicalValidMap, canonicalizeValidMap(validMap));
-    return validityChanged;
+    return validityChanged || freshnessChanged;
 }
 
 module.exports = {

--- a/backend/src/generators/incremental_graph/migration_decisions.js
+++ b/backend/src/generators/incremental_graph/migration_decisions.js
@@ -1,0 +1,18 @@
+/**
+ * Shared migration decision type definitions.
+ */
+
+/** @typedef {import('./database/types').ComputedValue} ComputedValue */
+/** @typedef {import('./database/types').NodeIdentifier} NodeIdentifier */
+
+/**
+ * @typedef {{ kind: 'keep' }} KeepDecision
+ * @typedef {{ kind: 'override', value: (nodeKey: NodeIdentifier) => Promise<ComputedValue> }} OverrideDecision
+ * @typedef {{ kind: 'invalidate', provenance: 'explicit' | 'propagated' }} InvalidateDecision
+ * @typedef {{ kind: 'delete' }} DeleteDecision
+ * @typedef {"up-to-date" | "potentially-outdated"} CreatedFreshness
+ * @typedef {{ kind: 'create', nodeKeyString: string, value: (nodeKey: NodeIdentifier) => Promise<ComputedValue>, freshness: CreatedFreshness }} CreateDecision
+ * @typedef {KeepDecision | OverrideDecision | InvalidateDecision | DeleteDecision | CreateDecision} Decision
+ */
+
+module.exports = {};

--- a/backend/src/generators/incremental_graph/migration_storage.js
+++ b/backend/src/generators/incremental_graph/migration_storage.js
@@ -10,14 +10,14 @@ const { MigrationStorageClass } = require("./migration_storage_class");
 /** @typedef {import('./database/types').ComputedValue} ComputedValue */
 /** @typedef {import('./database/types').NodeIdentifier} NodeIdentifier */
 
-/**
- * @typedef {{ kind: 'keep' }} KeepDecision
- * @typedef {{ kind: 'override', value: (nodeKey: NodeIdentifier) => Promise<ComputedValue> }} OverrideDecision
- * @typedef {{ kind: 'invalidate' }} InvalidateDecision
- * @typedef {{ kind: 'delete' }} DeleteDecision
- * @typedef {"up-to-date" | "potentially-outdated"} CreatedFreshness
- * @typedef {{ kind: 'create', nodeKeyString: string, value: (nodeKey: NodeIdentifier) => Promise<ComputedValue>, freshness: CreatedFreshness }} CreateDecision
- * @typedef {KeepDecision | OverrideDecision | InvalidateDecision | DeleteDecision | CreateDecision} Decision
+/** @typedef {import('./migration_decisions').KeepDecision} KeepDecision */
+/** @typedef {import('./migration_decisions').OverrideDecision} OverrideDecision */
+/** @typedef {import('./migration_decisions').InvalidateDecision} InvalidateDecision */
+/** @typedef {import('./migration_decisions').DeleteDecision} DeleteDecision */
+/** @typedef {import('./migration_decisions').CreatedFreshness} CreatedFreshness */
+/** @typedef {import('./migration_decisions').CreateDecision} CreateDecision */
+/** @typedef {import('./migration_decisions').Decision} Decision */
+
 
 /**
  * Read-only database view used by migration decision logic.

--- a/backend/src/generators/incremental_graph/migration_storage_class.js
+++ b/backend/src/generators/incremental_graph/migration_storage_class.js
@@ -35,15 +35,13 @@ const {
 /** @typedef {import('./types').NodeName} NodeName */
 /** @typedef {import('./migration_storage').ReadableMigrationStorage} ReadableMigrationStorage */
 
-/**
- * @typedef {{ kind: 'keep' }} KeepDecision
- * @typedef {{ kind: 'override', value: (nodeKey: NodeIdentifier) => Promise<ComputedValue> }} OverrideDecision
- * @typedef {{ kind: 'invalidate' }} InvalidateDecision
- * @typedef {{ kind: 'delete' }} DeleteDecision
- * @typedef {"up-to-date" | "potentially-outdated"} CreatedFreshness
- * @typedef {{ kind: 'create', nodeKeyString: string, value: (nodeKey: NodeIdentifier) => Promise<ComputedValue>, freshness: CreatedFreshness }} CreateDecision
- * @typedef {KeepDecision | OverrideDecision | InvalidateDecision | DeleteDecision | CreateDecision} Decision
- */
+/** @typedef {import('./migration_decisions').KeepDecision} KeepDecision */
+/** @typedef {import('./migration_decisions').OverrideDecision} OverrideDecision */
+/** @typedef {import('./migration_decisions').InvalidateDecision} InvalidateDecision */
+/** @typedef {import('./migration_decisions').DeleteDecision} DeleteDecision */
+/** @typedef {import('./migration_decisions').CreatedFreshness} CreatedFreshness */
+/** @typedef {import('./migration_decisions').CreateDecision} CreateDecision */
+/** @typedef {import('./migration_decisions').Decision} Decision */
 
 /**
  * MigrationStorage class.
@@ -228,10 +226,13 @@ class MigrationStorageClass {
         await checkSchemaCompatibility(nodeKey, this.newHeadIndex, identifiersKeysIndex, this.decisions);
         const existing = this.decisions.get(nodeKey);
         if (existing !== undefined) {
-            if (existing.kind === "invalidate") return;
+            if (existing.kind === "invalidate") {
+                existing.provenance = "explicit";
+                return;
+            }
             throw makeDecisionConflictError(nodeKey, existing.kind, "invalidate");
         }
-        this.decisions.set(nodeKey, { kind: "invalidate" });
+        this.decisions.set(nodeKey, { kind: "invalidate", provenance: "explicit" });
         await propagateInvalidate({
             nodeKey,
             visited: new Set(),
@@ -257,6 +258,10 @@ class MigrationStorageClass {
         const existing = this.decisions.get(nodeKey);
         if (existing !== undefined) {
             if (existing.kind === "delete") return;
+            if (existing.kind === "invalidate" && existing.provenance === "propagated") {
+                this.decisions.set(nodeKey, { kind: "delete" });
+                return;
+            }
             throw makeDecisionConflictError(nodeKey, existing.kind, "delete");
         }
         this.decisions.set(nodeKey, { kind: "delete" });

--- a/backend/src/generators/incremental_graph/migration_storage_dependencies.js
+++ b/backend/src/generators/incremental_graph/migration_storage_dependencies.js
@@ -23,15 +23,13 @@ const {
 /** @typedef {import('./types').NodeName} NodeName */
 /** @typedef {import('./migration_storage').ReadableMigrationStorage} ReadableMigrationStorage */
 
-/**
- * @typedef {{ kind: 'keep' }} KeepDecision
- * @typedef {{ kind: 'override', value: (nodeKey: NodeIdentifier) => Promise<ComputedValue> }} OverrideDecision
- * @typedef {{ kind: 'invalidate' }} InvalidateDecision
- * @typedef {{ kind: 'delete' }} DeleteDecision
- * @typedef {"up-to-date" | "potentially-outdated"} CreatedFreshness
- * @typedef {{ kind: 'create', nodeKeyString: string, value: (nodeKey: NodeIdentifier) => Promise<ComputedValue>, freshness: CreatedFreshness }} CreateDecision
- * @typedef {KeepDecision | OverrideDecision | InvalidateDecision | DeleteDecision | CreateDecision} Decision
- */
+/** @typedef {import('./migration_decisions').KeepDecision} KeepDecision */
+/** @typedef {import('./migration_decisions').OverrideDecision} OverrideDecision */
+/** @typedef {import('./migration_decisions').InvalidateDecision} InvalidateDecision */
+/** @typedef {import('./migration_decisions').DeleteDecision} DeleteDecision */
+/** @typedef {import('./migration_decisions').CreatedFreshness} CreatedFreshness */
+/** @typedef {import('./migration_decisions').CreateDecision} CreateDecision */
+/** @typedef {import('./migration_decisions').Decision} Decision */
 
 /**
  * Reads the outgoing validity frontier for a node from the previous storage.
@@ -72,7 +70,7 @@ async function propagateInvalidate(ctx) {
         }
         const identifiersKeysIndex = await getIdentifiersKeysIndex();
         await checkSchemaCompatibility(dep, newHeadIndex, identifiersKeysIndex, decisions);
-        decisions.set(dep, { kind: "invalidate" });
+        decisions.set(dep, { kind: "invalidate", provenance: "propagated" });
         await propagateInvalidate({
             nodeKey: dep,
             visited,
@@ -164,6 +162,11 @@ async function propagateDeletes(ctx) {
             const existing = decisions.get(dep);
             if (existing?.kind === "delete") continue;
             if (existing !== undefined) {
+                if (existing.kind === "invalidate" && existing.provenance === "propagated") {
+                    decisions.set(dep, { kind: "delete" });
+                    queue.push(dep);
+                    continue;
+                }
                 throw makeDecisionConflictError(dep, existing.kind, "delete");
             }
             if (!materializedNodes.has(dep)) {

--- a/backend/src/generators/incremental_graph/migration_storage_schema.js
+++ b/backend/src/generators/incremental_graph/migration_storage_schema.js
@@ -18,15 +18,13 @@ const { makeSchemaCompatibilityError } = require("./migration_errors");
 /** @typedef {import('./types').NodeName} NodeName */
 /** @typedef {import('./migration_storage').ReadableMigrationStorage} ReadableMigrationStorage */
 
-/**
- * @typedef {{ kind: 'keep' }} KeepDecision
- * @typedef {{ kind: 'override', value: (nodeKey: NodeIdentifier) => Promise<ComputedValue> }} OverrideDecision
- * @typedef {{ kind: 'invalidate' }} InvalidateDecision
- * @typedef {{ kind: 'delete' }} DeleteDecision
- * @typedef {"up-to-date" | "potentially-outdated"} CreatedFreshness
- * @typedef {{ kind: 'create', nodeKeyString: string, value: (nodeKey: NodeIdentifier) => Promise<ComputedValue>, freshness: CreatedFreshness }} CreateDecision
- * @typedef {KeepDecision | OverrideDecision | InvalidateDecision | DeleteDecision | CreateDecision} Decision
- */
+/** @typedef {import('./migration_decisions').KeepDecision} KeepDecision */
+/** @typedef {import('./migration_decisions').OverrideDecision} OverrideDecision */
+/** @typedef {import('./migration_decisions').InvalidateDecision} InvalidateDecision */
+/** @typedef {import('./migration_decisions').DeleteDecision} DeleteDecision */
+/** @typedef {import('./migration_decisions').CreatedFreshness} CreatedFreshness */
+/** @typedef {import('./migration_decisions').CreateDecision} CreateDecision */
+/** @typedef {import('./migration_decisions').Decision} Decision */
 
 /**
  * Read the persisted identifiers_keys_map and return it as an index Map.

--- a/backend/tests/migration_storage.test.js
+++ b/backend/tests/migration_storage.test.js
@@ -575,6 +575,61 @@ describe("MigrationStorage", () => {
             expect(decisions.get(D)?.kind).toBe("delete");
         });
 
+        test("delete propagation replaces automatically propagated invalidation", async () => {
+            const storage = makeInMemorySchemaStorage();
+            const headIndex = makeHeadIndex(["A", "C", "D"]);
+            const A = nk("A");
+            const C = nk("C");
+            const D = nk("D");
+            const scheme = {
+                format: 1,
+                nodes: [
+                    { head: "A", arity: 0, inputTemplates: [] },
+                    { head: "C", arity: 0, inputTemplates: [] },
+                    { head: "D", arity: 0, inputTemplates: [{ head: "A", args: [] }, { head: "C", args: [] }] },
+                ],
+            };
+            const lookup = makeLookupFromKeys([A, C, D]);
+            await storage.values.put(A, DUMMY_VALUE);
+            await storage.values.put(C, DUMMY_VALUE);
+            await storage.values.put(D, DUMMY_VALUE);
+            await storage.valid.put(C, [D]);
+            const ms = makeMigrationStorage(storage, headIndex, [A, C, D], "testfingerprint", 0, scheme, scheme, lookup);
+
+            await ms.invalidate(C);
+            await ms.delete(A);
+            const decisions = await ms.finalize();
+            expect(decisions.get(D)?.kind).toBe("delete");
+        });
+
+        test("delete propagation conflicts with explicit invalidation after automatic propagation", async () => {
+            const storage = makeInMemorySchemaStorage();
+            const headIndex = makeHeadIndex(["A", "C", "D"]);
+            const A = nk("A");
+            const C = nk("C");
+            const D = nk("D");
+            const scheme = {
+                format: 1,
+                nodes: [
+                    { head: "A", arity: 0, inputTemplates: [] },
+                    { head: "C", arity: 0, inputTemplates: [] },
+                    { head: "D", arity: 0, inputTemplates: [{ head: "A", args: [] }, { head: "C", args: [] }] },
+                ],
+            };
+            const lookup = makeLookupFromKeys([A, C, D]);
+            await storage.values.put(A, DUMMY_VALUE);
+            await storage.values.put(C, DUMMY_VALUE);
+            await storage.values.put(D, DUMMY_VALUE);
+            await storage.valid.put(C, [D]);
+            const ms = makeMigrationStorage(storage, headIndex, [A, C, D], "testfingerprint", 0, scheme, scheme, lookup);
+
+            await ms.invalidate(C);
+            await ms.invalidate(D);
+            await ms.delete(A);
+            const error = await ms.finalize().catch((e) => e);
+            expect(isDecisionConflict(error)).toBe(true);
+        });
+
 
         test("delete propagation follows removed target dependency", async () => {
             const storage = makeInMemorySchemaStorage();

--- a/backend/tests/sync_merge.test.js
+++ b/backend/tests/sync_merge.test.js
@@ -2042,6 +2042,46 @@ describe('mergeHostIntoReplica', () => {
         }
     });
 
+    test('equal-version invalidation propagates stale freshness to newer dependents', async () => {
+        const capabilities = getTestCapabilities();
+        let db;
+        try {
+            db = await getRootDatabase(capabilities);
+            await writeGraphScheme(db.schemaStorageForReplica('x'));
+            const logger = makeLogger();
+            const hostname = 'equal-version-peer';
+            await db.setGlobalVersion(db.version);
+            await db.setHostnameGlobal(hostname, 'version', db.version);
+
+            const nodeA = nodeIdentifierFromString('138-abcdefghi');
+            const nodeB = nodeIdentifierFromString('139-abcdefghi');
+            const keyA = stringToNodeKeyString('{"head":"stale_input_A","args":[]}');
+            const keyB = stringToNodeKeyString('{"head":"stale_input_B","args":[]}');
+
+            const target = db.schemaStorageForReplica('x');
+            await writeNode(target, nodeA, TS1, { source: 'A' });
+            await writeNode(target, nodeB, TS3, { source: 'B target' });
+            await target.valid.put(nodeA, [nodeB]);
+            await writeIdentifierLookup(target, [[nodeA, keyA], [nodeB, keyB]]);
+
+            const host = db.hostnameSchemaStorage(hostname);
+            await writeGraphScheme(host);
+            await writeNode(host, nodeA, TS1, { source: 'A' });
+            await writeNode(host, nodeB, TS2, { source: 'B host' });
+            await host.freshness.put(nodeA, 'potentially-outdated');
+            await host.freshness.put(nodeB, 'potentially-outdated');
+            await writeIdentifierLookup(host, [[nodeA, keyA], [nodeB, keyB]]);
+
+            db = await mergeAndReopenIfSwitched(capabilities, logger, db, hostname);
+
+            const storage = db.getSchemaStorage();
+            expect(await storage.freshness.get(nodeA)).toBe('potentially-outdated');
+            expect(await storage.freshness.get(nodeB)).toBe('potentially-outdated');
+        } finally {
+            if (db) await db.close();
+        }
+    });
+
     test('4. identifier lowering transports valid proofs to final identifiers', async () => {
         const { rebuildMergedValidity } = require('../src/generators/incremental_graph/database/sync_merge_validity');
         const capabilities = getTestCapabilities();


### PR DESCRIPTION
### Motivation
- Ensure freshness downgrades on merged inputs propagate to dependents so merged graph freshness reflects input staleness. 
- Make migration decision propagation deterministic by recording provenance for automatically propagated `invalidate` decisions and resolving conflicts between propagated invalidations and explicit `delete` requests.

### Description
- Update `rebuildMergedValidity` to track in-memory `freshness` and traverse merged nodes in topological order, downgrading nodes to `potentially-outdated` when any input is not `up-to-date`, persist those downgrades via `freshness.putOp`, and return a combined flag for validity or freshness changes; rename local callers to use the new `graphStateChanged` naming. 
- Add `migration_decisions.js` to centralize typedefs for migration `Decision` shapes and replace duplicated typedef blocks with imports from the new module in `migration_storage.js`, `migration_storage_class.js`, `migration_storage_dependencies.js`, and `migration_storage_schema.js`. 
- Make `invalidate` produce an `{ provenance: 'explicit' }` marker for explicit calls, make `propagateInvalidate` mark propagated invalidations as `{ provenance: 'propagated' }`, and update `delete`/`propagateDeletes` to convert a propagated invalidation into a `delete` while treating an explicit invalidation as a conflict. 
- Add unit tests covering freshness propagation during merge and the interaction between propagated invalidation and delete propagation in `backend/tests/migration_storage.test.js` and `backend/tests/sync_merge.test.js`.

### Testing
- Ran the backend unit tests that exercise migration storage behavior and sync merge logic, including the new tests in `backend/tests/migration_storage.test.js` and `backend/tests/sync_merge.test.js`, and they passed. 
- Verified the new `rebuildMergedValidity` behavior via the added merge test that checks freshness downgrades are persisted after a merge. 
- Verified migration propagation semantics via the added tests that cover converting propagated invalidations to deletes and conflict detection when an explicit invalidation is present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5d65f69e28832eae63d9f5c11ef9fe)