### PR TITLE
Restore authoritative graph merge and locking; enforce fixed-origin journal domain and integrate NotificationClock

### DIFF
--- a/docs/incremental-graph-journal.md
+++ b/docs/incremental-graph-journal.md
@@ -182,6 +182,18 @@ the corresponding files under `docs/specs/`.
   replica cutover.
 - Reset replaces graph state but preserves receiving-host journal identity and
   cursor history.
+- Existing-live reset preserves the receiving host's complete journal state.
+- Absent-state self-restoration restores the same host's previously published
+  `NotificationClock` and continues its counters.
+- No `JournalOriginId` may reuse a sequence lower than progress previously
+  published under that origin.
+- Restoration is not classified as empty-graph-to-restored-graph journal
+  actions.
+- Raw cross-host database copying remains unsupported.
+- A copied `localWriterId`/`localJournalOrigin` pair is not proof of writer
+  ownership.
+- A new host obtains a fresh graph fingerprint and its preassigned
+  writer/origin pair through the supported fresh-host lifecycle.
 - A writable replica cannot commit unless its local writer/origin pair equals
   its immutable `JournalDomain.writerOrigins` assignment.
 - When remote progress and a local synchronization-created transition share one

--- a/docs/incremental-graph-journal.md
+++ b/docs/incremental-graph-journal.md
@@ -28,10 +28,11 @@ or active/inactive cutover.
 
 ### Goal 3 — algebraic synchronization
 
-**Synchronization of synchronized journal state must be commutative,
-associative, and idempotent.** `NotificationClock` joins coordinate-wise by the
-maximum sequence. It is therefore a finite product of max-counter
-semilattices; the journal synchronization specification proves each law.
+**The replicated notification state of the journal synchronizes commutatively,
+associatively, and idempotently.** That replicated state is exactly
+`NotificationClock`, which joins coordinate-wise by maximum sequence. Local
+delivery indices, heads, watermarks, and physical gaps are cursor
+infrastructure, not algebraic merge state.
 
 ### Non-goal — graph authority
 
@@ -51,6 +52,7 @@ GraphReplica
     ├── NotificationClock
     ├── DeliveryByIndex
     ├── DeliveryHead
+    ├── JournalDomain
     ├── JournalOriginId
     └── lastLocalJournalIndex
 ```
@@ -123,6 +125,9 @@ the corresponding files under `docs/specs/`.
 
 ## Normative invariants
 
+- The graph merge is fully specified independently of the journal.
+- The notification clock never chooses graph state.
+- The journal rewrite does not remove or weaken the observatory locking model.
 - The graph database is the sole authority for graph state.
 - The journal is a notification source and never a graph-state source.
 - The journal has no false negatives for materialization, `ComputedValue`, or
@@ -136,6 +141,14 @@ the corresponding files under `docs/specs/`.
   up-to-date.
 - Notification-clock synchronization is pointwise maximum and is commutative,
   associative, and idempotent.
+- Every writable host has one unique origin from a fixed finite synchronization
+  domain.
+- Unknown origins cannot enlarge a clock.
+- For a fixed journal domain, total live journal state is O(n).
+- The replicated `NotificationClock` join is commutative, associative, and
+  idempotent.
+- Local delivery indices are cursor infrastructure and are not part of the
+  algebraic merge result.
 - Concurrent origins and distinct actions cannot overwrite one another.
 - At most one local delivery record exists per historic node key and exact
   action.
@@ -145,6 +158,8 @@ the corresponding files under `docs/specs/`.
   length.
 - The journal remains physically inside the graph replica and is copied as
   local cursor infrastructure during replica construction.
+- No committed materialization, value, or freshness transition lacks a covering
+  notification.
 
 ## Strict O(n) proof
 
@@ -162,6 +177,9 @@ The last equality requires fixed `r` and `a`; with unbounded origins it is
 `O(nr)`. Historic deleted keys remain in `n`. Mandatory replacement maintains
 the bound continuously. Operation/synchronization count, value/proof size,
 graph age, validity edges, and obsolete intermediate values add no terms.
+For this protocol version, `allowedOrigins` is finite and immutable, so `r` is
+an enforced domain constant. For a fixed journal domain, total live journal
+state is O(n).
 
 ## No-false-negatives proof
 

--- a/docs/incremental-graph-journal.md
+++ b/docs/incremental-graph-journal.md
@@ -28,11 +28,14 @@ or active/inactive cutover.
 
 ### Goal 3 — algebraic synchronization
 
-**The replicated notification state of the journal synchronizes commutatively,
-associatively, and idempotently.** That replicated state is exactly
-`NotificationClock`, which joins coordinate-wise by maximum sequence. Local
-delivery indices, heads, watermarks, and physical gaps are cursor
-infrastructure, not algebraic merge state.
+**The binary merge operator for already-emitted replicated `NotificationClock`
+states is commutative, associative, and idempotent.** The operator is
+`mergeNotificationClocks(A,B) = joinClock(A,B)`, a coordinate-wise maximum.
+An overall graph synchronization may subsequently emit new receiving-host clock
+progress for graph transitions created by that synchronization. This is a local
+update after the merge, not part of the merge algebra. Reversing the receiving
+host need not produce an identical complete replica or post-emission clock.
+Local delivery indices, heads, watermarks, and gaps remain cursor infrastructure.
 
 ### Non-goal — graph authority
 
@@ -53,6 +56,7 @@ GraphReplica
     ├── DeliveryByIndex
     ├── DeliveryHead
     ├── JournalDomain
+    ├── JournalWriterId
     ├── JournalOriginId
     └── lastLocalJournalIndex
 ```
@@ -141,12 +145,19 @@ the corresponding files under `docs/specs/`.
   up-to-date.
 - Notification-clock synchronization is pointwise maximum and is commutative,
   associative, and idempotent.
-- Every writable host has one unique origin from a fixed finite synchronization
-  domain.
+- Every writable writer identity has exactly one immutable origin assignment in
+  `JournalDomain`.
+- No two writer identities may own one `JournalOriginId`.
+- A peer's claimed writer/origin pair is validated against `JournalDomain`
+  before clock join.
 - Unknown origins cannot enlarge a clock.
 - For a fixed journal domain, total live journal state is O(n).
-- The replicated `NotificationClock` join is commutative, associative, and
-  idempotent.
+- `joinClock` is the commutative, associative, and idempotent binary merge
+  operator.
+- Post-merge synchronization-created emission is a new local update, not part of
+  the `joinClock` algebra.
+- The complete receiving-host post-emission clock need not equal the
+  reversed-role post-emission clock.
 - Local delivery indices are cursor infrastructure and are not part of the
   algebraic merge result.
 - Concurrent origins and distinct actions cannot overwrite one another.
@@ -171,8 +182,10 @@ the corresponding files under `docs/specs/`.
   replica cutover.
 - Reset replaces graph state but preserves receiving-host journal identity and
   cursor history.
-- A writable replica cannot commit while its local origin is absent from the
-  fixed allowed-origin set.
+- A writable replica cannot commit unless its local writer/origin pair equals
+  its immutable `JournalDomain.writerOrigins` assignment.
+- When remote progress and a local synchronization-created transition share one
+  delivery coordinate, the delivery uses local cutover time.
 - `joinClock` remains commutative, associative, and idempotent.
 
 ## Strict O(n) proof
@@ -191,8 +204,8 @@ The last equality requires fixed `r` and `a`; with unbounded origins it is
 `O(nr)`. Historic deleted keys remain in `n`. Mandatory replacement maintains
 the bound continuously. Operation/synchronization count, value/proof size,
 graph age, validity edges, and obsolete intermediate values add no terms.
-For this protocol version, `allowedOrigins` is finite and immutable, so `r` is
-an enforced domain constant. For a fixed journal domain, total live journal
+For this protocol version, `writerOrigins` is finite and immutable, so the
+cardinality of its unique origin values is an enforced domain constant. For a fixed journal domain, total live journal
 state is O(n).
 
 ## No-false-negatives proof

--- a/docs/incremental-graph-journal.md
+++ b/docs/incremental-graph-journal.md
@@ -160,6 +160,20 @@ the corresponding files under `docs/specs/`.
   local cursor infrastructure during replica construction.
 - No committed materialization, value, or freshness transition lacks a covering
   notification.
+- Every committed synchronization-created graph transition advances the
+  receiving host's synchronized action counter.
+- No graph transition is represented only by an unsynchronized local delivery.
+- A journal-only synchronization result still activates the destination
+  replica.
+- Replica cutover is skipped only when both graph and complete journal result
+  are unchanged.
+- `JournalDomain` survives synchronization, migration, reset, restart, and
+  replica cutover.
+- Reset replaces graph state but preserves receiving-host journal identity and
+  cursor history.
+- A writable replica cannot commit while its local origin is absent from the
+  fixed allowed-origin set.
+- `joinClock` remains commutative, associative, and idempotent.
 
 ## Strict O(n) proof
 

--- a/docs/specs/database-lifecycle.md
+++ b/docs/specs/database-lifecycle.md
@@ -76,15 +76,17 @@ The synchronization repository is part of creation even when the resulting datab
 
 ### 4.2 Restoring this host's synchronized state
 
-When local live state is absent, Volodyslav first asks whether the synchronization repository contains state previously published for the current hostname.
+When local live state is absent, Volodyslav first asks whether the synchronization repository contains the current synchronized state previously published for this same host and writer. The synchronization lifecycle must recognize the selected branch as the branch assigned to the current host/writer.
 
-If it does, startup uses the controlled reset-to-host path to restore that snapshot into a newly opened local database. The imported state is committed through the database's normal cutover mechanism, then the database is reopened and passed through the migration gate. Thus a host can recover its own synchronized state and then migrate it to the running version.
+This is **absent-state self-restoration**, not reset of an existing database. It restores and validates the authoritative graph together with `JournalDomain`, `localWriterId`, `JournalOriginId`, `NotificationClock`, `DeliveryByIndex`, `DeliveryHead`, `lastLocalJournalIndex`, and physical gaps. The restored identity must satisfy `JournalDomain.writerOrigins[localWriterId] == JournalOriginId`.
 
-Any failure to query, obtain, parse, or install that state is fatal to bootstrap. Volodyslav does not silently fall back to an empty database after discovering that the host is supposed to have synchronized state.
+Restoration resumes previously emitted state. It MUST NOT classify the restored graph as an empty-to-restored transition and MUST NOT emit `add` for every restored materialization. The restored counters and cursor history are installed through the normal durable cutover, after which the database is reopened and passed through the migration gate.
+
+The supported source is the host's current synchronized state, not an arbitrary historical checkpoint. Restoring an older checkpoint under the same writer/origin is unsupported unless a future recovery protocol supplies anti-rollback state or assigns a new origin. Any failure to query, obtain, validate, or install the expected current state is fatal; startup does not silently fall back to an empty database.
 
 ### 4.3 Creating a new host state
 
-If the current hostname has no synchronized branch, startup initializes the local synchronization working state and runs normal synchronization from an empty local database. This establishes the host's synchronization history and then considers other host branches under the ordinary synchronization rules.
+If the current hostname has no synchronized branch, startup uses the supported fresh-host lifecycle. It provisions a fresh graph allocation fingerprint and the host's preassigned `localWriterId`/`JournalOriginId` mapping before writable open, initializes local synchronization state, and runs normal synchronization from an empty graph. This establishes the host's own synchronization history and then joins other host clocks under ordinary synchronization rules without adopting their writer identities.
 
 The empty database is a legitimate initial state. On the first migration gate, absence of a stored database version means **fresh database**, and the running version is recorded without running a data migration.
 
@@ -199,13 +201,54 @@ Synchronization is therefore not globally atomic across all remote hosts. Its po
 
 After an initiated synchronization, Volodyslav attempts to reopen the local database and rerun the migration gate even if synchronization itself failed. If both synchronization and reopening fail, both failures are relevant. A synchronization error does not justify leaving the application interface attached to a closed database.
 
-### 7.4 Controlled reset
+### 7.4 Existing-live controlled reset
 
-A reset-to-host synchronization selects a host snapshot and installs it through a non-active target state followed by cutover. It is used during restoration and may also be invoked through a Volodyslav-controlled synchronization path.
+A reset-to-host synchronization applied to an established live database selects
+a snapshot's authoritative graph and installs it through a non-active target
+followed by cutover. The receiving host preserves its complete journal state:
+`JournalDomain`, `localWriterId`, `JournalOriginId`, `NotificationClock`,
+`DeliveryByIndex`, `DeliveryHead`, `lastLocalJournalIndex`, and physical gaps.
+The source contributes authoritative graph state only.
 
-Reset is intentionally different from normal merge: it selects the snapshot as the logical source rather than combining it node by node with the current state. The selected snapshot must still be structurally importable and must pass required database identity checks. When reset is applied to an already-existing local database, implementation-defined host-local state that must remain local is preserved by the reset path. When reset is used during absent-local-state bootstrap, there is no previous local database identity to preserve; the selected synchronized host snapshot is installed according to the bootstrap protocol.
+The reset classifies `ResetActions` from `oldLocalGraph` to `replacementGraph`.
+Every exact action advances the receiving origin and append-or-replaces a local
+delivery. Graph replacement and notification coverage commit atomically before
+cutover. This transition is distinct from absent-state self-restoration in §4.2.
+After reset, the database is reopened through the migration gate.
 
-After reset, the database is reopened through the migration gate. A reset snapshot may therefore be older than the running application if the supported migration can bring it forward. This does not weaken the normal synchronization rule that peer-to-peer merging requires matching versions before merge.
+### 7.5 Counter continuity during self-restoration
+
+A writer MUST never resume authoritative mutation with a local action sequence
+below a sequence it previously published under the same `JournalOriginId`.
+
+```text
+A previously published:
+    clock[K][OA][edit] = 10
+
+A loses its live database.
+
+A restores its own synchronized snapshot:
+    clock[K][OA][edit] = 10
+
+A edits K:
+    clock[K][OA][edit] = 11
+
+B previously observed 10:
+    join detects 11 > 10
+    B receives edit K
+```
+
+The rollback below is invalid because max join makes the new edit invisible:
+
+```text
+restore OA at sequence 0
+emit sequence 1
+peer already has sequence 10
+
+join chooses 10
+new edit is invisible
+```
+
 
 ## 8. Version compatibility
 
@@ -330,6 +373,9 @@ Implementations and future changes MUST preserve the following lifecycle propert
 10. Tests and diagnostics SHOULD distinguish incompatibility, failed preconditions, corruption, and unsupported manipulation rather than using those terms interchangeably.
 11. New recovery, import, or restore behavior MUST be implemented as a Volodyslav-controlled lifecycle transition. Documentation alone MUST NOT redefine raw file manipulation as supported.
 12. Storage refactors MAY change physical artifacts without changing this specification, provided these lifecycle preconditions, transitions, and postconditions remain true.
+13. Existing-live reset MUST preserve the receiving host's complete journal state.
+14. Absent-state self-restoration MUST restore the same host's current published clock and continue its counters without empty-graph classification.
+15. Raw cross-host copying of a live database remains unsupported; copied writer metadata does not establish ownership.
 
 ## 15. Known boundaries
 

--- a/docs/specs/incremental-graph-journal-migrations.md
+++ b/docs/specs/incremental-graph-journal-migrations.md
@@ -5,12 +5,19 @@ The inactive destination first copies the active local journal infrastructure
 exactly from one fixed snapshot:
 
 ```text
+JournalDomain
 NotificationClock
 DeliveryByIndex
 DeliveryHead
 JournalOriginId
 lastLocalJournalIndex
 ```
+
+Migration preserves this complete local domain and the receiving writer
+identity; it never creates, replaces, or infers a domain. Before cutover it
+validates domain equality with the source, membership of the local and all clock
+origins, the one-head invariant, and that the watermark is at least every
+retained delivery index.
 
 It then compares old and new authoritative graphs and applies the ordinary exact
 classifier: absent→present `add`, present→absent `delete`, unequal materialized

--- a/docs/specs/incremental-graph-journal-migrations.md
+++ b/docs/specs/incremental-graph-journal-migrations.md
@@ -6,6 +6,7 @@ exactly from one fixed snapshot:
 
 ```text
 JournalDomain
+localWriterId
 NotificationClock
 DeliveryByIndex
 DeliveryHead
@@ -16,7 +17,8 @@ lastLocalJournalIndex
 Migration preserves this complete local domain and the receiving writer
 identity; it never creates, replaces, or infers a domain. Before cutover it
 validates domain equality with the source, membership of the local and all clock
-origins, the one-head invariant, and that the watermark is at least every
+origins, equality of the local writer/origin pair with `writerOrigins`, the
+one-head invariant, and that the watermark is at least every
 retained delivery index.
 
 It then compares old and new authoritative graphs and applies the ordinary exact

--- a/docs/specs/incremental-graph-journal-sync.md
+++ b/docs/specs/incremental-graph-journal-sync.md
@@ -61,6 +61,11 @@ components are identical because validity requires equal times.
 A clock is a finite product over key/origin/action coordinates of max-counter
 semilattices. Finite products preserve these three laws.
 
+Ordinary local emission, including synchronization-created emission, may occur
+before or after a join. Emission changes an operand by advancing its assigned
+origin; it does not change the commutative, associative, or idempotent laws of
+`joinClock` itself.
+
 Normatively, the laws apply only to `NotificationClock`:
 
 ```text

--- a/docs/specs/incremental-graph-journal-sync.md
+++ b/docs/specs/incremental-graph-journal-sync.md
@@ -9,21 +9,29 @@ materialization and never participate in journal synchronization.
 Before joining, validate both complete inputs and require:
 
 ```text
-local.domainId == remote.domainId
-local.allowedOrigins == remote.allowedOrigins
+local.JournalDomain == remote.JournalDomain
+
+domain.writerOrigins[local.localWriterId]
+    == local.localJournalOrigin
+
+domain.writerOrigins[remote.localWriterId]
+    == remote.localJournalOrigin
+
+local.localWriterId != remote.localWriterId
+local.localJournalOrigin != remote.localJournalOrigin
 ```
 
-Set equality is exact. Reject either clock if any component names an origin
-outside `allowedOrigins`. Domain mismatch, unknown origin, malformed component,
-and equal-sequence/time conflict reject synchronization atomically and
-symmetrically before either result is installed. Remote data never silently
-adds an origin. Dynamic membership requires a separately specified
-journal-domain migration.
+Mapping equality is exact. Each staged peer declares its stable writer ID and
+assigned origin. Reject either clock if any coordinate uses an origin outside
+`set(domain.writerOrigins.values())`. Domain mismatch, unknown origin, malformed
+component, ownership mismatch, and equal-sequence/time conflict reject
+synchronization atomically and symmetrically before either result is installed.
+Remote data never adds a writer or origin. Dynamic membership requires a
+separately specified journal-domain migration.
 
-Distinct independently writable peers must have distinct assigned local
-origins. As a mandatory negative protocol test, two writable hosts configured
-with the same local origin are rejected before either may synchronize as a
-valid peer; neither destination is installed.
+Distinct independently writable peers must have distinct mapped writers and
+origins. Claims are checked against the immutable mapping, not merely against
+previously encountered peers.
 
 ## Coordinate join
 
@@ -74,6 +82,19 @@ joinClock(joinClock(A, B), C) = joinClock(A, joinClock(B, C))
 joinClock(A, A) = A
 ```
 
+`mergeNotificationClocks(A,B) = joinClock(A,B)` is the binary journal merge
+operator for already-emitted replicated states. The three laws above belong to
+that operator alone.
+
+```text
+mergeNotificationClocks(A, B) = mergeNotificationClocks(B, A)
+
+mergeNotificationClocks(mergeNotificationClocks(A, B), C)
+    = mergeNotificationClocks(A, mergeNotificationClocks(B, C))
+
+mergeNotificationClocks(A, A) = A
+```
+
 Different hosts or synchronization schedules need not produce identical
 physical delivery indices or watermarks. Local delivery state instead
 guarantees no false negatives, same-process cursor continuity, one retained
@@ -96,7 +117,7 @@ detects B. This is required for concurrent edits.
 ```text
 RemoteAdvancedActions = {
   (K,A) |
-  some O has finalClock[K][O][A].sequence
+  some O has joinedClock[K][O][A].sequence
              > localClock[K][O][A].sequence
 }
 ```
@@ -120,18 +141,36 @@ component greatest under `(sequence, JournalOriginId)` and copy its time.
 The clock join does not synchronize graph state and is never an input to graph
 conflict resolution.
 
+### Writer-ownership rejection across three hosts
+
+```text
+domain:
+    WA -> OA
+    WB -> OB
+    WC -> OC
+
+A declares: writer WA, origin OA
+B declares: writer WB, origin OA
+```
+
+C rejects B because `domain.writerOrigins[WB] = OB` but
+`B.localJournalOrigin = OA`. This works even when C synchronized with A and B
+at different times: ownership is verified from the immutable domain.
+
 ### Mandatory host-fork trace
 
 ```text
 A:
+    local writer WA
     local origin OA
     edit[K][OA] = 5
 
 copy A's storage to new writable host B
 
 before B may mutate:
-    B.local origin = OB
-    OA != OB
+    B.localWriterId = WB
+    B.local origin = domain.writerOrigins[WB] = OB
+    WA != WB and OA != OB
 
 B edits K:
     edit[K][OB] = 1

--- a/docs/specs/incremental-graph-journal-sync.md
+++ b/docs/specs/incremental-graph-journal-sync.md
@@ -157,29 +157,40 @@ C rejects B because `domain.writerOrigins[WB] = OB` but
 `B.localJournalOrigin = OA`. This works even when C synchronized with A and B
 at different times: ownership is verified from the immutable domain.
 
-### Mandatory host-fork trace
+### Supported fresh-host trace
 
 ```text
-A:
-    local writer WA
-    local origin OA
-    edit[K][OA] = 5
+domain:
+    WA -> OA
+    WB -> OB
 
-copy A's storage to new writable host B
+A is an existing host:
+    allocation fingerprint FA
+    localWriterId WA
+    origin OA
 
-before B may mutate:
-    B.localWriterId = WB
-    B.local origin = domain.writerOrigins[WB] = OB
-    WA != WB and OA != OB
+B is created through the supported fresh-host lifecycle:
+    allocation fingerprint FB
+    localWriterId WB
+    origin OB
 
-B edits K:
-    edit[K][OB] = 1
+require:
+    FA != FB
+    WA != WB
+    OA != OB
 
-join retains:
-    edit[K][OA] = 5
-    edit[K][OB] = 1
+B synchronizes with A:
+    B keeps FB, WB, and OB
+    B joins A's NotificationClock components
+    B never advances OA
 ```
 
-B retains OA's copied component but never advances it. Copying storage does not
-make B the OA writer. OB must be distinct, already allowed by the fixed domain,
-and assigned before B's first authoritative graph mutation.
+Normal synchronization validates a staged peer's mapped writer/origin claim and
+also its recognized host branch identity supplied by the synchronization
+lifecycle. These are correctness checks under the non-adversarial model, not
+cryptographic or Byzantine authentication.
+
+Raw cross-host copying of a live database is unsupported. A copied
+`localWriterId`/`localJournalOrigin` pair is not proof of writer ownership, and
+the journal mapping cannot authenticate the physical installation that holds
+copied files.

--- a/docs/specs/incremental-graph-journal-sync.md
+++ b/docs/specs/incremental-graph-journal-sync.md
@@ -1,5 +1,30 @@
 # Notification-clock synchronization
 
+## Domain validation and synchronization boundary
+
+Only `NotificationClock` is replicated journal state. `DeliveryByIndex`,
+`DeliveryHead`, `lastLocalJournalIndex`, and physical gaps are host-local cursor
+materialization and never participate in journal synchronization.
+
+Before joining, validate both complete inputs and require:
+
+```text
+local.domainId == remote.domainId
+local.allowedOrigins == remote.allowedOrigins
+```
+
+Set equality is exact. Reject either clock if any component names an origin
+outside `allowedOrigins`. Domain mismatch, unknown origin, malformed component,
+and equal-sequence/time conflict reject synchronization atomically and
+symmetrically before either result is installed. Remote data never silently
+adds an origin. Dynamic membership requires a separately specified
+journal-domain migration.
+
+Distinct independently writable peers must have distinct assigned local
+origins. As a mandatory negative protocol test, two writable hosts configured
+with the same local origin are rejected before either may synchronize as a
+valid peer; neither destination is installed.
+
 ## Coordinate join
 
 Missing coordinates have sequence zero. For each `(key, origin, action)`:
@@ -35,6 +60,20 @@ components are identical because validity requires equal times.
 
 A clock is a finite product over key/origin/action coordinates of max-counter
 semilattices. Finite products preserve these three laws.
+
+Normatively, the laws apply only to `NotificationClock`:
+
+```text
+joinClock(A, B) = joinClock(B, A)
+joinClock(joinClock(A, B), C) = joinClock(A, joinClock(B, C))
+joinClock(A, A) = A
+```
+
+Different hosts or synchronization schedules need not produce identical
+physical delivery indices or watermarks. Local delivery state instead
+guarantees no false negatives, same-process cursor continuity, one retained
+record per key/action, and O(n) live records. Local delivery indices are cursor
+infrastructure and are not part of the algebraic merge result.
 
 ## Independent coordinates
 
@@ -75,3 +114,28 @@ component greatest under `(sequence, JournalOriginId)` and copy its time.
 
 The clock join does not synchronize graph state and is never an input to graph
 conflict resolution.
+
+### Mandatory host-fork trace
+
+```text
+A:
+    local origin OA
+    edit[K][OA] = 5
+
+copy A's storage to new writable host B
+
+before B may mutate:
+    B.local origin = OB
+    OA != OB
+
+B edits K:
+    edit[K][OB] = 1
+
+join retains:
+    edit[K][OA] = 5
+    edit[K][OB] = 1
+```
+
+B retains OA's copied component but never advances it. Copying storage does not
+make B the OA writer. OB must be distinct, already allowed by the fixed domain,
+and assigned before B's first authoritative graph mutation.

--- a/docs/specs/incremental-graph-journal-types.md
+++ b/docs/specs/incremental-graph-journal-types.md
@@ -87,18 +87,22 @@ transaction identifier, or synchronization generation. Equal nonzero sequence
 at the same coordinate has exactly one valid time. Overflow is fatal and never
 wraps.
 
-Writer identity and assignment survive restart, reset, migration, and same-host
-active/inactive cutover. Remote snapshot import does not replace the receiving
-writer or origin. When A's storage is copied to new writable host B, B retains
-`JournalDomain` and every historical clock component, but before writable open:
+`JournalWriterId` is host identity established by a supported lifecycle
+transition outside arbitrary replica copying. Replica-local storage carries that
+already-established identity through restart, migration, existing-live reset,
+and same-host active/inactive cutover.
 
-```text
-B.localWriterId = WB
-B.localJournalOrigin = JournalDomain.writerOrigins[WB]
-```
+A writer identity is established by a supported host lifecycle transition.
+Possession of a copied replica containing that identity does not establish
+ownership. Raw cross-host copying of a live database is outside the supported
+lifecycle, and the journal protocol does not make it safe. Merely replacing the
+journal writer/origin pair would also leave copied graph allocation and allocator
+namespaces unsafe.
 
-WB must be the distinct mapping provisioned for B. B never advances A's origin.
-Copying storage alone does not transfer writer ownership.
+Absent-state self-restoration is different: it restores this same writer's
+current synchronized `JournalDomain`, identity, clock, delivery state, and graph.
+It must continue all previously published local-origin sequences and must not
+classify restoration as new graph actions.
 
 ## Local delivery types and cursors
 

--- a/docs/specs/incremental-graph-journal-types.md
+++ b/docs/specs/incremental-graph-journal-types.md
@@ -87,6 +87,13 @@ subsequent mutations. Adding or removing writable origins requires a separately
 specified journal-domain migration; dynamic membership is outside this protocol
 revision.
 
+Writable open and transaction finalization require
+`localJournalOrigin ∈ JournalDomain.allowedOrigins`. Missing domain, missing
+local origin, or an origin outside the fixed set prevents authoritative graph
+mutation. If A's storage is copied to a new writable host B, B must be
+provisioned with a distinct allowed origin before opening the graph for writes;
+B retains A's clock components but never advances them.
+
 ## Local delivery types and cursors
 
 ```text

--- a/docs/specs/incremental-graph-journal-types.md
+++ b/docs/specs/incremental-graph-journal-types.md
@@ -26,10 +26,23 @@ transitions can emit two actions.
 
 ## Stable origin and synchronized clock
 
-`JournalOriginId` is the durable identity of one independently writable replica
-origin. It is unique among concurrent writers and survives process restart,
-reset, migration, and active/inactive cutover. Both slots of one local graph
-lineage carry the same identity. It is not regenerated per operation or sync.
+`JournalDomainId` is the durable identity of one synchronization domain.
+`AllowedJournalOrigins` is a finite immutable set. This protocol version fixes
+membership:
+
+```text
+JournalDomain = {
+    domainId: JournalDomainId
+    allowedOrigins: AllowedJournalOrigins
+}
+
+AllowedJournalOrigins = finite immutable set<JournalOriginId>
+```
+
+`JournalOriginId` is the assigned writer identity of exactly one independently
+writable host. Every writable host has one unique origin from a fixed finite
+synchronization domain. Unknown origins cannot enlarge a clock. A host advances
+only its assigned local origin; it retains but never advances other origins.
 
 ```text
 NotificationClock =
@@ -55,6 +68,24 @@ only: it is not a graph revision/version, causal context, operation or
 transaction identifier, or synchronization generation. Equal nonzero sequence
 at the same coordinate has exactly one valid time. Overflow is fatal and never
 wraps.
+
+Origin identity obeys these lifecycle rules:
+
+```text
+process restart: preserve local origin
+reset: preserve local origin
+migration: preserve local origin
+active/inactive cutover on the same host: both slots share the local origin
+remote snapshot import: do not replace the receiving host's local origin
+new independently writable host:
+    assign a distinct allowed origin before its first graph mutation
+```
+
+A copied database does not transfer writer identity. A receiving host retains
+all synchronized clock components but uses only its own assigned origin for
+subsequent mutations. Adding or removing writable origins requires a separately
+specified journal-domain migration; dynamic membership is outside this protocol
+revision.
 
 ## Local delivery types and cursors
 
@@ -83,13 +114,16 @@ other than notification time, validity data, proofs, or graph assertions.
 
 ## Storage bound
 
-Let `n` be current plus historic semantic keys, `r` the fixed configured origin
-count, and `a = 5`. There are at most `n × r × a` clock components, `n × a`
-heads, and `n × a` records, plus constant origin/watermark metadata. Thus:
+Let `n` be current plus historic semantic keys, `a = 5`, and
+`r = |allowedOrigins|`, a fixed domain constant.
 
 ```text
-size = O(nra + na) = O(n) for fixed r and a
+NotificationClock: at most n × r × a components
+DeliveryHead:       at most n × a entries
+DeliveryByIndex:    at most n × a records
+total:              O(n)
 ```
 
-If origins are unbounded, the bound is `O(nr)`, not `O(n)`. Values and proofs are
-not stored, so their size cannot affect journal size.
+Domain metadata, local origin, and the watermark add constant state. The
+protocol rejects unbounded or unknown origins rather than admitting them.
+Values and proofs are not stored, so their size cannot affect journal size.

--- a/docs/specs/incremental-graph-journal-types.md
+++ b/docs/specs/incremental-graph-journal-types.md
@@ -24,25 +24,43 @@ timestamps, validity relations, freshness, dependency metadata, representation,
 or encoding when `ComputedValue` is equal. Independent value and freshness
 transitions can emit two actions.
 
-## Stable origin and synchronized clock
+## Stable writer ownership and synchronized clock
 
-`JournalDomainId` is the durable identity of one synchronization domain.
-`AllowedJournalOrigins` is a finite immutable set. This protocol version fixes
-membership:
+`JournalWriterId` is the durable identity of one independently writable host.
+It MUST be a stable validated replica identity whose lifecycle and uniqueness
+guarantees cover restart, reset, migration, and replica cutover. An unvalidated
+transient hostname is not sufficient. A deployment may use an existing validated
+replica fingerprint only if it has those guarantees; otherwise it provisions a
+separate durable writer ID.
+
+`JournalOriginId` is the durable counter namespace assigned to one writer.
+Ownership is authoritative only through the finite immutable domain mapping:
 
 ```text
 JournalDomain = {
     domainId: JournalDomainId
-    allowedOrigins: AllowedJournalOrigins
+    writerOrigins: Map<JournalWriterId, JournalOriginId>
 }
 
-AllowedJournalOrigins = finite immutable set<JournalOriginId>
+AllowedJournalOrigins = set(JournalDomain.writerOrigins.values())
 ```
 
-`JournalOriginId` is the assigned writer identity of exactly one independently
-writable host. Every writable host has one unique origin from a fixed finite
-synchronization domain. Unknown origins cannot enlarge a clock. A host advances
-only its assigned local origin; it retains but never advances other origins.
+All writer IDs are unique, all origin IDs are unique, no two writers map to one
+origin, and every permitted writable host has exactly one mapping. The derived
+`AllowedJournalOrigins` is useful for clock validation but is not the ownership
+authority. Dynamic writer membership requires a separately specified domain
+migration.
+
+Every writable replica carries both `localWriterId` and `localJournalOrigin`.
+Writable open and transaction finalization require:
+
+```text
+JournalDomain.writerOrigins[localWriterId] == localJournalOrigin
+```
+
+A missing domain, writer, or origin; a mismatched assignment; or duplicate
+ownership prevents authoritative mutation. A host advances only its assigned
+origin and retains but never advances other origins.
 
 ```text
 NotificationClock =
@@ -69,30 +87,18 @@ transaction identifier, or synchronization generation. Equal nonzero sequence
 at the same coordinate has exactly one valid time. Overflow is fatal and never
 wraps.
 
-Origin identity obeys these lifecycle rules:
+Writer identity and assignment survive restart, reset, migration, and same-host
+active/inactive cutover. Remote snapshot import does not replace the receiving
+writer or origin. When A's storage is copied to new writable host B, B retains
+`JournalDomain` and every historical clock component, but before writable open:
 
 ```text
-process restart: preserve local origin
-reset: preserve local origin
-migration: preserve local origin
-active/inactive cutover on the same host: both slots share the local origin
-remote snapshot import: do not replace the receiving host's local origin
-new independently writable host:
-    assign a distinct allowed origin before its first graph mutation
+B.localWriterId = WB
+B.localJournalOrigin = JournalDomain.writerOrigins[WB]
 ```
 
-A copied database does not transfer writer identity. A receiving host retains
-all synchronized clock components but uses only its own assigned origin for
-subsequent mutations. Adding or removing writable origins requires a separately
-specified journal-domain migration; dynamic membership is outside this protocol
-revision.
-
-Writable open and transaction finalization require
-`localJournalOrigin ∈ JournalDomain.allowedOrigins`. Missing domain, missing
-local origin, or an origin outside the fixed set prevents authoritative graph
-mutation. If A's storage is copied to a new writable host B, B must be
-provisioned with a distinct allowed origin before opening the graph for writes;
-B retains A's clock components but never advances them.
+WB must be the distinct mapping provisioned for B. B never advances A's origin.
+Copying storage alone does not transfer writer ownership.
 
 ## Local delivery types and cursors
 
@@ -122,7 +128,7 @@ other than notification time, validity data, proofs, or graph assertions.
 ## Storage bound
 
 Let `n` be current plus historic semantic keys, `a = 5`, and
-`r = |allowedOrigins|`, a fixed domain constant.
+`r = |set(writerOrigins.values())|`, a fixed domain constant.
 
 ```text
 NotificationClock: at most n × r × a components

--- a/docs/specs/incremental-graph-locking-design.md
+++ b/docs/specs/incremental-graph-locking-design.md
@@ -251,9 +251,9 @@ DeliveryHead updates
 lastLocalJournalIndex update
 ```
 
-Writable open and finalization require the local origin to belong to the
-replica's `JournalDomain.allowedOrigins`; missing or invalid identity prevents
-the graph mutation from committing.
+Writable open and finalization require
+`JournalDomain.writerOrigins[localWriterId] == localJournalOrigin`; a missing
+writer/origin or mismatched assignment prevents graph mutation from committing.
 
 For every exact before/after action, delivery replacement allocates a fresh
 index, deletes exactly the old headed record if present, puts the new record,
@@ -297,10 +297,10 @@ holiday
     -> release enterGarden
 ```
 
-That fixed snapshot contains `JournalDomain`, `NotificationClock`,
-`DeliveryByIndex`, `DeliveryHead`, `JournalOriginId`, and
-`lastLocalJournalIndex`. Inactive targets copy all six before applying their
-operation-specific graph and notification changes.
+That fixed snapshot contains `JournalDomain`, `localWriterId`,
+`NotificationClock`, `DeliveryByIndex`, `DeliveryHead`, `JournalOriginId`, and
+`lastLocalJournalIndex`. Inactive targets copy all identity and cursor fields
+before applying their operation-specific graph and notification changes.
 
 Inactive construction proceeds from that snapshot without garden access. The
 validated switch is:

--- a/docs/specs/incremental-graph-locking-design.md
+++ b/docs/specs/incremental-graph-locking-design.md
@@ -251,6 +251,10 @@ DeliveryHead updates
 lastLocalJournalIndex update
 ```
 
+Writable open and finalization require the local origin to belong to the
+replica's `JournalDomain.allowedOrigins`; missing or invalid identity prevents
+the graph mutation from committing.
+
 For every exact before/after action, delivery replacement allocates a fresh
 index, deletes exactly the old headed record if present, puts the new record,
 updates the head, and advances the watermark. A commit publishes all graph
@@ -293,13 +297,21 @@ holiday
     -> release enterGarden
 ```
 
+That fixed snapshot contains `JournalDomain`, `NotificationClock`,
+`DeliveryByIndex`, `DeliveryHead`, `JournalOriginId`, and
+`lastLocalJournalIndex`. Inactive targets copy all six before applying their
+operation-specific graph and notification changes.
+
 Inactive construction proceeds from that snapshot without garden access. The
 validated switch is:
 
 ```text
 holiday
+    -> destination fully constructed, durable, and validated
     -> closeGarden
-    -> validated active-pointer switch
+    -> active-pointer switch
+    -> release closeGarden
+    -> release holiday
 ```
 
 Code must never request `closeGarden` while holding `enterGarden`. Holiday
@@ -316,9 +328,13 @@ the garden coordinates replica lifetime and pointer visibility.
 | journal query | enterGarden → select replica → retain fixed journal snapshot and watermark → release enterGarden | No dome, telescope, or darkroom absent a demonstrated storage requirement. |
 | synchronization source capture | HOLIDAY_GATE_KEY → holiday dome → enterGarden → fixed graph+journal snapshot → release enterGarden | Construction uses the inactive replica; no computor runs. |
 | migration source capture | HOLIDAY_GATE_KEY → holiday dome → enterGarden → fixed graph+journal snapshot → release enterGarden | Migration logic uses the retained snapshot and inactive replica. |
-| cutover | retained holiday (without enterGarden) → closeGarden → validate destination → switch active pointer | Never upgrade enterGarden to closeGarden; failure leaves the active pointer unchanged. |
+| cutover | retained holiday (without enterGarden), after durable construction and validation → closeGarden → switch active pointer → release closeGarden → release holiday | Never upgrade enterGarden to closeGarden; failure leaves the active pointer unchanged. |
 
 The table supplements the telescope recursion and deadlock discipline above.
 No operation may acquire daytime while holding a telescope, and
 `withoutMutex` remains prohibited. Commit finalization remains per-replica;
 different replica darkrooms are independent.
+
+Graph merge, computors, and long-running destination validation never move into
+an ordinary active-replica darkroom. Destination graph and journal updates are
+already durable when `closeGarden` publishes the pointer.

--- a/docs/specs/incremental-graph-locking-design.md
+++ b/docs/specs/incremental-graph-locking-design.md
@@ -1,43 +1,324 @@
-# Incremental graph locking and replica cutover
+# Incremental Graph Locking Design
 
-## Ownership
+## Status
 
-Each `GraphReplica` physically owns authoritative IncrementalGraph storage and
-its notification journal (`NotificationClock`, `DeliveryByIndex`,
-`DeliveryHead`, `JournalOriginId`, and `lastLocalJournalIndex`). The graph is the
-sole authority; journal locks protect notification consistency, not graph
-projection.
+This document describes the locking model of the incremental graph.
 
-## Ordinary transaction boundary
+## Summary
 
-The existing durable transaction-finalization boundary serializes authoritative
-mutations, local clock increments, append-or-replace deletes/puts, head changes,
-and watermark advancement. A committed snapshot contains all of a transition
-and its coverage or none. Sequence overflow aborts rather than wraps.
+The target behavior is:
 
-## Queries
+1. Daytime activity (`getValue()`, `getFreshness()`, `listMaterializedNodes()`,
+   `invalidate()`) is exclusive with nighttime observation (`pull()`), but not
+   exclusive with other daytime activities.
+2. Inspection reads such as `getValue()` and `listMaterializedNodes()` are
+   allowed to run concurrently with `invalidate()`.
+3. Nighttime observation (`pull()`) is exclusive with daytime activity.
+4. Observations of the same concrete node must not coexist (telescope
+   mutex).
+5. Observations of different concrete nodes may coexist.
+6. Migration and replica cutover suspend all graph activity (daytime,
+   nighttime, and other exclusive work).
+7. Transaction commits for the same replica are serialized (the commit
+   mutex is per-replica, not global, so commits to different replicas
+   proceed concurrently).
 
-`possibleMaybeChanges` acquires shared garden access while selecting the active
-replica and opening a fixed committed journal snapshot. It captures the
-watermark within that snapshot, then scans `(since,H]`. The snapshot prevents a
-query from observing neither side of an atomic delivery replacement.
+## Sleeper Primitives
 
-## Synchronization and migration construction
+The design is based on two sleeper primitives:
 
-A lifecycle holiday excludes competing structural work. Under shared garden
-access, construction selects the active replica and opens one fixed committed
-source snapshot containing the graph and all five journal parts. After capture,
-shared access may be released while the inactive destination is built.
+### `withMutex(key, procedure)`
 
-The destination exact-copies the local journal infrastructure before adding
-records above the copied watermark. Synchronization joins only the remote clock;
-it never imports remote delivery history. Migration likewise copies local
-journal infrastructure, then records exact old/new authoritative transitions.
+This is the existing exclusive mutex:
 
-After destination validation, exclusive garden access serializes the atomic
-active-replica switch. Existing readers finish on their selected replica; new
-readers select the destination. Exact copied physical indices, heads, gaps, and
-watermark preserve same-process cursor positions.
+- at most one caller per key runs at a time;
+- other callers queue in FIFO order.
 
-The required locks and snapshots are exactly those protecting authoritative
-transactions, fixed journal reads, source capture, and replica cutover.
+It remains the right primitive for **per-node pull exclusion**.
+
+### `withModeMutex(key, mode, procedure)`
+
+This is a grouped lock:
+
+- callers with the same `(key, mode)` may run concurrently;
+- callers with the same `key` but a different `mode` are mutually exclusive;
+- queued callers are served in FIFO **mode groups** so that a later caller in
+  the current mode cannot skip ahead of an earlier conflicting mode.
+
+This is the right primitive for **global graph phases** where we want
+`nighttime`/`daytime` exclusion without forcing all pulls to serialize with each
+other.
+
+## Lock Keys
+
+The implementation derives keys from functor-based factories.
+
+### 1. Dome activity key
+
+There is exactly one dome key:
+
+- `DOME_ACTIVITY_KEY` — a zero-argument term key instantiated from `makeUniqueFunctor`.
+
+This key is acquired through `withModeMutex`. Three conditions are defined:
+
+- `"daytime"` for `invalidate()` and inspection reads;
+- `"nighttime"` for all pull activity;
+- `"holiday"` for migration and replica cutover.
+
+Because same-mode holders are compatible, many invalidates may overlap, many
+pulls may overlap, and many holiday operations are serialized via the holiday
+gate. Because different modes are incompatible, no pull may overlap any
+invalidate, inspection read, or holiday operation.
+
+Before acquiring the holiday dome condition, a small `HOLIDAY_GATE_KEY` mutex
+serializes concurrent holiday callers with each other.
+
+### 2. Telescope key (per-node pull)
+
+There is one exclusive mutex per concrete node, created through the
+`TELESCOPE_FUNCTOR`:
+
+- `TELESCOPE_FUNCTOR.instantiate([nodeKeyString])`
+
+This key is acquired through `withMutex`.
+
+It is used only by pull operations, and only for the concrete node currently
+being pulled. This is what serializes same-node pulls without blocking pulls on
+different nodes.
+
+### 3. Darkroom key (per-replica finalization)
+
+There is one exclusive mutex per replica, created through the `DARKROOM_FUNCTOR`:
+
+- `DARKROOM_FUNCTOR.instantiate([replicaName])`
+
+It serializes the short finalization step where a finished transaction's batch
+and identifier allocations become part of that replica's settled record.
+Commit-snapshot reads (`listMaterializedNodes()`) also acquire the darkroom
+to observe state between commit finalizations.
+
+## Operation Protocol
+
+### `invalidate(node)`
+
+1. Acquire `daytimeActivity(...)` (internally `withModeMutex(DOME_ACTIVITY_KEY, "daytime", ...)`).
+2. Open a transaction.
+3. Run the invalidation logic inside the transaction body — this runs outside the
+   darkroom lock, so concurrent invalidations can make progress.
+4. Acquire the per-replica darkroom lock only for transaction finalization:
+   finalize and flush any pending writes.
+5. Release the darkroom.
+6. Release the dome daytime lock.
+
+No per-node mutex is needed.
+
+### inspection read
+
+1. Acquire `daytimeActivity(...)` (internally `withModeMutex(DOME_ACTIVITY_KEY, "daytime", ...)`).
+2. Read the requested inspection data (e.g. `getValue()`, `getFreshness()`).
+3. Release the dome daytime lock.
+
+No per-node mutex is needed.
+
+`listMaterializedNodes()` additionally acquires the per-replica darkroom lock to
+observe state between commit finalizations — it reads the committed identifier
+lookup while no darkroom finalization is in progress.
+
+### `pull(node)`
+
+1. Acquire `nighttimeActivity(...)` (internally
+   `withModeMutex(DOME_ACTIVITY_KEY, "nighttime", ...)`).
+2. Acquire `telescopeActivity(nodeKeyString, ...)` (internally
+   `withMutex(TELESCOPE_FUNCTOR.instantiate([nodeKeyString]), ...)`).
+3. Inside the telescope, open a transaction — the darkroom is NOT acquired at
+   this point. The transaction body (dependency pulls and computor execution)
+   runs outside the per-replica darkroom lock.
+4. Run dependency pulls and the computor. Each dependency pull is a recursive
+   call to `pullNode` — it acquires its own telescope mutex, creates its own
+   transaction, commits independently under its own darkroom (step 5), and
+   returns the computed value. Dependencies commit before the parent computor
+   runs.
+5. After the transaction body returns, acquire the per-replica darkroom lock
+   **only for the short finalization phase**:
+   - reconcile validity mutations against the current committed state;
+   - prepare identifier-map and allocation-watermark writes;
+   - flush the durable batch (LevelDB `batch` write);
+   - publish the identifier overlay to the volatile committed lookup **only
+     after** the disk flush succeeds.
+6. In the cleanup path, release all identifier reservations owned by the
+   transaction, whether the transaction committed or failed.
+7. Release the per-node telescope mutex.
+8. Release the dome nighttime lock.
+
+The darkroom lock is per-replica, so commits to different replicas never
+contend. If a parent computor fails, successfully committed dependency pulls
+remain committed — their darkroom finalizations complete before the parent
+computor is invoked and before the parent transaction finalizes.
+
+Nested pulls (dependencies) share the same dome nighttime activity but acquire
+their own telescope mutex per concrete node and create their own Transaction
+(each with its own darkroom finalization). This matches the volatile-consistency
+spec: every call to pullNode is structurally identical, whether top-level or
+nested.
+
+### `migration / replica cutover`
+
+1. Acquire `holidayActivity(...)`.
+2. Run the migration or cutover.
+3. Release the holiday lock.
+
+The two-step acquisition (`HOLIDAY_GATE_KEY` → `DOME_ACTIVITY_KEY("holiday")`)
+is deadlock-free because nighttime and daytime operations only ever acquire
+`DOME_ACTIVITY_KEY`.
+
+The computor runs inside the telescope critical section but outside the
+darkroom. This is safe because the critical section is no longer graph-global:
+other pulls may still proceed on other nodes, while invalidates and inspection
+reads are excluded.
+
+## Why This Matches the Requested Semantics
+
+### Invalidates with invalidates
+
+Both use `daytimeActivity(...)`, so they are compatible.
+
+### Invalidates with reads
+
+Both use `daytimeActivity(...)`, so they are compatible.
+
+### Pulls with reads or invalidates
+
+Nighttime observations (`pull()`) use mode `"nighttime"` while reads and invalidates
+use mode `"daytime"`. Those modes conflict, so these operations are
+mutually exclusive.
+
+### Pulls on the same node
+
+They contend on the same telescope mutex key, so they serialize.
+
+### Pulls on different nodes
+
+They share the compatible global `"nighttime"` mode and use different per-node mutex
+keys, so they may proceed concurrently.
+
+## Deadlock Discipline
+
+The implementation keeps this acquisition discipline:
+
+1. acquire the dome mode lock first;
+2. acquire any per-node telescope mutexes after that;
+3. never acquire `"daytime"` while holding a telescope mutex.
+
+Inspection reads and invalidates only take the global mode lock, so they cannot
+participate in a node-level cycle.
+
+Pulls may recursively pull dependencies while already holding pull locks. The
+incremental graph is a DAG, so any wait edge from node `A` to node `B` implies
+that `A` depends on `B`. A deadlock cycle would therefore imply a dependency
+cycle, which the graph constructor already rejects.
+
+## Why `withoutMutex` Must Not Return
+
+`withoutMutex` encoded a very different strategy: temporarily leave the critical
+section and try to restore it later. That is fundamentally the wrong shape for
+the new invariants because:
+
+- it allows a pull to overlap an invalidate;
+- it allows two same-node pulls to race through the same recomputation;
+- it requires the caller to reason about a lock gap outside the type and API
+  structure of the primitive itself.
+
+The safer replacement is not a more careful "drop and reacquire" helper. The
+safer replacement is a pair of primitives that directly express the intended
+compatibility rules.
+
+## Journal integration without weakening graph locking
+
+The journal rewrite does not remove or weaken the observatory locking model.
+Each replica physically owns its authoritative graph and notification journal,
+but notifications add work only to existing commit and lifecycle boundaries.
+
+### Ordinary graph transaction
+
+During the existing per-replica darkroom/finalization boundary, one durable
+batch contains all applicable writes:
+
+```text
+authoritative graph mutations
+NotificationClock increments
+DeliveryByIndex delete/put operations
+DeliveryHead updates
+lastLocalJournalIndex update
+```
+
+For every exact before/after action, delivery replacement allocates a fresh
+index, deletes exactly the old headed record if present, puts the new record,
+updates the head, and advances the watermark. A commit publishes all graph
+changes and notification coverage or neither. No committed materialization,
+value, or freshness transition lacks a covering notification.
+
+Dependency pulls and computor execution remain in the telescope transaction
+body outside the darkroom. The darkroom continues to serialize only short
+per-replica finalization, including graph writes and their journal coverage.
+
+### Garden access and fixed snapshots
+
+`enterGarden` is shared access that pins selection of an active replica long
+enough to retain a fixed committed snapshot. `closeGarden` is exclusive access
+for the active-pointer switch. A safely retained snapshot remains readable
+after `enterGarden` is released.
+
+`possibleMaybeChanges` follows exactly:
+
+```text
+acquire enterGarden
+select active replica
+open fixed committed journal snapshot
+capture watermark in that snapshot
+release enterGarden when the snapshot is safely retained
+```
+
+It scans the retained snapshot through that watermark. It does not acquire
+daytime, nighttime, a telescope, or a darkroom unless the storage engine is
+shown to require an additional lock to retain a committed snapshot. The fixed
+snapshot observes either side of an atomic append-or-replace batch, never a
+mixture.
+
+Synchronization and migration capture their lifecycle source as:
+
+```text
+holiday
+    -> enterGarden
+    -> fixed graph+journal source snapshot
+    -> release enterGarden
+```
+
+Inactive construction proceeds from that snapshot without garden access. The
+validated switch is:
+
+```text
+holiday
+    -> closeGarden
+    -> validated active-pointer switch
+```
+
+Code must never request `closeGarden` while holding `enterGarden`. Holiday
+continues to exclude all ordinary daytime and nighttime graph activity, while
+the garden coordinates replica lifetime and pointer visibility.
+
+### Complete lock-order table
+
+| Operation | Required acquisition order | Compatibility and boundary |
+|---|---|---|
+| ordinary pull | nighttime dome → telescope for each recursively pulled node → that transaction's per-replica darkroom only at finalization | Same-node pulls serialize; different-node pulls overlap; dependency pulls commit before the parent computor; no daytime overlap. |
+| ordinary invalidate | daytime dome → per-replica darkroom only at finalization | Invalidations overlap one another and inspections; the durable graph+journal batch is atomic. |
+| inspection | daytime dome; `listMaterializedNodes` additionally takes the per-replica darkroom around its committed lookup read | Inspections overlap invalidations; no telescope is taken. |
+| journal query | enterGarden → select replica → retain fixed journal snapshot and watermark → release enterGarden | No dome, telescope, or darkroom absent a demonstrated storage requirement. |
+| synchronization source capture | HOLIDAY_GATE_KEY → holiday dome → enterGarden → fixed graph+journal snapshot → release enterGarden | Construction uses the inactive replica; no computor runs. |
+| migration source capture | HOLIDAY_GATE_KEY → holiday dome → enterGarden → fixed graph+journal snapshot → release enterGarden | Migration logic uses the retained snapshot and inactive replica. |
+| cutover | retained holiday (without enterGarden) → closeGarden → validate destination → switch active pointer | Never upgrade enterGarden to closeGarden; failure leaves the active pointer unchanged. |
+
+The table supplements the telescope recursion and deadlock discipline above.
+No operation may acquire daytime while holding a telescope, and
+`withoutMutex` remains prohibited. Commit finalization remains per-replica;
+different replica darkrooms are independent.

--- a/docs/specs/incremental-graph-synchronization.md
+++ b/docs/specs/incremental-graph-synchronization.md
@@ -141,7 +141,7 @@ and cursor infrastructure, then returns without processing additional hosts.
 
 **REQ-SYNC-03 (Reset mode separation):** Reset-to-hostname mode must not be
 mixed with normal per-host merge semantics. It preserves the receiving
-`JournalDomain`, `JournalOriginId`, `NotificationClock`, `DeliveryByIndex`,
+`JournalDomain`, `localWriterId`, `JournalOriginId`, `NotificationClock`, `DeliveryByIndex`,
 `DeliveryHead`, `lastLocalJournalIndex`, and physical gaps. Remote writer
 identity and physical cursor state are never installed. A source with a
 different journal domain is rejected before replacement; its domain is never
@@ -684,19 +684,24 @@ finalGraph =
     the fully specified authoritative graph merge in §§1–15
 
 joinedClock =
-    joinClock(localClock, remoteClock)
+    mergeNotificationClocks(localClock, remoteClock)
 
 SyncGraphActions =
     classifyExactActions(localGraph, finalGraph)
 
 finalClock =
-    emitActions(
+    emitSynchronizationCreatedTransitions(
         joinedClock,
-        localJournalOrigin,
+        receivingWriterOrigin,
         SyncGraphActions,
         cutoverTime
     )
 ```
+
+`mergeNotificationClocks(A,B) = joinClock(A,B)` is the commutative,
+associative, and idempotent binary merge of already-emitted replicated clock
+states. `emitSynchronizationCreatedTransitions` is an ordinary receiving-host
+local update after that merge and is not part of the binary operator.
 
 The graph merge is fully specified independently of the journal.
 `NotificationClock` must not influence `finalGraph`, and `finalGraph` must not
@@ -704,7 +709,8 @@ be reconstructed from the clock. Domain and clock validation precede joining,
 but clock contents never select candidates, conflicts, deletions, freshness,
 identifiers, or validity transport.
 
-For each `(K,A)` in `SyncGraphActions`, `emitActions` increments
+For each `(K,A)` in `SyncGraphActions`,
+`emitSynchronizationCreatedTransitions` increments
 `finalClock[K][localJournalOrigin][A].sequence` exactly once and sets its time to
 `cutoverTime`. Sequence overflow is fatal. Duplicate delivery coordinates do
 not suppress this local-origin advancement. Every committed synchronization-
@@ -738,10 +744,28 @@ unequal `ComputedValue` while materialized, `delete` only materialized-to-absent
 `invalidate` only fresh-to-stale, and `validate` only stale-to-fresh. Independent
 value and freshness changes can emit two actions.
 
+Delivery time is deterministic when notification sources overlap:
+
+```text
+if (K,A) ∈ SyncGraphActions:
+    DeliveryRecord.time = cutoverTime
+else:
+    DeliveryRecord.time =
+        time selected from advanced remote components by the
+        deterministic (sequence, JournalOriginId) rule
+```
+
+A synchronization-created action is an actual local cutover transition, so its
+time takes precedence. A coordinate in both sets still produces only one
+bounded delivery record. For example, if remote `edit K` advancement also makes
+the authoritative merge change the receiver's K value, `(K,edit)` belongs to
+both sets and its replacement delivery uses `cutoverTime`.
+
 The inactive destination exact-copies from one fixed local source snapshot:
 
 ```text
 JournalDomain
+localWriterId
 NotificationClock
 DeliveryByIndex
 DeliveryHead
@@ -757,15 +781,17 @@ replacement is needed, although every actual `SyncGraphAction` has already
 advanced its counter.
 
 Pre-cutover validation requires the destination `JournalDomain` to equal the
-local domain; the destination origin and every clock origin to belong to
-`allowedOrigins`; `DeliveryHead` and `DeliveryByIndex` to satisfy the one-head
-invariant; and the watermark not to be below any retained delivery index.
+local domain; its local writer/origin pair to equal the domain mapping; every
+clock origin to belong to `set(writerOrigins.values())`; `DeliveryHead` and
+`DeliveryByIndex` to satisfy the one-head invariant; and the watermark not to
+be below any retained delivery index.
 
 ### 17.1 Conflict-resolution and three-host trace
 
 For local `A,B → D → E → F`, suppose the host's canonical `A` candidate changes
-value and changes freshness from fresh to stale. The authoritative merge first emits no notification: it
-settles `A`, deletes multi-input `D`, propagates deletion to `E` and `F`, rebuilds
+value and changes freshness from fresh to stale. The authoritative merge first
+emits no notification: it settles `A`, deletes multi-input `D`, propagates
+deletion to `E` and `F`, rebuilds
 surviving validity, and validates the graph. Classification afterward yields
 `edit(A)`, `invalidate(A)`, and `delete(D)`, `delete(E)`, and `delete(F)`;
 each advances the receiving origin and receives one local delivery.
@@ -797,20 +823,61 @@ inactive destination MUST be activated so the joined clock and replacement edit
 delivery become visible. Replica cutover is skipped only when both graph and the
 complete journal result are unchanged.
 
+### 17.3 Binary merge boundary counterexample
+
+```text
+A:
+    graph K = value A
+    local origin OA
+
+B:
+    graph K = value B
+    local origin OB
+    clock[K][OB][edit] = 1
+
+authoritative merge selects B
+```
+
+```text
+A receives B:
+    joinedClock: OB.edit = 1
+    SyncGraphActions: edit K
+    finalClock: OB.edit = 1, OA.edit = 1
+
+B receives A:
+    joinedClock: OB.edit = 1
+    SyncGraphActions: none
+    finalClock: OB.edit = 1
+```
+
+The complete receiving-host result is not commutative because it includes a new
+local update after the commutative merge. The complete receiving-host
+post-emission clock need not equal the reversed-role post-emission clock. Once
+the emitted state is replicated, the binary operator converges it:
+
+```text
+joinClock(
+    { OA.edit = 1, OB.edit = 1 },
+    { OB.edit = 1 }
+)
+=
+{ OA.edit = 1, OB.edit = 1 }
+```
+
 ## 18. Lifecycle, writable-state, and failure requirements
 
 Every fixed graph+journal source snapshot and inactive initialization carries
-all six journal parts listed in §17. `JournalDomain` survives synchronization,
+all journal parts listed in §17. `JournalDomain` survives synchronization,
 migration, reset, restart, and replica cutover. Destination construction remains
 isolated in inactive replica T; failure leaves the active pointer unchanged.
 
 Writable open and transaction finalization both require
-`localJournalOrigin ∈ JournalDomain.allowedOrigins`. A replica with a missing
-domain, missing local origin, or origin outside the allowed set MUST NOT commit
-an authoritative graph mutation. A fork copied from host A must be provisioned
-with distinct allowed origin OB before host B opens for writes; it retains OA's
-clock components but never advances them. Provisioning is deployment-specific,
-but rejection is normative.
+`JournalDomain.writerOrigins[localWriterId] == localJournalOrigin`. A replica
+with a missing domain, writer, or origin, a mismatched assignment, or duplicate
+ownership MUST NOT commit an authoritative graph mutation. A fork copied from
+host A must be provisioned with B's distinct mapped writer/origin pair before B
+opens for writes; it retains OA's clock components but never advances them.
+Provisioning is deployment-specific, but rejection is normative.
 
 With holiday retained, the destination is fully constructed, made durable, and
 validated before `closeGarden` is acquired. Then the active pointer switches,

--- a/docs/specs/incremental-graph-synchronization.md
+++ b/docs/specs/incremental-graph-synchronization.md
@@ -135,13 +135,23 @@ steps in order:
    hosts and aggregate failures into a single error report.
 
 **TERM-SYNC-13 (Reset-to-hostname mode):** A synchronization mode that is NOT
-a graph merge. It synchronizes to a chosen hostname snapshot by replacing the
-local state with the snapshot's state and returns without processing additional
-hosts.
+a graph merge. It replaces authoritative graph state wholesale from a chosen
+hostname snapshot while preserving the receiving host's journal-domain identity
+and cursor infrastructure, then returns without processing additional hosts.
 
 **REQ-SYNC-03 (Reset mode separation):** Reset-to-hostname mode must not be
-mixed with normal per-host merge semantics. The reset procedure replaces
-replica state wholesale; it does not merge.
+mixed with normal per-host merge semantics. It preserves the receiving
+`JournalDomain`, `JournalOriginId`, `NotificationClock`, `DeliveryByIndex`,
+`DeliveryHead`, `lastLocalJournalIndex`, and physical gaps. Remote writer
+identity and physical cursor state are never installed. A source with a
+different journal domain is rejected before replacement; its domain is never
+silently installed.
+
+After constructing `replacementGraph`, classify
+`ResetActions = classifyExactActions(oldLocalGraph, replacementGraph)`. Each
+action advances the receiving local-origin component and append-or-replaces a
+receiving local delivery. The replacement graph, clock increments, deliveries,
+heads, and watermark commit atomically in the inactive target before cutover.
 
 ---
 
@@ -578,16 +588,23 @@ previously contained that materialization. A host-only key that is deleted
 before ever being written to the target does not by itself change the target
 state.
 
-**REQ-SYNC-21 (Switch condition):**
+**REQ-SYNC-21 (Complete-result switch condition):** The inactive destination
+MUST become active when any part of the complete replica result changes:
 
-- If graph data, identifier mapping, freshness, or validity metadata changed,
-  the inactive replica becomes active.
-- If no semantic data, identifier data, freshness, or validity relation
-  changed, the active pointer remains unchanged.
-- A "metadata-only" change, such as importing a valid provenance-backed
-  validity proof, is sufficient to switch replicas, because it affects future
-  recomputation behavior. Metadata-only changes must obey the provenance rules
-  of §11.
+```text
+mustSwitch =
+    authoritativeGraphChanged
+    || finalClock != localClock
+    || DeliveryActions is nonempty
+    || destination journal metadata differs
+```
+
+Cutover may be skipped only when the final authoritative graph equals the local
+authoritative graph, the final `NotificationClock` equals the local clock, no
+local delivery replacement is required, and all journal-domain and cursor
+metadata are unchanged. A journal-only synchronization result still activates
+the destination replica. The active replica MUST NOT be partially mutated as an
+alternative; inactive construction and atomic pointer cutover remain mandatory.
 
 **REQ-SYNC-22 (Partial failure safety):** The currently active local source
 replica must not be partially mutated by a failed host merge. Failure before
@@ -656,105 +673,151 @@ computor function, directly or indirectly.
 
 ---
 
-## 16. Independent Notification-Clock Result
+## 16. Independent Authoritative and Notification Results
 
-The graph and replicated notification results have separate ownership:
+The graph result is settled without journal input. Notification processing then
+joins replicated progress and emits the exact graph transitions created on the
+receiving host:
 
 ```text
 finalGraph =
     the fully specified authoritative graph merge in §§1–15
 
-finalClock =
+joinedClock =
     joinClock(localClock, remoteClock)
+
+SyncGraphActions =
+    classifyExactActions(localGraph, finalGraph)
+
+finalClock =
+    emitActions(
+        joinedClock,
+        localJournalOrigin,
+        SyncGraphActions,
+        cutoverTime
+    )
 ```
 
 The graph merge is fully specified independently of the journal.
 `NotificationClock` must not influence `finalGraph`, and `finalGraph` must not
-be reconstructed from `NotificationClock`. The notification clock never
-chooses graph state. Journal-domain and clock validation occurs before either
-result is installed, but successful clock contents have no role in candidate
-selection, conflict policy, deletion, freshness, identifier reconciliation, or
-validity transport.
+be reconstructed from the clock. Domain and clock validation precede joining,
+but clock contents never select candidates, conflicts, deletions, freshness,
+identifiers, or validity transport.
+
+For each `(K,A)` in `SyncGraphActions`, `emitActions` increments
+`finalClock[K][localJournalOrigin][A].sequence` exactly once and sets its time to
+`cutoverTime`. Sequence overflow is fatal. Duplicate delivery coordinates do
+not suppress this local-origin advancement. Every committed synchronization-
+created graph transition advances the receiving host's synchronized action
+counter. No graph transition is represented only by an unsynchronized local
+delivery.
+
+```text
+component = finalClock[K][localJournalOrigin][A]
+component.sequence += 1
+component.time = cutoverTime
+```
 
 ## 17. Notification journal integration
 
-After the authoritative algorithm has completely settled and validated
-`finalGraph`, compute notification delivery coordinates as follows:
+Compute remote advancement against the joined clock, before local emission:
 
 ```text
 RemoteAdvancedActions = {
     (K,A) |
     some allowed origin O has
-      finalClock[K][O][A].sequence > localClock[K][O][A].sequence
+      joinedClock[K][O][A].sequence > localClock[K][O][A].sequence
 }
-
-SyncGraphActions =
-    classifyExactActions(local authoritative graph, final authoritative graph)
 
 DeliveryActions =
     RemoteAdvancedActions ∪ SyncGraphActions
 ```
 
-`classifyExactActions` is the closed before/after classifier: `add` only for
-absent to materialized, `edit` only for unequal `ComputedValue` while both
-sides are materialized, `delete` only for materialized to absent, `invalidate`
-only for fresh to stale while materialized, and `validate` only for stale to
-fresh while materialized. Value and freshness changes may yield two independent
-actions. Duplicate `(K,A)` coordinates coalesce.
+The classifier remains exact: `add` only absent-to-materialized, `edit` only an
+unequal `ComputedValue` while materialized, `delete` only materialized-to-absent,
+`invalidate` only fresh-to-stale, and `validate` only stale-to-fresh. Independent
+value and freshness changes can emit two actions.
 
-Remote advances choose their delivery time by the notification-clock
-specification. A coordinate introduced only by `SyncGraphActions` uses local
-cutover time. Such graph-difference delivery does not advance a local clock
-component: synchronization grouping must not manufacture replicated progress.
-Remote physical indices, heads, gaps, and watermarks are not merged.
-
-The inactive destination starts as an exact copy of the fixed local source
-snapshot, including local delivery cursor infrastructure. It installs
-`finalClock`, then append-or-replaces one delivery for each `DeliveryActions`
-coordinate at fresh indices above the copied watermark. The destination graph,
-clock, deliveries, and watermark are validated and committed before the active
-pointer can switch. The journal integration supplements, and never replaces,
-any graph merge requirement in §§1–15.
-
-### 17.1 Conflict-resolution trace
-
-Consider local inputs `A` and `B`, a multi-input materialization `D(A,B)`, and
-dependants `E(D)` and `F(E)`. The host's canonical candidate for `A` wins and
-has a different value. Its selected freshness is stale, while local `A` was
-fresh. This establishes the authoritative value and freshness changes first.
-Relowering makes `D` a direct invalidation candidate; because `D` has two
-distinct semantic inputs, §7 deletes it. The structural deletion closure then
-deletes materialized dependants `E` and `F`. Validity edges and identifiers are
-rebuilt for survivors, and the complete result passes §12 validation.
-
-Only now compare local authoritative state with settled `finalGraph`:
+The inactive destination exact-copies from one fixed local source snapshot:
 
 ```text
-SyncGraphActions = {
-    (A, edit),
-    (A, invalidate),
-    (D, delete),
-    (E, delete),
-    (F, delete)
-}
+JournalDomain
+NotificationClock
+DeliveryByIndex
+DeliveryHead
+JournalOriginId
+lastLocalJournalIndex
 ```
 
-Any remote-advanced coordinates are unioned afterward. Thus classification
-reports the value change, freshness change, multi-input deletion, and propagated
-dependant deletions without participating in or altering their resolution.
+It then installs the authoritative graph, joined remote progress, receiving-
+origin increments, append-or-replaced deliveries, heads, and watermark as one
+durable destination result before cutover. Remote physical deliveries are never
+copied. For every duplicate coordinate in `DeliveryActions`, only one local
+replacement is needed, although every actual `SyncGraphAction` has already
+advanced its counter.
 
-## 18. Lifecycle and failure requirements for journal-bearing replicas
+Pre-cutover validation requires the destination `JournalDomain` to equal the
+local domain; the destination origin and every clock origin to belong to
+`allowedOrigins`; `DeliveryHead` and `DeliveryByIndex` to satisfy the one-head
+invariant; and the watermark not to be below any retained delivery index.
 
-The fixed source snapshot contains both authoritative graph state and the local
-journal state. Destination construction remains isolated in inactive replica T.
-Pre-cutover validation covers graph invariants, the fixed journal domain, clock
-validity, one-head delivery integrity, and notification coverage. Failure leaves
-the active pointer and active replica unchanged. Reset-to-hostname remains a
-separate wholesale authoritative operation; it preserves the receiving host's
-origin and emits exact local notifications for its before/after graph changes.
+### 17.1 Conflict-resolution and three-host trace
 
-Sequential multi-host processing still uses each prior successful authoritative
-result as the next local source. Graph-level pairwise commutativity remains
-REQ-SYNC-23. Independently, only the replicated `NotificationClock` join has the
-commutative, associative, and idempotent laws; local delivery indices and
-watermarks need not agree across hosts or synchronization schedules.
+For local `A,B → D → E → F`, suppose the host's canonical `A` candidate changes
+value and changes freshness from fresh to stale. The authoritative merge first emits no notification: it
+settles `A`, deletes multi-input `D`, propagates deletion to `E` and `F`, rebuilds
+surviving validity, and validates the graph. Classification afterward yields
+`edit(A)`, `invalidate(A)`, and `delete(D)`, `delete(E)`, and `delete(F)`;
+each advances the receiving origin and receives one local delivery.
+
+More specifically, hosts A and B independently change different inputs of
+`X,Y → D`. A synchronizes with B and the authoritative merge deletes D:
+
+```text
+A clock[D][OA].delete advances
+A local delivery receives delete D
+```
+
+Later C synchronizes with A while D is already absent on C. Although
+`localGraphC[D] == finalGraphC[D] == absent`, A's replicated OA delete component
+is greater than C's component. `(D,delete)` is therefore in
+`RemoteAdvancedActions`, and C receives a local delete delivery. Replicating the
+synchronization-created counter is what prevents the false negative.
+
+### 17.2 Journal-only activation trace
+
+```text
+local:  K value = A; edit[K][remoteOrigin] = 4
+remote: K value = A; edit[K][remoteOrigin] = 6
+```
+
+The remote host changed A to B and back to A. Thus `finalGraph == localGraph`,
+`finalClock != localClock`, and `RemoteAdvancedActions = {(K,edit)}`. The
+inactive destination MUST be activated so the joined clock and replacement edit
+delivery become visible. Replica cutover is skipped only when both graph and the
+complete journal result are unchanged.
+
+## 18. Lifecycle, writable-state, and failure requirements
+
+Every fixed graph+journal source snapshot and inactive initialization carries
+all six journal parts listed in §17. `JournalDomain` survives synchronization,
+migration, reset, restart, and replica cutover. Destination construction remains
+isolated in inactive replica T; failure leaves the active pointer unchanged.
+
+Writable open and transaction finalization both require
+`localJournalOrigin ∈ JournalDomain.allowedOrigins`. A replica with a missing
+domain, missing local origin, or origin outside the allowed set MUST NOT commit
+an authoritative graph mutation. A fork copied from host A must be provisioned
+with distinct allowed origin OB before host B opens for writes; it retains OA's
+clock components but never advances them. Provisioning is deployment-specific,
+but rejection is normative.
+
+With holiday retained, the destination is fully constructed, made durable, and
+validated before `closeGarden` is acquired. Then the active pointer switches,
+`closeGarden` releases, and finally holiday releases. Graph merge and long
+validation do not run in an ordinary active-replica darkroom.
+
+`joinClock` remains commutative, associative, and idempotent. Emitting ordinary
+local actions before or after a join does not change those algebraic laws of the
+join operation. Sequential multi-host graph processing and graph-level pairwise
+commutativity remain governed by §§14–15.

--- a/docs/specs/incremental-graph-synchronization.md
+++ b/docs/specs/incremental-graph-synchronization.md
@@ -134,10 +134,11 @@ steps in order:
 9. Failures are recorded per host. Synchronization may continue with remaining
    hosts and aggregate failures into a single error report.
 
-**TERM-SYNC-13 (Reset-to-hostname mode):** A synchronization mode that is NOT
-a graph merge. It replaces authoritative graph state wholesale from a chosen
-hostname snapshot while preserving the receiving host's journal-domain identity
-and cursor infrastructure, then returns without processing additional hosts.
+**TERM-SYNC-13 (Existing-live reset-to-hostname mode):** A synchronization mode
+for a receiving host with established live state. It is NOT a graph merge. It
+replaces authoritative graph state wholesale from a chosen hostname snapshot
+while preserving the receiving host's complete journal state, then returns
+without processing additional hosts.
 
 **REQ-SYNC-03 (Reset mode separation):** Reset-to-hostname mode must not be
 mixed with normal per-host merge semantics. It preserves the receiving
@@ -152,6 +153,20 @@ After constructing `replacementGraph`, classify
 action advances the receiving local-origin component and append-or-replaces a
 receiving local delivery. The replacement graph, clock increments, deliveries,
 heads, and watermark commit atomically in the inactive target before cutover.
+
+**REQ-SYNC-03a (Absent-state self-restoration):** When no local live database
+exists, restoring this same host's current synchronized branch is a distinct
+bootstrap transition. It restores and validates the authoritative graph,
+`JournalDomain`, `localWriterId`, `JournalOriginId`, `NotificationClock`,
+`DeliveryByIndex`, `DeliveryHead`, `lastLocalJournalIndex`, and physical gaps.
+The branch must be the current branch recognized for that host/writer, and the
+restored mapping must satisfy
+`JournalDomain.writerOrigins[localWriterId] == JournalOriginId`.
+
+Self-restoration resumes previously emitted state. It MUST NOT classify an
+empty graph against the restored graph and MUST NOT emit `add` actions for
+restored materializations. An arbitrary older checkpoint is unsupported without
+anti-rollback state or a new origin assignment.
 
 ---
 
@@ -874,10 +889,16 @@ isolated in inactive replica T; failure leaves the active pointer unchanged.
 Writable open and transaction finalization both require
 `JournalDomain.writerOrigins[localWriterId] == localJournalOrigin`. A replica
 with a missing domain, writer, or origin, a mismatched assignment, or duplicate
-ownership MUST NOT commit an authoritative graph mutation. A fork copied from
-host A must be provisioned with B's distinct mapped writer/origin pair before B
-opens for writes; it retains OA's clock components but never advances them.
-Provisioning is deployment-specific, but rejection is normative.
+ownership MUST NOT commit an authoritative graph mutation. Cross-host copying
+is not a supported way to create a new host. A new host instead receives a
+fresh graph allocation fingerprint and its preassigned mapped writer/origin pair
+through the supported fresh-host lifecycle, then joins other hosts' clock
+components without advancing their origins.
+
+A writer MUST NOT resume authoritative mutation with a local action sequence
+below progress it previously published under the same `JournalOriginId`.
+Raw cross-host database copying remains unsupported, and a copied
+writer/origin pair does not prove ownership of the physical installation.
 
 With holiday retained, the destination is fully constructed, made durable, and
 validated before `closeGarden` is acquired. Then the active pointer switches,

--- a/docs/specs/incremental-graph-synchronization.md
+++ b/docs/specs/incremental-graph-synchronization.md
@@ -1,76 +1,760 @@
-# Incremental graph synchronization
+# Specification for Incremental Graph Synchronization
 
-## Independent authoritative and notification results
+This document specifies synchronization of persisted IncrementalGraph replica
+states. It constrains how materialized graph state may be merged across host
+branches so that all future public IncrementalGraph operations remain valid
+under "incremental-graph.md". It does not change the public `pull()` or
+`invalidate()` semantics; it specifies only how stored graph state may be
+checkpointed, staged, merged, invalidated, and committed during
+synchronization.
 
-```text
-finalGraph  = synchronizeAuthoritativeGraphs(localGraph, remoteGraph)
-finalClock  = joinClock(localClock, remoteClock)
+---
+
+## 1. Scope and Non-Goals
+
+**Scope:**
+
+- This specification covers synchronization of persisted IncrementalGraph
+  state across host branches in a shared git repository.
+- Synchronization is not a public computation operation. It is an
+  administrative procedure that operates on stored replica state directly.
+- Synchronization MUST NOT invoke computors. It may copy, delete, invalidate,
+  or preserve stored graph state, but it must not compute new node values.
+- Synchronization must preserve the public operational semantics of
+  IncrementalGraph for all future calls to `pull()`, `invalidate()`, and the
+  inspection API.
+- Synchronization is allowed to be conservative: it may mark nodes
+  "potentially-outdated" even when a stronger proof could have preserved them.
+- Synchronization must not invent cache-validity facts that are not justified
+  by source provenance and final graph structure.
+
+**Non-goals:**
+
+- This document does not specify git internals beyond the observable
+  staging/checkpoint/branch role needed by synchronization.
+- Pairwise commutativity is required for any two valid source replicas using
+  the same schema: merging A with B and merging B with A must produce
+  observably equivalent final IncrementalGraph states after ignoring only
+  local physical details such as inactive replica slot names and temporary
+  paths.
+- This document does not establish associativity across three or more replicas
+  or arbitrary sequential host-order independence unless those properties are
+  separately proven.
+- This document does not specify exact LevelDB key formats except where
+  semantic lookup invariants require it.
+
+---
+
+## 2. Replica State Model
+
+**TERM-SYNC-01 (ReplicaState):** Persisted graph state for one schema version.
+A replica contains node values, freshness markers, timestamps, validity
+relations, an identifier lookup, allocation metadata, the graph scheme, and the
+database version string.
+
+**TERM-SYNC-02 (Local source replica L):** The active local replica before
+merging a host. Read during per-host merge, never modified by it.
+
+**TERM-SYNC-03 (Host source replica H):** Staged graph state scanned from one
+remote hostname branch into hostname staging storage.
+
+**TERM-SYNC-04 (Merge target replica T):** Inactive local replica used as the
+write target during per-host merge. Initially a copy of L; after a successful
+merge, contains the merged state and may become the active replica.
+
+**TERM-SYNC-05 (Final replica F):** The state in T after a successful per-host
+merge, before or after active-pointer switch.
+
+**TERM-SYNC-06 (Semantic node key):** The stable semantic identity of a node
+instance, derived from node name and bindings. Corresponds to `NodeKey` from
+the main graph spec (DEF-KEY-01).
+
+**TERM-SYNC-07 (Storage identifier):** Implementation-specific identifier used
+as the actual database key for node values, freshness, timestamps, and validity
+entries. Corresponds to `NodeIdentifier` from the volatile-consistency spec.
+
+**TERM-SYNC-08 (Identifier lookup):** Bijective mapping between storage
+identifiers and semantic node keys for materialized nodes. Persisted
+as `identifiers_keys_map` in the replica's global sublevel.
+
+**TERM-SYNC-09 (Materialized node):** A node whose identifier exists in
+`identifiers_keys_map`, `values`, `freshness`, and `timestamps`.
+
+**TERM-SYNC-11 (Freshness):** Freshness state of a node: `"up-to-date"` or
+`"potentially-outdated"`.
+
+**TERM-SYNC-12 (Validity relation):** Inverse validity flags. The entry
+`valid[D].has(N)` means N's stored value is known valid with respect to D's
+current stored value, subject to the main IncrementalGraph validity rules.
+
+**DEF-SYNC-01 (Value origin):** Provenance of a final stored value. A
+conceptual term, not a separate runtime representation:
+
+- The selected byte source identifies which replica supplied the final stored
+  bytes. Every surviving value (outcome ≠ delete) has provenance from its
+  selected structural side, including hard-invalidated and directly relowered
+  nodes. Deleted nodes have no final value and therefore no value origin.
+- The runtime representation of byte-source selection is `selectedSideByKey`.
+  No separate value-origin map is maintained.
+
+**DEF-SYNC-02 (Source-version identity):** A source-side materialization
+represents the final selected semantic value record only when it is the actual
+selected source materialization: its side matches `selectedSideByKey` and its
+identifier matches the final selected identifier.
+
+This is the canonical `sourceRepresentsFinalVersion()` operation. It
+determines whether source-side dependency histories and validity proofs apply
+to the final selected semantic record. Equal timestamps and equal identifiers do
+not prove equal values because a recomputation preserves the identifier and
+`modifiedAt` has finite resolution. ComputedValue equality, hashing, or
+serialization must not be used as identity evidence.
+
+**REQ-SYNC-01 (Value origin from copy, not equality):** Deep equality of
+stored values MUST NOT create a value origin.
+
+---
+
+## 3. Synchronization Pipeline
+
+**REQ-SYNC-02 (Normal synchronization):** Normal synchronization follows these
+steps in order:
+
+1. The caller holds the required synchronization/lock.
+2. The live database is checkpointed into the tracked filesystem snapshot.
+3. The local checkpoint branch is synchronized with the remote repository.
+4. Remote hostname branches are fetched from the remote repository.
+5. Each remote hostname branch is staged into hostname storage by scanning the
+   branch's rendered snapshot.
+6. Each staged host is merged into the local database by a per-host graph
+   merge.
+7. If a per-host merge switches the active replica, the root database is
+   reopened before continuing to the next host.
+8. Host staging storage is cleared after the per-host attempt (whether it
+   succeeded or failed).
+9. Failures are recorded per host. Synchronization may continue with remaining
+   hosts and aggregate failures into a single error report.
+
+**TERM-SYNC-13 (Reset-to-hostname mode):** A synchronization mode that is NOT
+a graph merge. It synchronizes to a chosen hostname snapshot by replacing the
+local state with the snapshot's state and returns without processing additional
+hosts.
+
+**REQ-SYNC-03 (Reset mode separation):** Reset-to-hostname mode must not be
+mixed with normal per-host merge semantics. The reset procedure replaces
+replica state wholesale; it does not merge.
+
+---
+
+## 4. Per-Host Merge Inputs and Preconditions
+
+**TERM-SYNC-14 (Per-host merge inputs):** A per-host merge takes:
+
+- **L**: active local source replica (read-only during merge).
+- **H**: staged host source replica (read-only during merge).
+- **T**: inactive local target replica (write target; initially a copy of L).
+
+**Preconditions:**
+
+1. The synchronization lock is held for the duration of the merge.
+2. H was staged from exactly one hostname branch.
+3. H and the local database have the same schema version. If not, the merge
+   for that host MUST fail with a host-version mismatch error.
+4. L is not modified by per-host merge.
+5. T may be overwritten or refreshed during the merge.
+6. H is staging storage and is cleared by the caller after the merge attempt.
+7. The host and target identifier lookups must be parseable.
+8. A storage identifier MUST NOT map to different semantic keys across source
+   lookups. That is corrupt metadata and MUST be rejected with an
+   `IdentifierLookupConflictError`.
+9. The same semantic node may have different storage identifiers across
+   replicas; that is not corrupt and must be reconciled by the merge plan.
+
+**REQ-SYNC-04 (Materialized node coverage):** A materialized node must be
+covered by its source identifier lookup. If a materialized value exists in
+storage for a storage identifier not present in the identifier lookup, the
+merge MUST reject the source as corrupt.
+
+**REQ-SYNC-05 (Final coverage):** A final materialized node must be covered by
+the final identifier lookup. Every storage identifier in the final values,
+freshness, timestamps, and validity sublevels must appear in the final
+identifier lookup.
+
+**REQ-SYNC-06 (Malformed metadata rejection):** Synchronization must reject
+malformed metadata (unparseable lookup, duplicate entries, index conflicts)
+rather than silently dropping materialized values.
+
+---
+
+## 5. Semantic Merge Domain
+
+**DEF-SYNC-03 (Semantic merge domain):** Per-host merge operates over semantic
+node keys, not raw storage identifiers. Let:
+
+- `Keys = keys(L.lookup) ∪ keys(H.lookup)`
+
+Each key in Keys is considered exactly once. For each key, the merge chooses a
+structural source side (target/local or host), selects a final storage
+identifier, derives final dependency edges from the graph scheme, and applies
+the result to T.
+
+**DEF-SYNC-04 (Selected source side):** `selectedSideByKey` records the
+per-node candidate source side before final outcome classification:
+
+- `selectedSideByKey(key) ∈ { keep, take }`
+- `keep` means the candidate source is the local/target replica.
+- `take` means the candidate source is the host replica.
+
+**DEF-SYNC-05 (Final outcome):** `outcomeByKey` records the canonical final
+outcome for each semantic key after classification:
+
+- `outcomeByKey(key) ∈ { keep, take, invalidate, delete }`
+- `keep` means preserve or copy from the local target source.
+- `take` means copy from the host source.
+- `invalidate` means the node is marked potentially-outdated regardless of
+  which side provides its structural data. One-input direct invalidation roots
+  are invalidated; their value is retained.
+- `delete` means the semantic key's materialization is omitted from the final
+  replica. A deleted materialization has no final identifier, cached value,
+  freshness, timestamps, validity entries, or value origin. Multi-input direct
+  invalidation roots are deleted. `delete` is an internal merge result, not a
+  request to delete the semantic node family from the graph schema.
+
+**TERM-SYNC-15 (finalIdentifierForKey):** A partial map from semantic node keys
+to their final storage identifiers:
+
+```
+finalIdentifierForKey:
+    { key ∈ Keys | outcomeByKey(key) ≠ delete } → NodeIdentifier
 ```
 
-These calculations are independent. The authoritative graph merge chooses graph
-state and conflict winners. The clock never influences `finalGraph`, and graph
-state is never projected from `finalClock`.
+- `keep` maps to the local source identifier.
+- `take` maps to the host source identifier.
+- `invalidate` maps to the identifier selected by `selectedSideByKey`.
+- `delete` has no final identifier and is absent from the map.
 
-For clock progress, compute `RemoteAdvancedActions` as every `(K,A)` for which at
-least one origin's final sequence exceeds its local sequence. If multiple
-origins advanced, make one local delivery and use the time from the greatest
-advanced `(sequence, JournalOriginId)` component.
+**TERM-SYNC-16 (mergedInputsMap):** The map from each surviving final storage
+identifier to the list of its final dependency storage identifiers, derived from
+the graph scheme and lowered through `finalIdentifierForKey`. Defined only for
+materializations whose outcome is not `delete`. Every dependency of a surviving
+materialization also survives and has a final identifier; the delete-propagation
+closure guarantees this.
 
-Independently classify `localGraph` versus `finalGraph` with the five exact rules
-to obtain `SyncGraphActions`. This covers a synchronization-created local value
-or freshness transition even when no incoming clock component advanced for that
-action. The delivery set is:
+---
+
+## 6. Timestamp Conflict Policy
+
+**REQ-SYNC-07 (Canonical materialization selection):** For each semantic key:
+
+- If present only in L: select that materialization.
+- If present only in H: select that materialization.
+- If present in both L and H, compare materialization candidates by the fixed
+  tuple `(modifiedAt, NodeIdentifier, sourceFingerprint)`:
+  1. the newer `modifiedAt` wins;
+  2. on equal `modifiedAt`, the lexicographically greater canonical
+     `NodeIdentifier` string wins using deterministic JavaScript code-unit
+     ordering;
+  3. on equal `modifiedAt` and `NodeIdentifier`, the lexicographically greater
+     validated source replica fingerprint wins using deterministic JavaScript
+     code-unit ordering.
+- The comparison MUST NOT prefer a candidate because it is named local, host,
+  keep, take, current, or target.
+- Missing timestamps for materialized values are invalid or corrupt state under
+  the main graph spec. Synchronization MUST NOT use missing timestamps to
+  justify an `up-to-date` final node. It may reject the host or merge
+  conservatively invalidate affected nodes, but it must not silently create an
+  `up-to-date` value whose timestamp provenance is broken.
+
+**REQ-SYNC-08 (Timestamps are not freshness proofs):** Timestamps select
+candidate stored values. They do not by themselves prove that a value is
+correct with respect to final merged inputs. Timestamp order is not a semantic
+proof of freshness.
+
+**REQ-SYNC-08d (Selected record timestamp copy):** Candidate selection chooses
+one complete stored materialization record. The final value, `createdAt`, and
+`modifiedAt` are copied from that selected record. Synchronization never
+combines the value from one source with timestamps from another source, never
+uses merge execution time as a materialization timestamp, and never computes a
+minimum or maximum `createdAt` across sources.
+
+**REQ-SYNC-08a (modifiedAt is a value version, not a merge timestamp):**
+`modifiedAt` records the time at which a node's stored semantic value last
+changed as a result of a computor producing a changed value. Merge decisions
+and metadata transformations produce no new semantic versions.
+
+- Taking a value copies its exact existing `modifiedAt` from the host side.
+- Keeping a value preserves its exact existing `modifiedAt`.
+- Invalidating freshness or rebuilding validity does not change `modifiedAt`.
+- Identifier reconciliation, input-edge relowering, and freshness changes do
+  not change `modifiedAt`.
+- Synchronization MUST NOT manufacture a new `modifiedAt` during merge.
+  Every final `modifiedAt` must be one of the timestamps already present in
+  the merge inputs (L or H).
+- Consequently, merging two fixed database snapshots is independent of
+  merge execution time. The result would be identical if the merge ran at
+  any future or past time.
+
+**REQ-SYNC-08b (No mergedAt field):** Synchronization MUST NOT introduce a
+persistent `mergedAt` field. Sync timing is available through logs and Git
+commits.
+
+**REQ-SYNC-08c (Same-coordinate stale freshness):** When both replicas have
+identical `modifiedAt` and identical `NodeIdentifier` for a semantic key, the
+records share a materialization coordinate but not necessarily a value. The
+merge MUST be conservative for freshness only:
+
+* If the selected side's value is `up-to-date` and the non-selected side's
+  freshness is not `up-to-date`, the final node MUST NOT remain `up-to-date`.
+  Set it to `potentially-outdated` without changing `modifiedAt` or the selected
+  value.
+* If the selected side is already not `up-to-date`, no adjustment is needed.
+* This same-coordinate relation MUST NOT create value provenance, dependency
+  history, or validity-proof transport for the non-selected source.
+* The stale metadata belonging to an older value version (`modifiedAt`)
+  MUST NOT taint a strictly newer value version. If one side has a newer
+  `modifiedAt`, the value selection based on timestamps is authoritative
+  and the stale metadata from the older version does not affect the
+  newer version's freshness.
+
+---
+
+## 7. Candidate Selection, Direct Invalidation, and Deletion
+
+The authoritative pairwise merge rule separates source selection, direct hard
+invalidation, propagated staleness, and deletion. Journal state is not an input
+to any of these decisions; this section specifies the conservative graph merge
+behaviour completely.
+
+**DEF-SYNC-06 (Taint propagation):** Keep-taint propagates forward from every
+key where the local candidate strictly wins by the complete canonical tuple.
+Take-taint propagates forward from every key where the host candidate strictly
+wins by the complete canonical tuple. Taint is ancestry information, not a
+source-selection override. A selected local/target candidate has opposite-side
+ancestry when take-taint reaches it. A selected host candidate has opposite-side
+ancestry when keep-taint reaches it.
+
+**DEF-SYNC-07 (Direct invalidation candidate):** A direct invalidation candidate
+is a selected cached node whose next required recomputation must invoke the
+computor rather than accept cache-only revalidation. Candidates are produced by:
+
+1. opposite-side ancestry reaching the selected candidate;
+2. direct input relowering;
+3. same-coordinate stale freshness metadata from REQ-SYNC-08c.
+
+**DEF-SYNC-08 (Direct relowering):** A selected cached node is directly
+relowered when at least one distinct semantic direct input used by its source
+materialization does not represent the final selected version of that semantic
+input through the canonical source-version identity relation
+(DEF-SYNC-02). Different storage identifiers, equal timestamps, or equal stored
+values do not make a non-selected source represent the selected source. Direct
+relowering creates a direct invalidation candidate; it is not by itself a
+deletion decision.
+
+**REQ-SYNC-09 (Distinct semantic input classifier):** The classifier counts
+distinct semantic direct dependency keys. It must not count computor argument
+positions, graph-scheme arity, lowered storage identifiers, or validity-edge
+count. `X(A)` and `X(A, A)` have one distinct semantic input. `X(A, B)` has two
+distinct semantic inputs.
+
+For every direct invalidation candidate:
+
+- zero or one distinct semantic input: retain the selected cached value,
+  preserve its `modifiedAt`, mark it `potentially-outdated`, and remove incoming
+  validity proofs so the next pull invokes the computor with the retained value
+  as `oldValue`;
+- more than one distinct semantic input: delete the materialization so the next
+  pull invokes the computor with `oldValue === undefined`, and `Unchanged` is not
+  legal.
+
+Direct relowering therefore follows:
 
 ```text
-RemoteAdvancedActions union SyncGraphActions
+direct relowering
+    → direct invalidation candidate
+    → hard invalidate when distinct-input count <= 1
+    → delete when distinct-input count > 1
 ```
 
-Duplicate coordinates coalesce. A coordinate in `SyncGraphActions` uses local
-cutover time. Synchronization-created graph differences make delivery records
-but do **not** advance the local synchronized clock: synchronization order and
-grouping must not manufacture replicated progress. Remote progress or a future
-local-versus-final graph comparison supplies coverage elsewhere.
+Thus `A → B` may hard-invalidate `B` when synchronization ambiguity prevents
+`B` from remaining current, but it does not delete `B`. For `A,B → D`, once `D`
+requires direct hard invalidation, the temporary policy deletes `D`.
 
-## Inactive replica protocol
+**REQ-SYNC-10 (Structural deletion closure):** Deletion roots expand through
+transitive materialized dependents in the selected semantic dependency graph. If
+`D` is deleted in `A,B → D → E → F`, then `E` and `F` are deleted as
+materialized dependents, while `A`, `B`, siblings, and unrelated
+materializations such as `U` survive. The closure follows structural semantic
+dependencies, not only validity edges, and synchronization never invokes
+computors while applying it. Deleted nodes have no final identifier, cached
+value, freshness, timestamps, validity entries, or value origin.
 
-1. Acquire the graph lifecycle holiday.
-2. Acquire shared garden access and select the active local replica.
-3. Open one fixed committed source snapshot `S`.
-4. Capture from `S` the authoritative local graph, `NotificationClock`,
-   `DeliveryByIndex`, `DeliveryHead`, `JournalOriginId`, and
-   `lastLocalJournalIndex`.
-5. Release shared garden access.
-6. Obtain and validate the remote authoritative graph and clock.
-7. Calculate `finalGraph` and `finalClock` independently.
-8. Initialize the inactive destination by exact-copying local delivery indexes,
-   origin identity, watermark, and clock from `S`.
-9. Install `finalClock`.
-10. Append-or-replace delivery records for the union above, allocating only
-    indices greater than the copied watermark.
-11. Install `finalGraph` and validate the complete destination.
-12. Acquire exclusive garden access, atomically switch active replica, release
-    locks.
+**TERM-SYNC-17 (Propagated staleness):** A node can become
+`potentially-outdated` because one of its inputs is stale. That is propagated
+staleness, not a direct invalidation candidate. Propagated stale nodes retain
+transportable incoming proofs and are not deleted merely because they have
+multiple inputs.
 
-Remote physical delivery records are never copied or merged. Exact local copying
-preserves old cursor positions and gaps through cutover.
+---
 
-## Coverage traces
+## 8. Identifier Reconciliation and Edge Lowering
 
-- If graph conflict resolution changes local value without a matching remote
-  `edit` advancement, `SyncGraphActions` adds local `edit` at cutover time but
-  does not increment the local clock.
-- Remote add then delete advances both action coordinates and yields both local
-  deliveries even if final local graph remains absent.
-- A pre-cutover cursor remains meaningful because source indices and watermark
-  are copied exactly and all new records are above that watermark.
+**REQ-SYNC-11 (Final identifier selection):** For each semantic key whose
+outcome is not `delete`, the final identifier is selected from
+`selectedSideByKey`:
 
-## Reset
+- `keep` → local source identifier.
+- `take` → host source identifier.
+- `invalidate` → the source identifier selected by `selectedSideByKey`.
 
-Reset is an authoritative local graph mutation. It compares before/after graphs,
-classifies every affected key, advances local clock components, replaces local
-deliveries, and commits all changes atomically. It does not reconstruct graph
-state from the journal, replace delivery history, reset `JournalOriginId`, lower
-or reset the watermark, or create a special reset event.
+The final identifier lookup maps final storage identifiers to semantic keys for
+surviving materializations only. It must be bijective between final identifiers
+and `FinalKeys = { key ∈ Keys | outcome(key) ≠ delete }`. Deleted keys must
+not remain in the lookup.
 
-A reset trace keeps origin `O` and watermark 90; deleting K emits `delete`,
-advances `clock[K][O].delete`, and allocates an index above 90.
+---
+
+## 9. Freshness Merge Policy
+
+**REQ-SYNC-11a (Up-to-date eligibility):** A final node may be `up-to-date`
+only if all of the following hold:
+
+1. It has a stored value in the final state.
+2. Every direct input (per the graph scheme) is known in the final identifier
+   lookup.
+3. Every direct input is materialized (has a stored value).
+4. Every direct input is itself `up-to-date`.
+5. Every direct input has a validity flag for this node in the final validity
+   relation.
+6. The stored value's provenance and final dependency structure justify
+   preserving it (the node was not invalidated by conflict propagation or
+   relowering).
+
+If any of these do not hold, the node MUST be `potentially-outdated` or
+unmaterialized.
+
+**REQ-SYNC-12 (Meaning of potentially-outdated):** `potentially-outdated` means
+the system does not currently have enough proof to guarantee the stored value
+without verifying it. A stale node pulls all dependencies:
+
+- A **direct invalidation root** has had all incoming proofs removed. Its next pull must invoke its computor.
+- A **propagated stale descendant** retains all incoming and outgoing proofs. Its next pull may cache-revalidate without invoking its computor when every incoming proof remains present.
+
+A stale node that cache-revalidates is marked `up-to-date` and returns its stored value. A stale node whose cache predicate fails invokes its computor.
+
+---
+
+## 10. Value Origin and Provenance
+
+**REQ-SYNC-13 (Equality does not create origin):**
+
+- Equal stored values do not imply same origin.
+- Equal stored values do not imply interchangeable validity proofs.
+- Equal stored values do not permit importing source-side validity metadata.
+- JSON or deep equality MUST NOT be used in value-origin inference.
+- A value origin must be based on copy or preservation history, not on result
+  comparison.
+
+**Rationale:** The main IncrementalGraph spec permits nondeterministic
+computors. Two computor invocations may produce equal values for different
+reasons, under different hidden external conditions, or with different side
+effects. Deep equality is a property of returned data, not a certificate that
+the computation histories are interchangeable.
+
+---
+
+## 11. Validity Proof Transport
+
+**DEF-SYNC-09 (Source validity proof):** A source-side relation entry
+`valid[D].has(N)` means that, in that source replica, N's stored value was
+known valid with respect to D's stored value according to the IncrementalGraph
+validity algorithm.
+
+**REQ-SYNC-14 (Validity proof transport conditions):** A source proof from
+side `S ∈ { target, host }`:
+
+```
+valid[sourceD].has(sourceN)
+```
+
+may be transported to final:
+
+```
+valid[finalD].has(finalN)
+```
+
+only if ALL of the following hold:
+
+1. `sourceD` and `sourceN` both have semantic keys in the source side's
+   identifier lookup.
+2. Those semantic keys both have final identifiers in
+   `finalIdentifierForKey`.
+3. `sourceD` represents the final version of D through the canonical
+   source-version identity relation (DEF-SYNC-02).
+4. `sourceN` represents the final version of N through the same relation.
+5. `finalD` is a direct structural input of `finalN` in the final lowered
+   graph per `mergedInputsMap`.
+6. The final dependency edge is derived from the final graph scheme and
+   semantic inputs, not copied blindly from source storage.
+
+The two endpoints of the source proof must still come from one source replica.
+Their final stored byte origins do not need to be that source replica when
+equal-timestamp copies represent the same temporary semantic versions.
+
+**REQ-SYNC-15 (Negative transport rules):**
+
+- The source side must match for both endpoints. Cross-side mixed proofs MUST
+  NOT be transported.
+- Proofs involving deleted or discarded identifiers MUST NOT be transported.
+- Proofs involving unknown semantic keys MUST NOT be transported.
+- Proofs involving non-materialized final endpoints MUST NOT be transported.
+- Proofs whose final edge is no longer a structural dependency MUST NOT be
+  transported.
+- Stored value equality MUST NOT be used as a fallback for any endpoint in
+  validity proof transport. A proof is transported only when both endpoints
+  represent the final selected versions through the canonical identity
+  relation, not on extensional value match.
+
+**REQ-SYNC-16 (Required incoming validity for up-to-date nodes):** Every final
+`up-to-date` materialized node must have complete incoming validity proofs for
+all its direct inputs. Validated source invariants plus source-version identity
+(DEF-SYNC-02) justify complete proof transport for every node that is not a
+direct invalidation candidate. Validity reconstruction expects the planning
+classification to be complete and throws `UnplannedMissingValidityProofError` if
+a missing proof is discovered. Reconstruction does not itself create a new direct
+invalidation root.
+
+**REQ-SYNC-17 (Rebuild, not merge):** The final validity relation must be
+rebuilt from the final lowered graph, not textually merged from source
+validity relations. Transported proofs are added individually under the
+conditions above; no bulk textual merge of validity storage is permitted.
+
+---
+
+## 12. Final-State Invariants
+
+**REQ-SYNC-18 (Pre-switch validation):** After building the final merged state
+in T but before switching the active replica pointer, the implementation MUST
+validate the following invariants:
+
+1. Every stored value key is present in the final identifier lookup.
+2. Every freshness key is present in the final identifier lookup.
+3. Every timestamp key is present in the final identifier lookup.
+4. Every validity key is present in the final identifier lookup.
+5. Every validity key is materialized.
+6. Every validity dependent is present in the final identifier lookup.
+7. Every validity dependent is materialized.
+8. Every validity edge is a structural dependency edge in the final graph.
+9. Every final `up-to-date` node has a stored value.
+10. Every final `up-to-date` node's direct inputs are known in the final
+    identifier lookup.
+11. Every final `up-to-date` node's direct inputs are materialized.
+12. Every final `up-to-date` node's direct inputs are `up-to-date`.
+13. Every final `up-to-date` node has validity flags from each direct input.
+14. No discarded or losing storage identifier remains in values, freshness,
+    timestamps, or validity storage.
+15. The final identifier lookup is internally consistent and bijective.
+
+**REQ-SYNC-19 (Validation failure):** If these invariants cannot be
+established, the per-host merge MUST fail and the active replica pointer MUST
+remain unchanged.
+
+---
+
+## 13. Commit and Active Replica Switching
+
+**REQ-SYNC-20 (Write target isolation):** Per-host merge writes into inactive
+replica T. The active replica pointer switches only after the final state is
+built, validated, and committed.
+
+**TERM-SYNC-18 (Merge summary):** After each per-host merge, the implementation
+records counts of outcomes:
+
+- `kept`: number of semantic keys whose final outcome is `keep`.
+- `taken`: number of semantic keys whose final outcome is `take`.
+- `invalidated`: number of semantic keys whose final outcome is `invalidate`.
+- `deleted`: number of semantic keys whose final outcome is `delete`.
+
+A deletion counts as a semantic graph-state change only when the target replica
+previously contained that materialization. A host-only key that is deleted
+before ever being written to the target does not by itself change the target
+state.
+
+**REQ-SYNC-21 (Switch condition):**
+
+- If graph data, identifier mapping, freshness, or validity metadata changed,
+  the inactive replica becomes active.
+- If no semantic data, identifier data, freshness, or validity relation
+  changed, the active pointer remains unchanged.
+- A "metadata-only" change, such as importing a valid provenance-backed
+  validity proof, is sufficient to switch replicas, because it affects future
+  recomputation behavior. Metadata-only changes must obey the provenance rules
+  of §11.
+
+**REQ-SYNC-22 (Partial failure safety):** The currently active local source
+replica must not be partially mutated by a failed host merge. Failure before
+commit must not leave callers reading from an invalid partial merge target.
+
+---
+
+## 14. Multi-Host Synchronization
+
+**REQ-SYNC-23 (Pairwise commutativity):** For valid source replicas A and B using the same schema, merging A with B and merging B with A produce observably equivalent final IncrementalGraph states. Observable equivalence includes semantic keys, selected identifiers, stored values, freshness, timestamps, lowered inputs, reverse dependencies, validity proofs, deletion outcomes, and invalidation outcomes. It excludes host-local allocator capability metadata: each host intentionally retains its own `fingerprint` and `last_node_index` allocation namespace. It may also ignore local physical details such as temporary paths, logs, replica-slot names, and source-role labels.
+
+**REQ-SYNC-24 (Sequential per-host merge):** Normal synchronization may merge
+multiple host branches sequentially. Each per-host merge observes the result of
+prior successful per-host merges (because each merge may switch the active
+replica and advance its state).
+
+**REQ-SYNC-25 (Per-host validation after success):** The implementation MUST
+validate the graph state after every successful per-host merge against the
+invariants in §12 before proceeding to the next host.
+
+**REQ-SYNC-26 (Host failure isolation):** If one host's merge fails,
+synchronization may continue with remaining hosts and aggregate all failures
+into a single composite error.
+
+**REQ-SYNC-27 (No multi-host order independence guarantee):** This specification requires pairwise commutativity for a single two-replica merge. It does not guarantee associativity across three or more replicas or arbitrary sequential host-order independence unless a future document proves and requires those properties. Correctness is not full CRDT-like convergence.
+The correctness obligation for multi-host synchronization is that each
+individual per-host merge satisfies the invariants of §12 at the moment it
+completes, and that the final state after all host merges (successful or
+skipped) is a valid IncrementalGraph state from which all future public
+operations produce results consistent with the main IncrementalGraph spec.
+This is a safety property, not a convergence property.
+
+---
+
+## 15. Proof Obligations and Specification Labels
+
+**TERM-SYNC-19 (Normative labels):** The following label prefixes are used
+throughout this specification:
+
+| Prefix | Category |
+|--------|----------|
+| TERM-SYNC- | Terminology definitions |
+| DEF-SYNC- | Formal definitions |
+| REQ-SYNC- | Normative requirements |
+| PROP-SYNC- | Correctness properties |
+| INV-SYNC- | Invariants |
+
+**PROP-SYNC-01 (Public operation transparency):** After any sequence of
+synchronization operations, the public IncrementalGraph operations
+(`pull()`, `invalidate()`, inspection methods) produce results consistent with
+the main IncrementalGraph specification given the same schema and the merged
+state.
+
+**PROP-SYNC-02 (Conservative freshness):** Synchronization never marks a node
+`up-to-date` unless the rules in §9 and §11 are satisfied. It may mark nodes
+`potentially-outdated` even when a more sophisticated proof might have
+preserved them.
+
+**PROP-SYNC-03 (No value invention):** Synchronization never introduces new
+node values. Every final stored value originates from either the local source
+replica L or the host source replica H, or was already present in the initial
+copy of L into T.
+
+**PROP-SYNC-04 (No computor invocation):** Synchronization never invokes a
+computor function, directly or indirectly.
+
+---
+
+## 16. Independent Notification-Clock Result
+
+The graph and replicated notification results have separate ownership:
+
+```text
+finalGraph =
+    the fully specified authoritative graph merge in §§1–15
+
+finalClock =
+    joinClock(localClock, remoteClock)
+```
+
+The graph merge is fully specified independently of the journal.
+`NotificationClock` must not influence `finalGraph`, and `finalGraph` must not
+be reconstructed from `NotificationClock`. The notification clock never
+chooses graph state. Journal-domain and clock validation occurs before either
+result is installed, but successful clock contents have no role in candidate
+selection, conflict policy, deletion, freshness, identifier reconciliation, or
+validity transport.
+
+## 17. Notification journal integration
+
+After the authoritative algorithm has completely settled and validated
+`finalGraph`, compute notification delivery coordinates as follows:
+
+```text
+RemoteAdvancedActions = {
+    (K,A) |
+    some allowed origin O has
+      finalClock[K][O][A].sequence > localClock[K][O][A].sequence
+}
+
+SyncGraphActions =
+    classifyExactActions(local authoritative graph, final authoritative graph)
+
+DeliveryActions =
+    RemoteAdvancedActions ∪ SyncGraphActions
+```
+
+`classifyExactActions` is the closed before/after classifier: `add` only for
+absent to materialized, `edit` only for unequal `ComputedValue` while both
+sides are materialized, `delete` only for materialized to absent, `invalidate`
+only for fresh to stale while materialized, and `validate` only for stale to
+fresh while materialized. Value and freshness changes may yield two independent
+actions. Duplicate `(K,A)` coordinates coalesce.
+
+Remote advances choose their delivery time by the notification-clock
+specification. A coordinate introduced only by `SyncGraphActions` uses local
+cutover time. Such graph-difference delivery does not advance a local clock
+component: synchronization grouping must not manufacture replicated progress.
+Remote physical indices, heads, gaps, and watermarks are not merged.
+
+The inactive destination starts as an exact copy of the fixed local source
+snapshot, including local delivery cursor infrastructure. It installs
+`finalClock`, then append-or-replaces one delivery for each `DeliveryActions`
+coordinate at fresh indices above the copied watermark. The destination graph,
+clock, deliveries, and watermark are validated and committed before the active
+pointer can switch. The journal integration supplements, and never replaces,
+any graph merge requirement in §§1–15.
+
+### 17.1 Conflict-resolution trace
+
+Consider local inputs `A` and `B`, a multi-input materialization `D(A,B)`, and
+dependants `E(D)` and `F(E)`. The host's canonical candidate for `A` wins and
+has a different value. Its selected freshness is stale, while local `A` was
+fresh. This establishes the authoritative value and freshness changes first.
+Relowering makes `D` a direct invalidation candidate; because `D` has two
+distinct semantic inputs, §7 deletes it. The structural deletion closure then
+deletes materialized dependants `E` and `F`. Validity edges and identifiers are
+rebuilt for survivors, and the complete result passes §12 validation.
+
+Only now compare local authoritative state with settled `finalGraph`:
+
+```text
+SyncGraphActions = {
+    (A, edit),
+    (A, invalidate),
+    (D, delete),
+    (E, delete),
+    (F, delete)
+}
+```
+
+Any remote-advanced coordinates are unioned afterward. Thus classification
+reports the value change, freshness change, multi-input deletion, and propagated
+dependant deletions without participating in or altering their resolution.
+
+## 18. Lifecycle and failure requirements for journal-bearing replicas
+
+The fixed source snapshot contains both authoritative graph state and the local
+journal state. Destination construction remains isolated in inactive replica T.
+Pre-cutover validation covers graph invariants, the fixed journal domain, clock
+validity, one-head delivery integrity, and notification coverage. Failure leaves
+the active pointer and active replica unchanged. Reset-to-hostname remains a
+separate wholesale authoritative operation; it preserves the receiving host's
+origin and emits exact local notifications for its before/after graph changes.
+
+Sequential multi-host processing still uses each prior successful authoritative
+result as the next local source. Graph-level pairwise commutativity remains
+REQ-SYNC-23. Independently, only the replicated `NotificationClock` join has the
+commutative, associative, and idempotent laws; local delivery indices and
+watermarks need not agree across hosts or synchronization schedules.

--- a/docs/specs/migration.md
+++ b/docs/specs/migration.md
@@ -168,14 +168,15 @@ If no previous version is found, the migration is a no-op.
 
 Migration constructs the new authoritative graph independently of the journal;
 the graph remains the sole authority. From one fixed active-replica snapshot,
-the inactive destination exact-copies local `JournalDomain`, `NotificationClock`,
+the inactive destination exact-copies local `JournalDomain`, `localWriterId`, `NotificationClock`,
 `DeliveryByIndex`, `DeliveryHead`, `JournalOriginId`, and
 `lastLocalJournalIndex` as cursor infrastructure.
 
 Migration preserves the complete local domain and local writer identity. It
 does not create, replace, or infer a journal domain. Pre-cutover validation
 requires the destination domain to equal the local domain, every represented
-origin to be allowed, delivery heads and records to satisfy the one-head
+origin to occur in `writerOrigins`, the local writer/origin pair to match its
+mapping, delivery heads and records to satisfy the one-head
 invariant, and the watermark to cover every retained delivery index.
 
 After construction, migration compares old and new authoritative states. It

--- a/docs/specs/migration.md
+++ b/docs/specs/migration.md
@@ -168,9 +168,15 @@ If no previous version is found, the migration is a no-op.
 
 Migration constructs the new authoritative graph independently of the journal;
 the graph remains the sole authority. From one fixed active-replica snapshot,
-the inactive destination exact-copies local `NotificationClock`,
+the inactive destination exact-copies local `JournalDomain`, `NotificationClock`,
 `DeliveryByIndex`, `DeliveryHead`, `JournalOriginId`, and
 `lastLocalJournalIndex` as cursor infrastructure.
+
+Migration preserves the complete local domain and local writer identity. It
+does not create, replace, or infer a journal domain. Pre-cutover validation
+requires the destination domain to equal the local domain, every represented
+origin to be allowed, delivery heads and records to satisfy the one-head
+invariant, and the watermark to cover every retained delivery index.
 
 After construction, migration compares old and new authoritative states. It
 emits `add` for absent-to-materialized, `delete` for materialized-to-absent,


### PR DESCRIPTION
### Motivation

- The previous specification draft replaced the authoritative graph merge and the full observatory locking model with journal-centric summaries, which weakened invariants now that the graph is the sole authority; this PR restores the normative authoritative behavior.
- The accepted notification-only journal design must be preserved and integrated without making the journal determine graph state.
- The protocol must enforce a fixed finite synchronization domain and per-host origin identity so the `O(n)` bound, clock validation, and host-fork semantics are honest and auditable. 

### Description

- Restored the complete authoritative graph synchronization specification (scope, per-host merge pipeline, candidate selection, timestamp/identifier conflict policy, deletion roots and dependency-closure deletion, identifier reconciliation, validity-proof transport, final-state invariants, pre-cutover validation, write-target isolation, partial-failure safety, pairwise commutativity, and the prohibition on computor invocation) in `docs/specs/incremental-graph-synchronization.md` while keeping the graph merge independent of the journal. 
- Restored and expanded the observatory locking model in `docs/specs/incremental-graph-locking-design.md` (DOME_ACTIVITY_KEY modes, HOLIDAY_GATE_KEY, telescope per-node mutexes, per-replica darkroom finalization, `enterGarden`/`closeGarden` lifecycle, ordinary transaction bundling of graph + journal writes, and a complete lock-order table) and explicitly integrated journal commit coverage without moving computors into the darkroom. 
- Made the journal synchronization domain normative in `docs/specs/incremental-graph-journal-types.md` and `docs/specs/incremental-graph-journal-sync.md` by introducing `JournalDomainId` / `AllowedJournalOrigins`, enforcing exact-domain membership and rejecting unknown origins, defining host origin assignment and host-fork traces, and clarifying that only `NotificationClock` is algebraically joined. 
- Added an explicit post-merge "Notification journal integration" section and definitions for `RemoteAdvancedActions`, `SyncGraphActions`, and `DeliveryActions` that classify deliveries only after the authoritative `finalGraph` is settled, and added a conflict-resolution trace showing value/freshness/delete propagation. 
- Updated the journal overview `docs/incremental-graph-journal.md` to state the final invariants (graph merge independent of journal, NotificationClock never chooses graph state, journal locking preserved, one unique origin per writable host, unknown-origins rejection, O(n) bound for fixed domain, algebraic properties of `NotificationClock`, and that local delivery indices are cursor infrastructure). 
- This is specification-only: no runtime code was added or modified, and the accepted exact-action and bounded-delivery journal design (actions: `add`, `edit`, `delete`, `invalidate`, `validate`; append-or-replace delivery semantics) was preserved unchanged.

### Testing

- Ran dependency install with `npm install` to ensure environment consistency, which completed successfully. 
- Ran static checks with `npm run static-analysis` (TypeScript compile + `eslint --max-warnings 0`), which completed successfully. 
- Performed repository checks including `git diff --check` and targeted `rg` searches for removed/forbidden terms and for the required authoritative/locking terms, all of which returned expected results (no residual journal-as-state artifacts and restored authoritative/locking language present). 
- Verified that the spec files compile/format changes were applied and the working tree is clean after the edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7509d8b8e4832ead20290619f08e00)