### PR TITLE
Clarify journal observable boundary, timestamps, and opaque cursors

### DIFF
--- a/docs/incremental-graph-journal.md
+++ b/docs/incremental-graph-journal.md
@@ -4,8 +4,9 @@
 
 ### Goal 1 — no false negatives
 
-**The journal must have no false negatives with respect to graph changes.** A
-graph change is exactly a committed transition in materialization presence,
+**The journal must have no false negatives with respect to graph changes.** For
+the notification journal, a graph change means exactly a committed
+transition in materialization presence,
 `ComputedValue`, or the freshness sublevel. The corresponding closed action set
 is `add`, `edit`, `delete`, `invalidate`, and `validate`. Every such transition
 produces a covering notification. Repeated changes of the same exact action may
@@ -104,14 +105,67 @@ materialization transitions and never additionally produce freshness actions.
 
 ## Journal-observable graph surface
 
-The complete surface is exactly materialization presence, `ComputedValue`, and
-freshness sublevel. Other fields are derived from those dimensions, cannot
-change independently, or are deliberately non-observable internal metadata.
-`createdAt` changes only with add; `modifiedAt` only with a value change and
-therefore edit; `NodeIdentifier` is stable for a semantic node or identity
-replacement is specified as delete plus add; validity edges can change silently
-while freshness is unchanged; storage representation is not observable. No
-other independently changing semantic field is presently in this contract.
+The journal's no-false-negatives contract covers exactly:
+
+1. materialization presence;
+2. `ComputedValue`;
+3. freshness sublevel.
+
+Other persisted or public graph metadata may change without a journal
+notification. Where permitted by the authoritative graph operation, this
+includes `NodeIdentifier`, `createdAt`, `modifiedAt`, validity relations,
+dependency or validity evidence, storage representation, and other metadata
+outside the three journal-observable dimensions. These fields are not all
+derived from the observable dimensions and are not required to change with one
+of them.
+
+During ordinary local computor execution, `modifiedAt` changes only when the
+computor changes the stored value. Synchronization may nevertheless select a
+remote materialization whose value is equal to the receiver's current value but
+whose existing `modifiedAt` and `createdAt` differ. Copying those source
+timestamps is metadata replacement, not a local value edit, and emits no edit
+notification.
+
+`NodeIdentifier` is storage identity, not semantic `NodeKey` identity.
+Synchronization may reconcile the same semantic `NodeKey` to a different
+selected `NodeIdentifier` without a delete/add journal transition.
+
+For example, consider the mandatory metadata-only synchronization trace:
+
+```text
+local K:
+    id         = n-local
+    value      = A
+    createdAt  = 100
+    modifiedAt = 1000
+    freshness  = up-to-date
+
+remote K:
+    id         = n-remote
+    value      = A
+    createdAt  = 200
+    modifiedAt = 2000
+    freshness  = up-to-date
+
+remote wins by modifiedAt
+```
+
+The final receiving transition is:
+
+```text
+id:               n-local -> n-remote
+createdAt:        100 -> 200
+modifiedAt:       1000 -> 2000
+value:            A -> A
+freshness:        up-to-date -> up-to-date
+materialization:  present -> present
+
+journal result:   no action
+```
+
+This result is required. `edit` is not emitted because `ComputedValue` did not
+change; `delete` and `add` are not emitted because materialization did not
+change; and no freshness action is emitted because freshness did not change.
 
 ## Core guarantees
 

--- a/docs/specs/incremental-graph-journal-api.md
+++ b/docs/specs/incremental-graph-journal-api.md
@@ -25,6 +25,23 @@ Actions have only these meanings: absent-to-materialized `add`; materialized
 repeated identical actions are permitted; false negatives on these dimensions
 are not.
 
+Every `PossibleNodeChange` returned by `possibleMaybeChanges` carries a private
+same-process cursor position corresponding to its local `JournalIndex`. The
+private cursor position:
+
+- is not one of the public data fields;
+- is not directly readable as a raw journal index;
+- is not user-constructible from `nodeName`, `bindings`, `action`, and `time`;
+- is accepted internally when that returned token is later passed as `since`;
+- is valid only within the documented same-process cursor domain; and
+- has no persistence or serialization guarantee.
+
+`baselinePossibleNodeChange()` similarly returns an opaque sentinel strictly
+before every real local journal position. The implementation representation is
+deliberately unspecified. It may use private fields, symbols, nominal branding,
+object identity plus private lookup, or another mechanism satisfying this
+contract. A raw numeric `JournalIndex` is not part of the public API.
+
 ## Fixed-snapshot query
 
 A query performs:

--- a/docs/specs/incremental-graph-journal-types.md
+++ b/docs/specs/incremental-graph-journal-types.md
@@ -119,11 +119,17 @@ DeliveryHead = Map<(NodeKey, JournalAction), JournalIndex>
 ```
 
 `JournalIndex` is a monotonically allocated physical token in one process-local
-cursor domain. `lastLocalJournalIndex` is its never-decreasing watermark. A
-`PossibleNodeChange` containing a real index, or the sentinel returned by
-`baselinePossibleNodeChange()`, is a cursor token. Tokens address local physical delivery progress, not synchronized clock
-positions or graph versions. Sparse indices are valid because replacement deletes old records but
-never reuses their indices.
+cursor domain. `lastLocalJournalIndex` is its never-decreasing watermark. Every
+returned `PossibleNodeChange` privately carries the position of its real local
+index, and `baselinePossibleNodeChange()` returns an opaque sentinel strictly
+before all real local positions. Neither token exposes a raw index as a public
+field or permits construction from the public change fields. Tokens are
+accepted internally as `since`, are valid only in the documented same-process
+domain, and have no persistence or serialization guarantee. Their private
+representation is deliberately unspecified, and a raw numeric `JournalIndex`
+is not part of the public API. Tokens address local physical delivery progress,
+not synchronized clock positions or graph versions. Sparse indices are valid
+because replacement deletes old records but never reuses their indices.
 
 `DeliveryHead[K,A]`, when present, points to the sole retained record for that
 coordinate. `DeliveryRecord` contains no graph values, identifiers, timestamps

--- a/docs/specs/incremental-graph.md
+++ b/docs/specs/incremental-graph.md
@@ -521,10 +521,15 @@ interface IncrementalGraph {
 
 **REQ-IFACE-08 (Timestamp Invariants):**
 * `getCreationTime(N, B) <= getModificationTime(N, B)` for any materialized node instance `N@B`.
-* `getCreationTime(N, B)` MUST NOT change once set.
+* During ordinary local graph operations, `getCreationTime(N, B)` MUST NOT
+  change once set. Synchronization may replace it only by copying the selected
+  materialization record's exact existing `createdAt`.
 * `getModificationTime(N, B)` is a version timestamp for the stored semantic value.
 * A **new timestamp record** is created when a semantic value is first stored for a node (including migration `create` and the node's initial computation). `createdAt` and `modifiedAt` are both set to the current time at this point.
-* An existing `modifiedAt` **advances** only when a computor produces a changed value that replaces the previous stored value. `modifiedAt` MUST NOT advance in any other circumstance.
+* During ordinary local computor execution, an existing `modifiedAt`
+  **advances** only when a computor produces a changed value that replaces the
+  previous stored value. Synchronization can instead replace it with the exact
+  existing `modifiedAt` of the selected source materialization.
 * Synchronization may replace a local node value and timestamp with another replica's existing value-version pair (the `take` decision). This copies the existing timestamp; it does not mint a new one. Synchronization MUST NOT replace a timestamp with the merge execution time or any other manufactured value.
 * `modifiedAt` MUST NOT change when:
   * a node becomes `potentially-outdated` (invalidation);
@@ -532,7 +537,8 @@ interface IncrementalGraph {
   * validity flags are added, removed, transported, or rebuilt;
   * a computor returns `Unchanged`;
   * synchronization keeps an existing value (the `keep` decision);
-  * identifier reconciliation occurs;
+  * identifier reconciliation occurs without selection of a different source
+    materialization record;
   * dependency identifiers are relowered;
   * a cached value is deleted because the old value is not valid for the final dependency structure;
   * freshness changes between `up-to-date` and `potentially-outdated`; no freshness record exists for unmaterialized nodes.
@@ -631,7 +637,12 @@ freshness sublevel. The public journal API consists of:
 
 - `graph.possibleMaybeChanges({ since, to })` — Queries possible node changes since a previously observed position, restricted to nodes matching the given filter. Returns `Promise<Array<PossibleNodeChange>>`. The `since` parameter accepts `PossibleNodeChange | BaselinePossibleNodeChange`; the `to` parameter is a `NodeFilter`. See `docs/specs/incremental-graph-journal-api.md` for the full specification.
 
-- `baselinePossibleNodeChange()` — Returns a `BaselinePossibleNodeChange` sentinel (a position less than any real journal index). When passed as `since` to `graph.possibleMaybeChanges`, scanning starts from the first journal entry. This is a standalone function, not an `IncrementalGraph` method.
+- `baselinePossibleNodeChange()` — Returns an opaque
+  `BaselinePossibleNodeChange` sentinel strictly before every real local
+  journal position. When passed as `since` to
+  `graph.possibleMaybeChanges`, scanning starts from the first journal entry.
+  This is a standalone function, not an `IncrementalGraph` method. The raw
+  physical `JournalIndex` is not part of the public API.
 
 Journal notification has no false negatives for those three dimensions, but it
 may have false positives and collapse repeated occurrences of one exact action.
@@ -644,14 +655,67 @@ potentially-outdated; and `validate` is only potentially-outdated to up-to-date.
 Add/delete do not also emit freshness actions. Value and freshness transitions
 may independently produce two actions.
 
-`createdAt` changes only as part of add. `modifiedAt` changes only with value and
-therefore alongside edit. `NodeIdentifier` is stable for a semantic key, or an
-identity replacement is explicitly delete plus add. Validity edges and
-dependency evidence are internal metadata: changing them with unchanged
-freshness emits nothing. Storage representation is not journal-observable.
-There is no additional independently changing semantic field in the journal
-contract; adding one requires explicitly extending the observable surface rather
-than broadening an existing action.
+The journal's no-false-negatives contract covers exactly:
+
+1. materialization presence;
+2. `ComputedValue`;
+3. freshness sublevel.
+
+For the notification journal, a graph change means a committed transition in
+one of those dimensions. Other persisted or public graph metadata may change
+without a journal notification. Where permitted by the authoritative graph
+operation, this includes `NodeIdentifier`, `createdAt`, `modifiedAt`, validity
+relations, dependency or validity evidence, storage representation, and other
+metadata outside the three journal-observable dimensions. These fields are not
+all derived from the observable dimensions or incapable of independent change.
+
+During ordinary local computor execution, `modifiedAt` changes only when the
+computor changes the stored value. Synchronization may nevertheless select a
+remote materialization whose value is equal to the receiver's current value but
+whose existing `modifiedAt` and `createdAt` differ. Copying those source
+timestamps is metadata replacement, not a local value edit, and emits no edit
+notification.
+
+`NodeIdentifier` is storage identity, not semantic `NodeKey` identity.
+Synchronization may reconcile the same semantic `NodeKey` to a different
+selected `NodeIdentifier` without a delete/add journal transition.
+
+The required metadata-only synchronization trace is:
+
+```text
+local K:
+    id         = n-local
+    value      = A
+    createdAt  = 100
+    modifiedAt = 1000
+    freshness  = up-to-date
+
+remote K:
+    id         = n-remote
+    value      = A
+    createdAt  = 200
+    modifiedAt = 2000
+    freshness  = up-to-date
+
+remote wins by modifiedAt
+
+final receiving state:
+    id               n-local -> n-remote
+    createdAt        100 -> 200
+    modifiedAt       1000 -> 2000
+    value            A -> A
+    freshness        up-to-date -> up-to-date
+    materialization  present -> present
+
+journal result:
+    no action
+```
+
+`edit` MUST NOT be emitted because `ComputedValue` did not change.
+`delete`/`add` MUST NOT be emitted because materialization did not change. No
+freshness action is emitted because freshness did not change. Extending the
+observable surface requires a separate explicit contract change rather than
+broadening an existing action.
 
 The journal type system, emission rules, synchronization model, migration
 interaction, and mandatory append-or-replace delivery rules are specified in:
@@ -753,7 +817,7 @@ Additionally, `pull()` acquires a **per-node mutex** inside the mode mutex to pr
 | `listMaterializedNodes()` | `daytime` | Other `daytime`-mode methods; **NOT** with `pull()` |
 | `getCreationTime()` | `daytime` | Other `daytime`-mode methods; **NOT** with `pull()` |
 | `getModificationTime()` | `daytime` | Other `daytime`-mode methods; **NOT** with `pull()` |
-| `possibleMaybeChanges()` | `enterGarden` (shared garden access) | Daytime and nighttime methods; ordinary append-only journal growth; does not acquire `DOME_ACTIVITY_KEY` or darkroom; structural operations excluded by garden; replica cutover serialized via `closeGarden` + `holiday` |
+| `possibleMaybeChanges()` | `enterGarden` (shared garden access) | Daytime and nighttime methods; ordinary atomic journal emission and append-or-replace delivery updates; does not acquire `DOME_ACTIVITY_KEY` or darkroom; structural operations excluded by garden; replica cutover serialized via `closeGarden` + `holiday` |
 | `getSchemas()` | none (in-memory read) | Everything |
 | `getSchemaByHead()` | none (in-memory read) | Everything |
 | `getDbVersion()` | none (in-memory read) | Everything |


### PR DESCRIPTION
### Motivation

- Make the notification-journal contract honest about which graph fields are journal-observable and which may change silently during authoritative synchronization. 
- Correct incorrect claims that timestamps and `NodeIdentifier` can only change with local add/edit/delete actions, aligning the journal text with the synchronization selection rules. 
- Preserve the accepted journal architecture and exact action semantics while removing misleading append-only wording and exposing same-process cursor semantics as opaque tokens.

### Description

- Revised `docs/incremental-graph-journal.md` to define that, for the notification journal, a graph change means a committed transition in exactly one of: materialization presence, `ComputedValue`, or freshness sublevel. 
- Added normative language showing that other persisted/public metadata (including `NodeIdentifier`, `createdAt`, and `modifiedAt`) may change without emitting a journal notification, and added a mandatory metadata-only synchronization trace illustrating a no-action outcome. 
- Clarified timestamp invariants in `docs/specs/incremental-graph.md` to distinguish ordinary local computor advances from synchronization copying of source timestamps, and to allow synchronization to replace timestamps without emitting `edit` or materialization actions when `ComputedValue` and freshness remain equal. 
- Introduced opaque same-process cursor semantics in `docs/specs/incremental-graph-journal-api.md` and `docs/specs/incremental-graph-journal-types.md`, making it explicit that returned `PossibleNodeChange` tokens carry a private position that is not a public numeric `JournalIndex` and has no persistence guarantee. 
- Replaced misleading "append-only journal growth" wording with wording describing "atomic journal emission and append-or-replace delivery updates" without changing locking or delivery guarantees. 
- Files changed: `docs/incremental-graph-journal.md`, `docs/specs/incremental-graph.md`, `docs/specs/incremental-graph-journal-api.md`, and `docs/specs/incremental-graph-journal-types.md`.

### Testing

- Ran `npm run static-analysis` (TypeScript + ESLint) against the modified repository and it completed successfully with no new lint/type failures. 
- Performed repository consistency searches for prior erroneous claims (searches for `createdAt`, `modifiedAt`, `NodeIdentifier`, and `append-only` phrasing) and updated all affected specifications; pattern checks passed. 
- Performed basic repository checks (`git diff --check` and other local validations) with no blocking issues found; documentation-only changes were committed. 

Notes: these are specification-only changes that do not alter runtime code paths; the public API and accepted notification architecture were preserved. Like polishing a ship's chart so captains won't mistake tides for reefs — @ottojung

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7559f90ddc832eb6e4825a744dacd6)