### PR TITLE
Scope IncrementalGraph journal proofs to supported histories and add baselinePossibleNodeChange API

### DIFF
--- a/docs/incremental-graph-journal.md
+++ b/docs/incremental-graph-journal.md
@@ -1,5 +1,24 @@
 # IncrementalGraph journal
 
+## Supported-state boundary
+
+The journal protocol is specified for graph and journal states produced by
+supported Volodyslav lifecycle transitions, using the definition of supported
+and corrupted or unsupported state in
+[`database-lifecycle.md`](specs/database-lifecycle.md#11-corruption-model).
+Journal correctness, synchronization, compaction, convergence, freshness,
+provenance, and cursor-coverage guarantees quantify only over those states and
+over history deliveries and unions that can arise between them.
+
+A journal state that requires violation of the authoring, lifecycle, locking,
+clock, immutability, or causal-context invariants is therefore corrupted or
+unsupported under that lifecycle definition. Unless a specification explicitly
+says otherwise, the protocol does not guarantee its detection, rejection,
+recovery, convergence, or preservation as forensic evidence. Implementations
+MAY detect and reject such corruption defensively, but those checks are not the
+semantic correctness contract, and compaction need not retain evidence solely
+for later corruption diagnosis.
+
 The IncrementalGraph journal is immutable logical history and possible-change
 notification infrastructure. It is not authoritative graph state. The graph
 continues to own current values, freshness, wall-clock timestamps, identifiers,
@@ -16,7 +35,8 @@ snapshots and retained history defined here. When that evidence is insufficient,
 the specified conservative stale/delete rules apply.
 
 Synchronization never invokes computors or invents a `ComputedValue`. Logical
-journal merge is commutative, associative, and idempotent. Reconciliation is
+journal merge is commutative, associative, and idempotent over supported
+histories whose delivery is a supported protocol state. Reconciliation is
 pairwise and decentralized, requires neither a leader nor all-to-all exchange,
 and permits hosts to be unavailable for arbitrary periods subject to the host
 lifecycle and directional-fairness assumptions. `possibleMaybeChanges()` has no

--- a/docs/specs/incremental-graph-journal-compaction.md
+++ b/docs/specs/incremental-graph-journal-compaction.md
@@ -1,5 +1,16 @@
 # Logical journal compaction
 
+## Proof domain
+
+This specification uses the
+[journal supported-state boundary](incremental-graph-journal-types.md#supported-state-boundary),
+which inherits the lifecycle definition in `database-lifecycle.md`. Every
+preservation, dominance, freshness, closure, and merge claim below quantifies
+over supported reachable journal states and deliveries/unions that are
+supported protocol states, not arbitrary sets of fabricated entries.
+Compaction need not preserve discarded evidence solely to diagnose a past or
+future corrupted/unsupported history.
+
 Compaction considers immutable `JournalEntry` contents only; `localIndex` is
 ignored. For notification coverage, E2 covers E1 when author, key, and action are
 equal and E2 has greater sequence. There is no cross-author coverage.
@@ -16,7 +27,12 @@ it is add G, retain:
 4. every exact invalidate referenced by every retained validation causal context, including coordinate-max validations for losing generations; and
 5. every add referenced by a retained generation-scoped entry.
 
-If presence is absent, generation-authority witnesses are empty. Invalid same-key generation references, unresolved/mismatched causal references, references not preceding their validation, and non-monotone same-author validation contexts reject the journal before selection. Reference closure leaves no dangling context. Results have canonical
+If presence is absent, generation-authority witnesses are empty. Retained
+generation and causal references must be structurally resolvable and meaningful
+before selection. Implementations MAY also reject non-monotone contexts and
+other corruption defensively when evidence is available, but compaction
+correctness does not require complete diagnosis of unsupported history.
+Reference closure leaves no dangling retained context. Results have canonical
 `JournalEntryId` order.
 
 Let G win before compaction. Every losing add H is below a retained presence
@@ -27,7 +43,11 @@ freshness authority while retaining coordinate maxima.
 
 The algorithm preserves `presenceHead`; each winning-generation `valueHead(author,K,G)` by retaining add G and each author's greatest G-scoped edit; the exact equal-`valueModifiedAt` `candidateEvents` inputs needed by `canonicalEvent(K,G)`; `invalidateFrontier(K,G)`; existence of an individual effective validation; every required generation reference; and every retained causal reference.
 
-For same author/key/generation validations, journal validity requires later contexts to be componentwise nondecreasing. Thus an older discarded validation is dominated by the retained later one: every invalidate it covered remains covered. This is an enforced input invariant, not an assumption about well-behaved hosts.
+For same author/key/generation validations, supported authoring makes later
+contexts componentwise nondecreasing. Thus an older discarded validation is
+dominated by the retained later one: every invalidate it covered remains
+covered. This is a reachable-state invariant guaranteed by a correct durable
+author, not a claim about arbitrary structurally constructible entries.
 
 ## Cursor coverage when entries are removed
 
@@ -44,15 +64,21 @@ surviving witness; no logical duplicate is appended.
 
 ## ACI closure proof
 
-Canonical compaction satisfies:
+For supported reachable journal states A and B whose delivery/union is a
+supported protocol state, canonical compaction satisfies:
 
 ```text
 compact(compact(A) union B) = compact(A union B)
 ```
 
-A discarded coordinate loser cannot beat its retained maximum. Winning-generation value heads and equal-time canonical-event inputs remain explicit. A discarded older same-author invalidate is dominated by the retained frontier element. A discarded older same-author validation has a componentwise-dominated context by the validated monotonicity invariant. Every referenced invalidate and add remains resolvable. A delayed invalidate either adds an author coordinate or advances its frontier and defeats any validation that did not name it; this result is identical whether compaction ran before or after delivery. Partial validations never combine. Losing generations cannot regain authority, while a future greater add brings isolated value and freshness witnesses.
+A discarded coordinate loser cannot beat its retained maximum. Winning-generation value heads and equal-time canonical-event inputs remain explicit. A discarded older same-author invalidate is dominated by the retained frontier element. A discarded older same-author validation has a componentwise-dominated context by the supported-authoring monotonicity invariant. Every referenced invalidate and add remains resolvable. A delayed supported invalidate either adds an author coordinate or advances its frontier and defeats any validation that did not name it; this result is identical whether compaction ran before or after delivery. Partial validations never combine. Losing generations cannot regain authority, while a future greater add brings isolated value and freshness witnesses. Delayed delivery of another supported history cannot expose a same-author regression because no supported durable author can create one.
 
-These cases establish closure under every later union. Since compaction is canonical and idempotent, closure plus ACI set union yields commutative, associative, and idempotent logical merge. The conclusion does not follow from union alone. Logical equality excludes local indexes.
+These cases establish closure under every later supported union. Since
+compaction is canonical and idempotent on this domain, closure plus ACI set union
+yields commutative, associative, and idempotent logical merge for supported
+histories. These are not algebraic claims over arbitrary sets of
+`JournalEntry` values. The conclusion does not follow from union alone. Logical
+equality excludes local indexes.
 
 ## Fully compacted bound and optional timing
 
@@ -64,9 +90,23 @@ Per key, constant actions times r coordinates use `O(r)` entries. There are at m
 
 ## Executable bounded verification
 
-`scripts/verify-journal-spec-model.py` uses one combined six-atom universe rather than a freshness-only universe. Its composite atoms preserve every materially distinct class while keeping full ACI exhaustive: competing generations and an intervening delete; losing coordinate maxima and winning edit witnesses; cross-author heads; two-author split invalidation knowledge; complete validation; a delayed later same-author hard invalidate; later complete validation; and generation replacement.
+`scripts/verify-journal-spec-model.py` uses one combined six-atom bounded
+supported-state universe rather than a freshness-only universe. Its composite
+atoms preserve every materially distinct supported class while keeping ACI
+exhaustive within that universe: competing generations and an intervening
+delete; losing coordinate maxima and winning edit witnesses; cross-author
+heads; two-author split invalidation knowledge; complete validation; a delayed
+later same-author hard invalidate; later complete validation; and generation
+replacement.
 
-It checks 64 valid combined states and all 64 resulting compact states, 64 projection-preservation/idempotence checks, 4,096 full-universe closure pairs, and 262,144 full compact-universe ACI triples. Projections include presence/generation, value heads, equal-time canonical inputs, invalidate frontier, effective-validation existence, add references, and causal references. Negative cases reject malformed variants, observation-order violations, and backward same-author contexts.
+It checks 64 supported combined states and all 64 resulting compact states, 64
+projection-preservation/idempotence checks, 4,096 supported-universe closure
+pairs, and 262,144 compact supported-universe ACI triples. Projections include
+presence/generation, value heads, equal-time canonical inputs, invalidate
+frontier, effective-validation existence, add references, and causal
+references. Negative cases exercise defensive validation of malformed variants,
+observation-order violations, and backward same-author contexts; they are not a
+completeness proof for corruption detection.
 
 The independent cursor model remains exhaustive and now covers 20,736
 four-operation words and 82,944 committed prefixes, carrying 189,449

--- a/docs/specs/incremental-graph-journal-emission.md
+++ b/docs/specs/incremental-graph-journal-emission.md
@@ -138,7 +138,11 @@ nothing, changes no graph, and advances neither watermark.
 
 ## Reachability invariant
 
-All correctness arguments range over snapshots reachable through atomic normal
-mutations, migrations that preserve these invariants, and the synchronization
-protocol. Arbitrary mismatched graph/journal pairs are corrupt inputs, not
-ordinary conflicts.
+All correctness arguments use the
+[journal supported-state boundary](incremental-graph-journal-types.md#supported-state-boundary)
+and therefore range over snapshots reachable through atomic normal mutations,
+migrations that preserve these invariants, and the synchronization protocol.
+Arbitrary mismatched graph/journal pairs are corrupted or unsupported under the
+definition in `database-lifecycle.md`, not ordinary conflicts. Defensive
+validation MAY reject some such inputs, but complete detection is not a protocol
+correctness obligation.

--- a/docs/specs/incremental-graph-journal-migrations.md
+++ b/docs/specs/incremental-graph-journal-migrations.md
@@ -13,11 +13,15 @@ localJournalIndexWatermark
 Within one running receiver, migration separately threads the receiver's
 runtime-only cursor-domain identity into the inactive target; it never reads or
 writes that identity as database or synchronization content. It copies every
-retained entry and its receiver-local index exactly, then
-validates immutable ID content, generation and validation-causal references,
-same-author validation-context monotonicity, canonical compaction,
-logical clock coverage, unique indexes, and index-watermark coverage. It never
-imports another host's index or author ownership.
+retained entry and its receiver-local index exactly, then checks the structural
+invariants required to load retained state: generation and retained
+validation-causal references, canonical compaction, logical clock coverage,
+unique indexes, and index-watermark coverage. It MAY also check immutable-ID
+conflicts and same-author validation-context monotonicity defensively when the
+relevant evidence remains. These checks do not promise complete diagnosis of
+corrupted/unsupported history after compaction. It never imports another host's
+index or author ownership and uses the
+[journal supported-state boundary](incremental-graph-journal-types.md#supported-state-boundary).
 
 Migration applies the exact closed classifier. New logical entries use the host
 clock, required generation, wall-clock occurrence `time`, required add/edit `valueModifiedAt`, and distinct fresh

--- a/docs/specs/incremental-graph-journal-sync.md
+++ b/docs/specs/incremental-graph-journal-sync.md
@@ -1,5 +1,22 @@
 # Logical journal synchronization
 
+## Supported-state boundary
+
+This specification inherits the supported and corrupted/unsupported state
+definition from
+[`database-lifecycle.md`](database-lifecycle.md#11-corruption-model), as applied
+by the [journal types specification](incremental-graph-journal-types.md#supported-state-boundary).
+Synchronization, convergence, projection, provenance, freshness, and merge-law
+guarantees quantify only over supported reachable graph/journal states and
+deliveries or unions that can arise between them. Fabricated, manually edited,
+rolled-back, or otherwise unsupported histories are outside that correctness
+contract.
+
+Structural preconditions needed to interpret retained entries remain normative.
+Implementations MAY reject additional corruption defensively, but complete
+detection, recovery, and preservation of forensic evidence are not promised;
+compaction does not have to retain evidence solely for a later diagnosis.
+
 ## Merge
 
 Only immutable logical entries replicate. Receiver-local `localIndex` values,
@@ -9,10 +26,23 @@ Only immutable logical entries replicate. Receiver-local `localIndex` values,
 J1 ⊔ J2 = compact(entries(J1) ∪ entries(J2))
 ```
 
-Inputs must have the same schema, valid durable authors, valid actions and keys,
-and unique content for every `JournalEntryId`. Every edit/invalidate/validate must carry a generation resolving to a valid same-key add in the validated merge input. Every validation context coordinate `A -> I` must resolve I in that input; I must be a same-key, same-generation invalidate authored by A, and `I.sequence < V.sequence`. For every two validations V1,V2 with the same author, key, and generation and `V1.sequence < V2.sequence`, V2 must contain an equal-or-later same-author invalidate reference for every coordinate in V1. It may add or advance coordinates, but never forget or move one backward. Journals violating either causal-reference rule are rejected atomically before merge or compaction. Two entries
-with one ID but different content are corruption and reject the operation
-atomically and symmetrically. Remote entries never transfer author ownership.
+Supported inputs have the same schema, valid durable authors, valid actions and
+keys, and one immutable content for every `JournalEntryId`. Every retained
+edit/invalidate/validate must carry a generation resolving to a valid same-key
+add in the merge input. Every retained validation context coordinate `A -> I`
+must resolve I in that input; I must be a same-key, same-generation invalidate
+authored by A, and `I.sequence < V.sequence`. These are structural
+preconditions required to interpret the retained state.
+
+For every two validations V1,V2 with the same author, key, and generation and
+`V1.sequence < V2.sequence`, supported authoring guarantees that V2 contains an
+equal-or-later same-author invalidate reference for every coordinate in V1. It
+may add or advance coordinates, but never forget or move one backward. A
+validator MAY reject a visible violation. Likewise, two entries with one ID but
+different content are corrupted or unsupported and MAY be rejected atomically
+and symmetrically. These defensive checks do not promise detection after
+compaction has legitimately discarded the conflicting historical evidence.
+Remote entries never transfer author ownership.
 
 The receiver imports an unknown entry unchanged, stores it once, and assigns a
 fresh local index. The sender's index is ignored. An already-known entry is not
@@ -20,14 +50,16 @@ moved merely because it was received again.
 
 ## ACI proof
 
-Compaction retains every coordinate maximum plus, for the sole winning presence
+For supported reachable states and supported deliveries/unions, compaction
+retains every coordinate maximum plus, for the sole winning presence
 generation G, the bounded value/freshness-authority witnesses defined in the
 compaction specification. Presence maxima are monotone: a discarded losing
 generation can never win after union with more entries. Thus both the winning G
 and its witness selection are canonical functions of set union. Set union is
 commutative, associative, and idempotent; inserting this canonical closure after
 either parenthesization produces the same maxima and G witnesses. Canonical
-ordering is only a representation function. Therefore logical merge is:
+ordering is only a representation function. Therefore, for supported reachable
+A and B whose union is a supported protocol state, logical merge is:
 
 ```text
 compact(compact(A) ∪ B) = compact(A ∪ B)
@@ -35,7 +67,8 @@ compact(compact(A) ∪ B) = compact(A ∪ B)
 
 Coordinate losers cannot beat retained maxima, and a losing generation cannot
 become winning after union because its greater retained presence head cannot
-disappear. A future winning add brings its own authority witnesses. Therefore:
+disappear. A future winning add brings its own authority witnesses. On the same
+supported-state domain, therefore:
 
 ```text
 J1 ⊔ J2 = J2 ⊔ J1

--- a/docs/specs/incremental-graph-journal-types.md
+++ b/docs/specs/incremental-graph-journal-types.md
@@ -6,6 +6,27 @@ The journal is notification and history infrastructure. It is not authoritative
 graph state: current values, materialization, freshness, timestamps, and
 validity come from the IncrementalGraph.
 
+### Supported-state boundary
+
+This specification inherits the definition of supported and corrupted or
+unsupported database state from
+[`database-lifecycle.md`](database-lifecycle.md#11-corruption-model). Journal
+correctness, synchronization, compaction, convergence, freshness, provenance,
+and cursor-coverage guarantees range only over states produced by supported
+Volodyslav lifecycle transitions and deliveries or unions that can arise
+between those states. An arbitrary mathematical set of structurally
+constructible `JournalEntry` values is not necessarily a supported journal
+history.
+
+A state requiring violation of an authoring, lifecycle, locking, clock,
+immutability, or causal-context invariant is corrupted or unsupported in the
+lifecycle specification's sense. Unless explicitly specified otherwise, the
+protocol promises neither detection, rejection, recovery, convergence, nor
+preservation of forensic evidence for such a state. Implementations MAY retain
+cheap defensive rejection checks, but semantic correctness does not depend on
+their completeness and compaction need not preserve evidence solely for future
+corruption diagnosis.
+
 ```text
 JournalEntry =
     AddJournalEntry
@@ -62,10 +83,12 @@ host fingerprint and receives no additional discriminator.
 There is no separate journal membership domain. Supported host creation
 allocates one globally unique durable `HostFingerprint`; restoration may resume
 it only from that host's current synchronized state. Reset, migration, and
-copying never transfer ownership. Synchronization validates that every author
-is a well-formed supported host fingerprint and that one `JournalEntryId` has only
-one immutable content. Duplicate ownership or rollback under the same author is
-unsupported and prevents writable open.
+copying never transfer ownership. Supported authoring makes every author a
+well-formed supported host fingerprint and gives one immutable content to each
+`JournalEntryId`. Implementations MAY check these facts defensively when the
+relevant evidence is available. Duplicate ownership or rollback under the same
+author is corrupted or unsupported under the lifecycle definition; complete
+historical detection after compaction is not promised.
 
 The journal has no fixed closed writer-membership domain. A supported new host
 may introduce a new durable `HostFingerprint`, so storage is not bounded
@@ -87,7 +110,38 @@ generation field. After a delete and later add `G2=(50,B)`, subsequent scoped
 events for the new incarnation contain `generation=(50,B)`. Events scoped to G1
 are inapplicable to G2.
 
-`clearsInvalidates` is immutable causal evidence, not a Lamport threshold. Each mapping `A -> I` MUST resolve to a real invalidate authored by A for the validation's exact key and generation. It contains at most one reference per author: the greatest same-author invalidate in the exact transaction-visible frontier at genuine revalidation. Malformed, unresolved, or mismatched references reject the journal. The named invalidate must also have `I.sequence < V.sequence`; observed entries raise the validating author allocator before V is allocated. For any validations V1,V2 by the same author/key/generation with `V1.sequence < V2.sequence`, V2 MUST retain an equal-or-later reference for every coordinate in V1. It may add/advance coordinates but never forget or move backward. This is a normative journal-validity rule checked before merge and compaction.
+`clearsInvalidates` is immutable causal evidence, not a Lamport threshold. Each mapping `A -> I` MUST resolve to a real invalidate authored by A for the validation's exact key and generation. It contains at most one reference per author: the greatest same-author invalidate in the exact transaction-visible frontier at genuine revalidation. Retained state must satisfy these structural reference preconditions in order to be interpreted. The named invalidate must also have `I.sequence < V.sequence`; observed entries raise the validating author allocator before V is allocated.
+
+Supported authoring additionally guarantees, for validations V1 and V2 by the
+same author, key, and generation:
+
+```text
+V1.sequence < V2.sequence
+    =>
+V1.clearsInvalidates <=componentwise V2.clearsInvalidates
+```
+
+A correct durable author never forgets an invalidation already observed. V2
+may add or advance coordinates but cannot forget or move one backward. This is
+a supported-authoring and reachable-state invariant; it justifies later
+same-author validation dominance during compaction. It is not an obligation for
+compacted state to retain discarded validations so that every remote point in
+an arbitrarily fabricated past remains diagnosable.
+
+For example, this history for one author B, key K, and generation G is outside
+the supported model:
+
+```text
+V10 clears X:I5
+V15 clears X:I4
+V20 clears X:I6
+```
+
+The `I5 -> I4` transition regresses B's causal knowledge and cannot be authored
+through the supported protocol. Compaction therefore need not retain V10 merely
+so a later-delivered corrupted V15 can be diagnosed. A defensive validator MAY
+reject this history when the conflicting evidence is available; complete
+historical detection after compaction is not promised.
 
 Action variant and authorship context are orthogonal. Ordinary mutation,
 migration, synchronization-authored destruction, and controlled reset all use

--- a/docs/specs/incremental-graph-synchronization.md
+++ b/docs/specs/incremental-graph-synchronization.md
@@ -2,6 +2,15 @@
 
 ## Scope and state boundary
 
+This specification inherits supported and corrupted/unsupported state from
+[`database-lifecycle.md`](database-lifecycle.md#11-corruption-model) through the
+[journal supported-state boundary](incremental-graph-journal-types.md#supported-state-boundary).
+Its correctness and convergence claims quantify only over supported reachable
+snapshots and history deliveries/unions that can arise between them, not
+arbitrary structurally constructible journal sets. Defensive validation MAY
+reject additional corruption, but complete detection, recovery, and
+preservation of forensic evidence are not promised.
+
 Synchronization is decentralized bilateral reconciliation of two complete,
 reachable snapshots:
 
@@ -315,16 +324,22 @@ Before planning, synchronization MUST reject atomically:
 4. duplicate or internally conflicting lookup entries;
 5. a value, freshness, timestamp, or validity record whose identifier is not
    covered by its source lookup;
-6. malformed journal entries, including edit/invalidate/validate without a
+6. retained journal entries which cannot be structurally interpreted, including
+   edit/invalidate/validate without a
    generation resolving to a same-key add witness; a validation causal
    reference which is absent, mismatched, or not sequence-earlier than the
-   validation; or same-author/key/generation validations whose later context
-   forgets or moves an earlier coordinate backward;
-7. conflicting content at one `JournalEntryId`; or
-8. `localJournalClock` below an observed sequence;
-9. a retained entry missing exactly one unique valid local index;
-10. `localJournalIndexWatermark` below a retained local index; or
-11. any use of local index in logical equality, provenance, or merge.
+   validation;
+7. `localJournalClock` below an observed sequence;
+8. a retained entry missing exactly one unique valid local index;
+9. `localJournalIndexWatermark` below a retained local index; or
+10. any use of local index in logical equality, provenance, or merge.
+
+When evidence is simultaneously available, an implementation MAY additionally
+reject conflicting immutable content at one `JournalEntryId` or
+same-author/key/generation validations whose later context forgets or moves an
+earlier coordinate backward. These cheap defensive checks diagnose corrupted
+or unsupported input; they are not a completeness guarantee, and canonical
+compaction need not preserve discarded history solely to make them possible.
 
 Before journal join or conflict planning, validate each source against its own
 pre-merge journal. Every source materialization MUST resolve its source presence
@@ -581,7 +596,8 @@ measure; the proof does not assume that Lamport order implies observation.
 
 ### C. Journal gossip converges
 
-After the final entry, logical merge is commutative, associative, and idempotent.
+After the final entry in the supported execution described by this theorem,
+logical merge is commutative, associative, and idempotent.
 For any retained entry and any target host, connectedness gives a finite path;
 directional fairness eventually carries the entry through receives oriented
 along that path. With finitely many entries and hosts, eventually every host has

--- a/docs/specs/incremental-graph.md
+++ b/docs/specs/incremental-graph.md
@@ -484,6 +484,8 @@ interface IncrementalGraph {
   getModificationTime(nodeName: NodeName, bindings?: BindingEnvironment): Promise<DateTime>;
 
   // Journal API (read-only)
+  baselinePossibleNodeChange(): BaselinePossibleNodeChange;
+
   possibleMaybeChanges({ since, to }: {
     since: PossibleNodeChange | BaselinePossibleNodeChange,
     to: NodeFilter,

--- a/scripts/verify-journal-spec-model.py
+++ b/scripts/verify-journal-spec-model.py
@@ -70,6 +70,10 @@ ATOMS = (
 
 def valid(es):
     ids = {e.id: e for e in es}
+    # Defensive corruption check: exact immutable duplicates are harmless, but
+    # distinct contents claiming one logical ID are unsupported input. This is
+    # hardening, not part of the supported-state algebra proof below.
+    if any(ids[e.id] != e for e in es): return False
     for e in es:
         if e.action in ("add", "delete"):
             if e.generation is not None or e.clears: return False
@@ -101,6 +105,9 @@ assert not valid((G1, Entry(201, "B", "K", "delete", 30, G1.id)))
 assert not valid((G1, Entry(202, "B", "K", "edit", 30)))
 assert not valid((G1, Entry(203, "B", "K", "invalidate", 30)))
 assert not valid((G1, Entry(204, "B", "K", "validate", 30)))
+# Supported allocation and immutable authoring cannot produce this conflict.
+assert not valid((G1, Entry(1, "A", "K", "add", 11,
+                            value_modified_at=11)))
 
 I1_BAD = Entry(10, "A", "Z", "invalidate", 10, (1, "A"))
 GZ = Entry(1, "A", "Z", "add", 1, value_modified_at=1)
@@ -183,6 +190,11 @@ def projections(es):
     required_causal = frozenset(ref for e in retained_scoped for _, ref in e.clears)
     return (p, p.id, vh, canonical_inputs, frontier, effective(es, p), required_adds, required_causal)
 
+# This model enumerates bounded histories satisfying the supported journal
+# authoring/lifecycle invariants. Algebra and projection assertions quantify
+# over that supported-state universe; they intentionally do not prove detection
+# or recovery for arbitrary fabricated/corrupted Entry sets. Negative checks
+# above are defensive validation examples, not a completeness proof.
 VALID = []
 for mask in range(1 << len(ATOMS)):
     state = frozenset().union(*(ATOMS[i] for i in range(len(ATOMS)) if mask & (1 << i)))
@@ -376,7 +388,7 @@ for word in product(ops, repeat=4):
     states_checked += 1
 assert max_records <= 4
 
-print(f"valid combined logical states: {len(VALID)}")
+print(f"supported combined logical states: {len(VALID)}")
 print(f"projection preservation checks: {len(VALID)}")
 print(f"distinct compact logical states: {len(COMPACT)}")
 print(f"merge triples checked: {len(COMPACT) ** 3}")


### PR DESCRIPTION
### Motivation

- Make the journal correctness and compaction proofs explicit about their domain by restricting claims to states produced by supported Volodyslav lifecycle transitions (the lifecycle boundary in `database-lifecycle.md`).
- Clarify that defensive corruption checks may be implemented but are not part of the semantic correctness contract and compaction need not preserve forensic evidence for fabricated/corrupted histories.
- Reclassify validation-context monotonicity as a supported-authoring / reachable-state invariant so same-author dominance for compaction is properly justified.
- Fix an API inconsistency by adding the missing baseline cursor method to the normative `IncrementalGraph` interface.

### Description

- Added a concise supported-state boundary and explicit references to `docs/specs/database-lifecycle.md` across the journal overview and specs so correctness, synchronization, compaction, convergence, freshness, provenance, and cursor guarantees are stated only over supported lifecycle histories (`docs/incremental-graph-journal.md`, `docs/specs/incremental-graph-journal-types.md`, `docs/specs/incremental-graph-journal-compaction.md`, `docs/specs/incremental-graph-journal-sync.md`, `docs/specs/incremental-graph-journal-emission.md`, `docs/specs/incremental-graph-journal-migrations.md`, `docs/specs/incremental-graph-synchronization.md`).
- Rewrote verifier and spec wording to separate normative structural preconditions (what retained state must satisfy to be interpretable) from optional defensive corruption checks, and documented that defensive checks do not expand the supported proof domain (`scripts/verify-journal-spec-model.py`, multiple docs above).
- Documented validation-context monotonicity as a supported-authoring invariant and explicitly called out the `V10/I5 -> V15/I4 -> V20/I6` counterexample as outside the supported model so compaction is not required to preserve discarded validations for post-hoc corruption diagnosis (`docs/specs/incremental-graph-journal-types.md`, `docs/specs/incremental-graph-journal-compaction.md`).
- Left the canonical compaction algorithm and its storage bound unchanged and scoped compaction theorems (closure, commutativity, associativity, idempotence, convergence, validation dominance, freshness preservation) to supported reachable histories only (`docs/specs/incremental-graph-journal-compaction.md`).
- Added an optional defensive verifier check that rejects distinct immutable contents claiming the same `JournalEntryId` (duplicates with identical content remain harmless) and documented it as hardening rather than part of the algebraic proof (`scripts/verify-journal-spec-model.py`).
- Added the missing `baselinePossibleNodeChange(): BaselinePossibleNodeChange` method to the normative `IncrementalGraph` interface and left `possibleMaybeChanges()` semantics unchanged (`docs/specs/incremental-graph.md`).

### Testing

- Ran the executable bounded verifier with the updated supported-state universe: `python3 scripts/verify-journal-spec-model.py` and observed successful coverage of the bounded supported universe (64 supported combined states, 4,096 closure pairs, 262,144 merge triples, and all cursor/model checks passed).
- Ran static analysis: `npm run static-analysis` (TypeScript compilation + ESLint) and it completed successfully.
- Performed `git diff --check` and repository status checks to ensure no stray whitespace or formatting errors were introduced; no blocking errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a793e64820c832eab0503626530b56c)