### PR TITLE
Specify synchronized wall clocks, canonical ValueRevision, and nominal immutable possible-change cursors

### DIFF
--- a/docs/incremental-graph-journal.md
+++ b/docs/incremental-graph-journal.md
@@ -137,14 +137,19 @@ For this bound, `n` is the number of current or historic semantic keys represent
 **This guarantee applies only to complete canonical compaction.** Ordinary mutations may append immutable entries, and no operation-count-independent bound is promised for an uncompacted physical journal. Compaction may run at any time, after any transaction, during maintenance or synchronization, repeatedly, or be skipped arbitrarily long. Correctness never depends on its timing.
 ## Synchronization projections
 
-Supported hosts have monotone system wall clocks. Wall time is the best
-available approximation of universal cross-host event order. It is the primary
+All participating hosts in a supported execution share a synchronized real wall
+clock. For value-changing events E1 and E2, if E1 occurs before E2 in real time,
+then `E1.time <= E2.time`. Finite timestamp resolution is allowed, so distinct
+events may have equal timestamps. Wall time is the intended real-time order and the primary
 coordinate inside `ValueRevision` ordering among candidates which remain
 eligible at the relevant selection stage. It does not override presence,
 canonical-event, coherence, or fallback rules. Its finite resolution permits
-equal timestamps; journal identity resolves only those collisions. Clock
-rollback violates the supported execution model and has undefined
-synchronization behavior.
+equal timestamps; journal identity resolves only those collisions. Cross-host
+clock skew, clock rollback, or any condition that can invert real event order in
+wall-clock timestamps is outside the supported execution model. Synchronization
+correctness and value-selection guarantees do not apply to such executions;
+implementations need not detect them, and Volodyslav does not detect, repair,
+compensate for, or preserve causality across unsynchronized clocks.
 
 For materialized x in winning add generation G, each author-specific value head
 contains only add G or edits explicitly scoped to G and its `time`
@@ -153,7 +158,8 @@ multiple provenance events match that same timestamp does sequence-first
 `JournalEntryId=(sequence,author)` select the canonical origin:
 
 ```text
-ValueRevision(x,G) = [modifiedAt(x), author, sequence]
+origin(x,G) = canonicalEvent(x,G)
+ValueRevision(x,G) = [modifiedAt(x), origin(x,G).sequence, origin(x,G).author]
 presenceHead(x)  = greatest add/delete by JournalEntryId
 invalidateFrontier(x,G)[A] = greatest invalidate by A scoped to G
 effectiveValidate(V,x,G) iff V alone covers every frontier invalidate by exact-or-later same-author causal reference

--- a/docs/specs/database-lifecycle.md
+++ b/docs/specs/database-lifecycle.md
@@ -254,16 +254,16 @@ At reset time R, first materialization sets
 `createdAt=modifiedAt=add.time=R`. Changed materialization preserves `createdAt`,
 sets `modifiedAt=add.time=R`, and uses an add allocated above all receiver
 history observed by reset. This fresh generation makes old-generation value and
-freshness entries structurally inapplicable even if an old edit has a later wall
-time. Equal values preserve both receiver timestamps and author no value event.
+freshness entries structurally inapplicable before value ordering. Equal values
+preserve both receiver timestamps and author no value event.
 Source timestamp differences are irrelevant. Freshness and validity-only changes
 preserve `modifiedAt`.
 
 This is journal-minimal subject to reset authority: absent and equal-value states
 author no value action; deletion authors only delete; each new or genuinely
 changed value authors exactly one add. The fresh generation for a changed value
-is required to supersede already-observed old-generation history independently
-of wall-clock skew, rather than an attempt to replace receiver history.
+is required to supersede already-observed old-generation history structurally,
+rather than an attempt to replace receiver history by timestamp comparison.
 
 Freshness is classified independently: fresh-to-stale authors invalidate,
 stale-to-fresh authors validate, and equal freshness is silent. A validation is
@@ -296,11 +296,13 @@ and `modifiedAt` unchanged, and relowers the source proof so D remains fresh.
 There is no transient invalidate/revalidate cycle because classification compares
 the two committed states around one atomic coherent final construction.
 
-Clock-skew trace: generation G contains B's observed edit `EB=(10,B)` with
-`EB.time=200` and value B. Reset occurs with receiver wall time 150 and target A.
+Supported reset trace: generation G contains B's observed edit `EB=(10,B)` with
+`EB.time=200` and value B. Reset occurs later at synchronized wall time 250 with
+target A.
 Reset authors receiver add `GR=(n,R)` with `n>10` and
-`GR.time=graph.modifiedAt=150`. Presence selects GR before value ordering, so EB
-is structurally inapplicable despite its later wall time. A later union which
+`GR.time=graph.modifiedAt=250`. Presence selects GR before value ordering, so EB
+is structurally inapplicable independently of timestamp comparison. A later
+union which
 merely redelivers EB cannot resurrect B. This protects against already-observed
 history; genuinely unseen later normal synchronization remains governed by the
 ordinary synchronization rules.

--- a/docs/specs/incremental-graph-journal-api.md
+++ b/docs/specs/incremental-graph-journal-api.md
@@ -3,7 +3,8 @@
 ```text
 graph.possibleMaybeChanges({ since, to })
 graph.baselinePossibleNodeChange()
-PossibleNodeChange { nodeName, bindings, action, time }
+PossibleNodeChange = visible change payload + private cursor snapshot
+BaselinePossibleNodeChange = private baseline cursor snapshot
 InvalidPossibleChangeCursorError
 isInvalidPossibleChangeCursorError(object)
 ```
@@ -14,12 +15,59 @@ covering possibility are allowed; action-specific false negatives are forbidden.
 
 ## Cursor and query
 
-`since` is an opaque cursor conceptually
+`PossibleNodeChange` and `BaselinePossibleNodeChange` are opaque nominal public
+types. Conceptually their public declarations use a module-private brand:
+
+```ts
+declare const possibleNodeChangeCursorBrand: unique symbol; // not exported
+
+type PossibleChangeCursorSnapshot = Readonly<{
+  cursorDomainIdentity: CursorDomainIdentity;
+  localIndex: UInt64;
+  actionOrdinal: PossibleActionOrdinal;
+}>;
+
+interface PossibleNodeChange {
+  readonly nodeName: NodeName;
+  readonly bindings: BindingEnvironment;
+  readonly action: "add" | "edit" | "delete" | "invalidate" | "validate";
+  readonly time: DateTime;
+  readonly [possibleNodeChangeCursorBrand]: PossibleChangeCursorSnapshot;
+}
+
+interface BaselinePossibleNodeChange {
+  readonly [possibleNodeChangeCursorBrand]: BaselineCursorSnapshot;
+}
+```
+
+The declarations are conceptual, not a mandated runtime representation. A
+module-private symbol property, private class field, `WeakMap`, or equivalent
+non-forgeable mechanism MAY carry the snapshot. The brand symbol, domain
+identity, numeric index, and ordinal MUST NOT be exported or otherwise exposed
+to ordinary callers. Callers can receive and pass tokens back, while runtime
+code can recover their hidden snapshots.
+
+Consequently normal external TypeScript MUST reject structural fabrication of
+either type. In particular `{ nodeName, bindings, action, time }` does not
+type-check as `PossibleNodeChange` because it lacks the inaccessible nominal
+component, and no visible object literal type-checks as
+`BaselinePossibleNodeChange`. JavaScript, `any`, casts, stale objects, and tokens
+from other graphs still require runtime validation.
+
+Implementation verification MUST include negative compile-time cases for both
+structural forgeries, plus runtime tests for foreign change tokens, foreign
+baselines, same-process cutover continuity, new-runtime rejection, and an issued
+token retaining its copied index after the stored witness is touched.
+
+The hidden snapshot is conceptually
 `(cursorDomainIdentity,localIndex,actionOrdinal)`, where the ordinal uses the
 fixed order add, edit, delete, invalidate, validate. It is neither a
 `JournalEntryId` nor serializable or user-constructible.
-`graph.baselinePossibleNodeChange()` returns its receiver domain's opaque
-`(domain,before-all-history)` position; there is no universal baseline.
+`graph.baselinePossibleNodeChange()` returns an immutable nominal token bound to
+its receiver domain, conceptually `(domain,before-all-local-indexes,
+before-first-action)`; there is no universal baseline. It is non-serializable,
+non-user-constructible, foreign after a new runtime domain is allocated, and
+remains valid across supported same-process cutovers that preserve the domain.
 
 Before interpreting either numeric coordinate, `possibleMaybeChanges()` MUST
 compare the token's private domain identity with its receiver. A foreign token,
@@ -29,17 +77,30 @@ reinterpreted, or treated as baseline. This dedicated public API error is export
 `isInvalidPossibleChangeCursorError(object)` `instanceof` type guard. Raw
 positions and domain identity are never exposed.
 
-This cursor coordinate is `StoredJournalEntry.localIndex`, allocated from the
+The numeric coordinate captured in a cursor is copied from
+`StoredJournalEntry.localIndex`, allocated from the
 receiver's `localJournalIndexWatermark`; it is not the replicated
 `JournalEntry.sequence` allocated from `localJournalClock`. Sequence travels
 with immutable logical history, whereas local index never leaves its receiver
-and may move when that receiver touches the entry.
+and may move when that receiver touches the entry. The issued cursor snapshot is
+immutable and is not the mutable stored entry. A token issued for `(R,51,edit)`
+permanently means `(R,51,edit)` even if `touch(E)` moves E from index 51 to 90.
+It MUST NOT contain a live reference whose index is consulted later, derive its
+position lazily from E, or change when E or another witness is touched.
 
 A query retains one fixed committed active snapshot, captures
 `localJournalIndexWatermark=H`, considers stored entries after `since` and at or
 before H, expands them, applies `NodeFilter`, and returns deterministic
 `(localIndex,actionOrdinal)` order. An implementation may scan the current physical journal; any secondary local index must be reconstructible. Because compaction is optional, cost may depend on uncompacted size.
 Cutover cannot straddle snapshot selection.
+
+For each returned record, while holding that snapshot, the query reads the
+stored entry's numeric local index, expands its five actions, and captures the
+current receiver domain, copied index, and action ordinal into a new immutable
+nominal token. `nodeName`, `bindings`, `action`, and `time` are visible payload;
+the hidden `(domain,index,ordinal)` snapshot is continuation identity.
+`possibleMaybeChanges({since})` interprets only that hidden snapshot and MUST
+NOT reconstruct a position from visible payload fields.
 
 For every qualifying stored entry E:
 

--- a/docs/specs/incremental-graph-journal-api.md
+++ b/docs/specs/incremental-graph-journal-api.md
@@ -32,32 +32,68 @@ interface PossibleNodeChange {
   readonly bindings: BindingEnvironment;
   readonly action: "add" | "edit" | "delete" | "invalidate" | "validate";
   readonly time: DateTime;
-  readonly [possibleNodeChangeCursorBrand]: PossibleChangeCursorSnapshot;
+  readonly [possibleNodeChangeCursorBrand]: never; // nominal typing only
 }
 
 interface BaselinePossibleNodeChange {
-  readonly [possibleNodeChangeCursorBrand]: BaselineCursorSnapshot;
+  readonly [possibleNodeChangeCursorBrand]: never; // nominal typing only
 }
 ```
 
-The declarations are conceptual, not a mandated runtime representation. A
-module-private symbol property, private class field, `WeakMap`, or equivalent
-non-forgeable mechanism MAY carry the snapshot. The brand symbol, domain
-identity, numeric index, and ordinal MUST NOT be exported or otherwise exposed
-to ordinary callers. Callers can receive and pass tokens back, while runtime
-code can recover their hidden snapshots.
+The declarations are conceptual, not a mandated compile-time encoding. The
+private `unique symbol` is only a TypeScript nominal brand; it MUST NOT carry the
+runtime snapshot as a symbol-keyed property on the public object. Symbol-keyed
+properties are reflectable through `Object.getOwnPropertySymbols()`, so an
+unexported symbol binding alone does not provide runtime opacity.
 
-Consequently normal external TypeScript MUST reject structural fabrication of
-either type. In particular `{ nodeName, bindings, action, time }` does not
-type-check as `PossibleNodeChange` because it lacks the inaccessible nominal
-component, and no visible object literal type-checks as
-`BaselinePossibleNodeChange`. JavaScript, `any`, casts, stale objects, and tokens
-from other graphs still require runtime validation.
+The actual cursor snapshot MUST instead reside in genuinely private runtime
+state: for example, a module-private `WeakMap<object, CursorSnapshot>`,
+inaccessible class-private state with non-public construction, or another
+mechanism providing equivalent runtime opacity. Both possible-change and
+baseline tokens use this private-token-store principle. Conceptually:
+
+```text
+privateCursorSnapshots: WeakMap<object, CursorSnapshot>
+
+construct token:
+    token = public readonly payload object
+    privateCursorSnapshots.set(token, immutable snapshot)
+
+consume token:
+    snapshot = privateCursorSnapshots.get(token)
+    if snapshot is absent:
+        reject InvalidPossibleChangeCursorError
+    if snapshot.cursorDomainIdentity != receiver.cursorDomainIdentity:
+        reject InvalidPossibleChangeCursorError
+```
+
+The token object itself exposes no snapshot coordinates. Callers can receive,
+replay, and pass a legitimate token back unchanged, while only runtime code can
+recover its registered snapshot. The brand symbol, domain identity, numeric
+index, and ordinal MUST NOT be exported or otherwise exposed to ordinary
+callers.
+
+These mechanisms provide independent guarantees. At the TypeScript boundary,
+normal external code cannot structurally fabricate either nominal token type.
+In particular `{ nodeName, bindings, action, time }` does not type-check as
+`PossibleNodeChange` because it lacks the inaccessible nominal component, and no
+visible object literal type-checks as `BaselinePossibleNodeChange`. At runtime,
+JavaScript objects, `any`, casts, stale objects, and clones have no cursor
+authority unless the exact object is registered in private runtime state.
 
 Implementation verification MUST include negative compile-time cases for both
-structural forgeries, plus runtime tests for foreign change tokens, foreign
-baselines, same-process cutover continuity, new-runtime rejection, and an issued
-token retaining its copied index after the stored witness is touched.
+structural forgeries and runtime tests proving all of the following:
+
+1. a plain structural object is rejected;
+2. an object supplied through a cast or `any` is rejected;
+3. a clone of a real token without its private runtime registration is rejected;
+4. inspecting every ordinary own property name and symbol of a real token does
+   not reveal its cursor domain, index, or ordinal;
+5. foreign real tokens, including foreign baselines, are rejected;
+6. an original legitimate token remains valid; and
+7. touching its stored witness does not change its captured position.
+
+Tests MUST also retain same-process cutover continuity and new-runtime rejection.
 
 The hidden snapshot is conceptually
 `(cursorDomainIdentity,localIndex,actionOrdinal)`, where the ordinal uses the

--- a/docs/specs/incremental-graph-journal-sync.md
+++ b/docs/specs/incremental-graph-journal-sync.md
@@ -104,8 +104,17 @@ candidateEvents(x,G) = E such that
 canonicalEvent(x,G) = greatest candidate by JournalEntryId
                       = greatest by (E.sequence,E.author)
 origin(x,G) = canonicalEvent(x,G)
-ValueRevision(x,G) = [modifiedAt(x), origin(x,G).author, origin(x,G).sequence]
+ValueRevision(x,G) = [modifiedAt(x), origin(x,G).sequence, origin(x,G).author]
 ```
+
+This is the one and only `ValueRevision` total order: lexicographic
+`(modifiedAt,sequence,author)`. For unequal timestamps, greater `modifiedAt`
+wins. At equal time, greater sequence wins; at equal time and sequence, greater
+author fingerprint wins. The suffix is exactly the
+`JournalEntryId=(sequence,author)` order used by `canonicalEvent`. Sequence
+remains Lamport-style observation order, immutable entry identity and
+provenance, and an exact-time collision coordinate; it never overrides a
+different wall timestamp.
 
 Within this already equal-`modifiedAt` candidate set, sequence is primary
 because it preserves observed-before order; author only breaks genuinely
@@ -182,7 +191,7 @@ This follows by lifecycle induction:
   actual modification time for edit time and modifiedAt;
 * self-restoration resumes durable state without re-authoring values.
 
-Thus `ValueRevision=[graph.modifiedAt,origin.author,origin.sequence]` has
+Thus `ValueRevision=[graph.modifiedAt,origin.sequence,origin.author]` has
 `origin.time` as its first coordinate. Finite-resolution equal-time collisions
 remain disambiguated by sequence-first `JournalEntryId`; sequence is not the
 primary ordering coordinate across wall times.
@@ -216,8 +225,8 @@ In every reachable snapshot, two admissible materializations with equal
 
 Thus `ValueRevision` is collision-free over reachable admissible states. Its
 lexicographic tuple is a strict deterministic total order: timestamps decide
-first, different simultaneous authors second, repeated same-author changes at
-one timestamp third. This external revision-tuple comparison is not provenance
+first, sequence decides simultaneous events second, and author breaks an equal
+numeric-sequence tie third. This external revision-tuple comparison is not provenance
 recovery: matching same-time journal events were already reduced to one
 canonical event by sequence-first `JournalEntryId`. Equal revision with unequal
 values is corruption, not a hash tie-break case.
@@ -225,7 +234,7 @@ values is corruption, not a hash tie-break case.
 ## Traces
 
 * **Same writer/time:** A's edits at wall time 100 receive sequences 7 and 8;
-  `[100,A,8]` wins.
+  `[100,8,A]` wins.
 * **Different wall times:** A edits at 10:00 with sequence 500; B edits at 10:01
   with sequence 20. B's `ValueRevision` ranks higher among the candidates being
   compared at that selection stage because wall time is its primary coordinate.
@@ -242,7 +251,7 @@ values is corruption, not a hash tie-break case.
 * **Concurrent adds:** A adds K at `(10,A)` with `modifiedAt=200`; B adds K at
   `(50,B)` with `modifiedAt=100`. Joined presence chooses B's generation, so A's
   bytes are inadmissible despite their later wall time. The result uses B's
-  value and derives `[100,B,50]`; presence and value cannot name different
+  value and derives `[100,50,B]`; presence and value cannot name different
   generations.
 * **Concurrent old-generation validation:** A validates old G1 with
   `V=(100,A,generation=G1)`. Concurrently B establishes newer winning
@@ -268,7 +277,7 @@ values is corruption, not a hash tie-break case.
   101. LWW presence selects G. Freshness differs: a concurrent validation cannot
   clear an unseen invalidate regardless of its ID because its causal context
   does not name that barrier.
-* **Carrier independence:** A's `[100,A,8]` travels A → B → C. B and C import
+* **Carrier independence:** A's `[100,8,A]` travels A → B → C. B and C import
   the entry and allocate their own local indexes but author no edit. All three
   compare the same revision.
 * **Same-writer supersession:** A's retained head is edit 12. A host carrying

--- a/docs/specs/incremental-graph-journal-types.md
+++ b/docs/specs/incremental-graph-journal-types.md
@@ -227,20 +227,24 @@ and local index are not competing logical journal coordinates. Both overflow
 fatally, and neither allocator reuses a value within its applicable domain.
 
 This mutable stored position is distinct from an issued cursor token. A
-`PossibleNodeChange` contains visible change payload plus an immutable hidden
-nominal snapshot copying one `(cursorDomainIdentity,localIndex,actionOrdinal)`
-position at query time. A `BaselinePossibleNodeChange` contains only its hidden
-nominal baseline snapshot. Touch may move `StoredJournalEntry.localIndex`, but it
-cannot mutate or reinterpret any already-issued snapshot. Private domain
-identity and raw numeric coordinates are never public.
+`PossibleNodeChange` contains visible change payload while its exact object
+identity is registered with an immutable snapshot copying one
+`(cursorDomainIdentity,localIndex,actionOrdinal)` position at query time. A
+`BaselinePossibleNodeChange` is likewise registered with its private baseline
+snapshot. Registration and snapshots reside in genuinely private runtime state,
+not reflectable properties of the public objects. Touch may move
+`StoredJournalEntry.localIndex`, but it cannot mutate or reinterpret any
+already-issued snapshot. Private domain identity and raw numeric coordinates are
+never public.
 
 Each logical runtime receiver allocates one fresh private, unforgeable
 cursor-domain identity, unique from every unrelated receiver. It is runtime
 state: not part of `JournalEntry` or durable database state, not an author
 fingerprint, journal clock, or replica name, not remotely replicated, not
 serialized into Git/synchronization state, and not user-accessible. Object
-identity, an unexported symbol, or an equivalent private mechanism may implement
-it.
+identity, an unexported symbol retained only inside private runtime state, or an
+equivalent private mechanism may implement it. The identity MUST NOT appear as a
+reflectable property value on a public cursor token.
 
 Supported synchronization, migration, or reset inactive construction within the
 same running receiver threads this identity through the construction path with

--- a/docs/specs/incremental-graph-journal-types.md
+++ b/docs/specs/incremental-graph-journal-types.md
@@ -226,6 +226,14 @@ authors may allocate the same numeric sequence;
 and local index are not competing logical journal coordinates. Both overflow
 fatally, and neither allocator reuses a value within its applicable domain.
 
+This mutable stored position is distinct from an issued cursor token. A
+`PossibleNodeChange` contains visible change payload plus an immutable hidden
+nominal snapshot copying one `(cursorDomainIdentity,localIndex,actionOrdinal)`
+position at query time. A `BaselinePossibleNodeChange` contains only its hidden
+nominal baseline snapshot. Touch may move `StoredJournalEntry.localIndex`, but it
+cannot mutate or reinterpret any already-issued snapshot. Private domain
+identity and raw numeric coordinates are never public.
+
 Each logical runtime receiver allocates one fresh private, unforgeable
 cursor-domain identity, unique from every unrelated receiver. It is runtime
 state: not part of `JournalEntry` or durable database state, not an author

--- a/docs/specs/incremental-graph-synchronization.md
+++ b/docs/specs/incremental-graph-synchronization.md
@@ -65,10 +65,10 @@ reconstruction or stronger maximal-preservation property is implied.
 
 ### Clock assumptions
 
-Synchronization assumes that system wall clocks are monotone over
-IncrementalGraph operations on every supported host. Wall-clock timestamps are
-the closest available approximation of a universal temporal order between
-operations performed on different hosts and are therefore the primary
+All participating hosts in a supported execution are assumed to share a
+synchronized real wall clock. For value-changing events E1 and E2, if E1 occurs
+before E2 in real time, then `E1.time <= E2.time`. Wall-clock timestamps are
+therefore the intended real-time order and the primary
 cross-host coordinate within `ValueRevision` ordering among candidates still
 eligible at the relevant selection stage. This does not make wall time a global
 override of presence-generation applicability, collision canonicalization,
@@ -76,17 +76,20 @@ coherence classification, or fallback rules.
 
 Wall-clock timestamps have finite resolution and are not injective: distinct
 value-changing operations may receive exactly equal timestamps. The journal
-identity deterministically disambiguates those collisions. Clock rollback or
-any other violation of these assumptions is outside the supported execution
-model and gives undefined synchronization behavior. Synchronization does not
-attempt to repair it.
+identity deterministically disambiguates those collisions. Cross-host clock
+skew, clock rollback, or any condition that can invert real event order in
+wall-clock timestamps is outside the supported execution model. "Undefined"
+means that synchronization correctness and value-selection guarantees do not
+apply; implementations need not detect the condition. Volodyslav does not
+detect, repair, compensate for, or preserve causality across unsynchronized
+wall clocks.
 
 This specification uses the definitions in the journal synchronization spec:
 
 ```text
-ValueRevision(x,G) = [modifiedAt(x), modifiedBy(x,G), modifiedAtVirtual(x,G)]
-modifiedBy(x,G) = origin(x,G).author
+ValueRevision(x,G) = [modifiedAt(x), modifiedAtVirtual(x,G), modifiedBy(x,G)]
 modifiedAtVirtual(x,G) = origin(x,G).sequence
+modifiedBy(x,G) = origin(x,G).author
 
 presenceHead(x) = greatest add/delete by (sequence,author)
 invalidateFrontier(x,G)[A] = greatest invalidate by A scoped to G
@@ -105,20 +108,24 @@ These are distinct orders:
 
 ```text
 ValueRevision ordering:
-    modifiedAt first, as approximate cross-host real-time order
+    modifiedAt first, as synchronized cross-host real-time order
+    sequence second
+    author fingerprint third
 
 canonical provenance among events with equal modifiedAt:
     JournalEntryId = (sequence,author)
 ```
 
-Thus `modifiedBy` and `modifiedAtVirtual` provide exact deterministic identity
+Thus `modifiedAtVirtual` and `modifiedBy` provide exact deterministic identity
 when finite-resolution wall times collide. `modifiedAtVirtual` does not replace
-wall time and is not intended to repair a non-monotone system clock.
-For `T1 < T2`, T2 wins regardless of journal sequences. At equal T, distinct
-writer fingerprints distinguish cross-host revisions, while the journal
-sequence distinguishes repeated same-writer changes and selects the canonical
-event under sequence-first `JournalEntryId`. No hash or value-equality fallback
-is used as revision identity.
+wall time and is not intended to repair an unsynchronized system clock.
+For `T1 < T2`, T2 wins by wall time regardless of journal sequences. For equal
+T, greater sequence wins. For equal timestamp and equal sequence, greater author
+fingerprint wins because distinct concurrent authors may allocate the same
+numeric sequence. This suffix exactly matches sequence-first
+`JournalEntryId=(sequence,author)`. No hash or value-equality fallback is used as
+revision identity. Thus `[201,1,B] > [200,1000,A]`: sequence never becomes the
+primary global value clock.
 
 For an exact `modifiedAt` collision inside G, the greatest matching event by
 `JournalEntryId=(sequence,author)` is canonical. A source candidate resolves its
@@ -433,7 +440,7 @@ wall-clock timestamp.
 ### Timestamp collisions
 
 A makes two actual edits at wall time `t`. Its journal allocator produces 40 and
-41, so the distinct sequences keep `[t,A,41]` and `[t,A,40]` distinct and the
+41, so the distinct sequences keep `[t,41,A]` and `[t,40,A]` distinct and the
 sequence-first canonical event is 41. Independently A and B may each edit at
 `t`; sequence decides first and author breaks an equal-sequence tie. No
 physical-host or hash tie-break is needed.
@@ -446,10 +453,11 @@ and receives a durable delete barrier.
 
 ### Unsupported clock rollback
 
-K has an old value at `modifiedAt=12:00`. A later actual edit after system-clock
-rollback receives `modifiedAt=11:59`. This violates the monotone-clock
-assumption and has undefined synchronization semantics. Neither journal sequence
-nor any other synchronization mechanism repairs this unsupported execution.
+K has an observed value at `modifiedAt=12:00`. A later actual edit on a skewed
+host receives `modifiedAt=11:59`. This violates the synchronized-wall-clock
+assumption and is unsupported: synchronization correctness and value-selection
+guarantees do not apply. Neither journal sequence nor any other synchronization
+mechanism repairs this execution.
 
 ### Concurrent presence generations
 
@@ -457,7 +465,7 @@ A adds root K as VA at `(10,A)` and wall time 200. Concurrently B, after
 unrelated journal activity, adds VB at `(50,B)` and wall time 100. Presence is
 resolved first to B's add generation. VA is not a candidate inside that
 generation, so its wall time cannot override the presence decision; final K is
-VB with revision `[100,B,50]`.
+VB with revision `[100,50,B]`.
 
 ### Losing-generation edit collision
 
@@ -482,7 +490,7 @@ events use author as the deterministic tie-break.
 A authors `(A,12,K,edit,t,generation=G)`. A → B imports that entry and value; B
 stores it once with a fresh local index. B → C transmits only the immutable
 entry, and C assigns its own index. All
-hosts derive `[t,A,12]`, so support referring to K survives physical movement.
+hosts derive `[t,12,A]`, so support referring to K survives physical movement.
 Neither B nor C emits edit.
 
 ### Same-writer later edit
@@ -510,9 +518,9 @@ proves exact G2 inputs, and emits validate V2 scoped to G2 may restore freshness
 
 ### Unchanged
 
-D at revision `[t,A,7]` was supported by input revisions `[a1,b1]`. Inputs become
+D at revision `[t,7,A]` was supported by input revisions `[a1,b1]`. Inputs become
 `[a2,b2]`; normal recomputation returns `Unchanged` and restores both valid
-flags. D remains `[t,A,7]`, while transient `Support(D)` is now `[a2,b2]`.
+flags. D remains `[t,7,A]`, while transient `Support(D)` is now `[a2,b2]`.
 
 ### Compaction
 
@@ -557,8 +565,8 @@ satisfies IncrementalGraph correctness.
 
 **Theorem.** Let a finite set of writable hosts share one fixed finite schema and
 finite materialized dependency DAG. Suppose ordinary graph mutation becomes
-quiescent and every host satisfies the monotone-wall-clock assumptions above.
-Executions containing clock rollback are excluded. Let there be a fixed
+quiescent and every host satisfies the synchronized-wall-clock assumption above.
+Executions containing clock skew or rollback are excluded. Let there be a fixed
 connected undirected neighbor graph. For every
 neighbor edge `{A,B}`, require both directed receive operations `A <- B` and
 `B <- A` infinitely often (**directional fairness**). A receive stages the

--- a/docs/specs/incremental-graph.md
+++ b/docs/specs/incremental-graph.md
@@ -473,6 +473,16 @@ function makeIncrementalGraph(
 
 ### 3.2 IncrementalGraph Interface
 
+`PossibleNodeChange` and `BaselinePossibleNodeChange` are opaque nominal public
+types branded by a module-private, unexported `unique symbol` (or an equivalent
+non-forgeable declaration). The former combines the visible readonly
+`{nodeName, bindings, action, time}` payload with a private immutable cursor
+snapshot; the latter carries a private immutable baseline snapshot. External
+TypeScript callers cannot construct either type structurally, and raw domain,
+local-index, and action-ordinal coordinates are not public. The complete type,
+snapshot, and runtime-validation contract is in
+`incremental-graph-journal-api.md`.
+
 ```typescript
 interface IncrementalGraph {
   // Mutation and computation

--- a/docs/specs/incremental-graph.md
+++ b/docs/specs/incremental-graph.md
@@ -474,8 +474,10 @@ function makeIncrementalGraph(
 ### 3.2 IncrementalGraph Interface
 
 `PossibleNodeChange` and `BaselinePossibleNodeChange` are opaque nominal public
-types branded by a module-private, unexported `unique symbol` (or an equivalent
-non-forgeable declaration). The former combines the visible readonly
+types branded at compile time by a module-private, unexported `unique symbol`
+(or an equivalent non-forgeable type declaration). That symbol is not a runtime
+snapshot carrier; cursor authority resides in genuinely private runtime state
+such as a module-private `WeakMap`. The former combines the visible readonly
 `{nodeName, bindings, action, time}` payload with a private immutable cursor
 snapshot; the latter carries a private immutable baseline snapshot. External
 TypeScript callers cannot construct either type structurally, and raw domain,

--- a/scripts/verify-journal-spec-model.py
+++ b/scripts/verify-journal-spec-model.py
@@ -130,6 +130,31 @@ def value_heads(es, g):
         if e.author not in out or out[e.author].sequence < e.sequence: out[e.author] = e
     return frozenset(out.values())
 
+def canonical_event(events, modified_at):
+    """Select equal-wall-time provenance by JournalEntryId=(sequence, author)."""
+    return max((e for e in events if e.time == modified_at), key=lambda e: e.id)
+
+def value_revision(event):
+    """Order supported value events by wall time, sequence, then author."""
+    return (event.time, event.sequence, event.author)
+
+# This verifier quantifies only over executions satisfying the synchronized
+# wall-clock assumption. It models finite-resolution equality, not skew repair.
+REV_G = (1, "R")
+REV_SEQUENCE_10 = Entry(10, "A", "R", "edit", 200, REV_G)
+REV_SEQUENCE_11 = Entry(11, "B", "R", "edit", 200, REV_G)
+assert canonical_event((REV_SEQUENCE_10, REV_SEQUENCE_11), 200) == REV_SEQUENCE_11
+assert value_revision(REV_SEQUENCE_11) > value_revision(REV_SEQUENCE_10)
+REV_AUTHOR_A = Entry(12, "A", "R", "edit", 200, REV_G)
+REV_AUTHOR_B = Entry(12, "B", "R", "edit", 200, REV_G)
+assert canonical_event((REV_AUTHOR_A, REV_AUTHOR_B), 200) == REV_AUTHOR_B
+assert value_revision(REV_AUTHOR_B) > value_revision(REV_AUTHOR_A)
+REV_TIME_200 = Entry(1000, "A", "R", "edit", 200, REV_G)
+REV_TIME_201 = Entry(1, "B", "R", "edit", 201, REV_G)
+assert value_revision(REV_TIME_201) > value_revision(REV_TIME_200)
+assert tuple(map(value_revision, (REV_SEQUENCE_11, REV_AUTHOR_B))) == (
+    (200, 11, "B"), (200, 12, "B"))
+
 def invalidate_frontier(es, g):
     out = {}
     for e in es:
@@ -437,20 +462,20 @@ assert hardened.journal[-1].action == "invalidate"
 assert hardened.journal[-1].generation == harden_add_d.id
 
 # A changed-value reset add is a fresh presence generation above every observed
-# receiver entry. An already-observed edit with a later wall time belongs to the
-# old generation and cannot resurrect through subsequent journal union.
-skew_add = Entry(1, "B", "K", "add", 100)
-skew_edit = Entry(10, "B", "K", "edit", 200, skew_add.id)
-skew_state = ResetState(
+# receiver entry. The synchronized later reset occurs at time 250; generation
+# authority, rather than timestamp comparison, makes the old edit inapplicable.
+reset_generation_add = Entry(1, "B", "K", "add", 100)
+reset_generation_edit = Entry(10, "B", "K", "edit", 200, reset_generation_add.id)
+reset_generation_state = ResetState(
     (("K", ResetNode("receiver-K", "B", 100, 200, True)),),
-    frozenset(), frozenset(), (skew_add, skew_edit), 10, 2, object(), 2)
-skew_reset = reset(skew_state, {"K": ("A", True)},
-                   frozenset(), frozenset(), 150)
-reset_add = skew_reset.journal[-1]
-assert reset_add.action == "add" and reset_add.sequence > skew_edit.sequence
-assert reset_add.time == dict(skew_reset.nodes)["K"].modified_at == 150
-assert presence(skew_reset.journal, "K") == reset_add
-assert skew_edit not in value_heads(skew_reset.journal, reset_add)
+    frozenset(), frozenset(), (reset_generation_add, reset_generation_edit), 10, 2, object(), 2)
+reset_generation_result = reset(reset_generation_state, {"K": ("A", True)},
+                                frozenset(), frozenset(), 250)
+reset_add = reset_generation_result.journal[-1]
+assert reset_add.action == "add" and reset_add.sequence > reset_generation_edit.sequence
+assert reset_add.time == dict(reset_generation_result.nodes)["K"].modified_at == 250
+assert presence(reset_generation_result.journal, "K") == reset_add
+assert reset_generation_edit not in value_heads(reset_generation_result.journal, reset_add)
 
 # Physical tuple order is not presence authority. G1 is learned after the
 # winning G2 and its invalidate, but its lower JournalEntryId remains losing.
@@ -548,6 +573,16 @@ A1_cursor = issued_cursors(A1)[-1]
 A2 = Stored(A1.entries, A1.watermark, A1.domain)
 assert query(A2, A1_cursor) == query(A1, A1_cursor)
 
+# An issued token snapshots its numeric position. Touch moves only the retained
+# witness: querying from the old token still starts after index 1, not index 2.
+snapshot_state = put(Stored((), 0, DOMAIN_A), "K-snapshot")
+snapshot_cursor = issued_cursors(snapshot_state)[-1]
+touched_snapshot_state = touch(snapshot_state, "K-snapshot")
+assert snapshot_cursor[1] == 1
+assert dict(touched_snapshot_state.entries)["K-snapshot"] == 2
+assert query(touched_snapshot_state, snapshot_cursor) == {
+    ("K-snapshot", action) for action in ACTIONS}
+
 NEW_RUNTIME_DOMAIN = object()
 A_RESTORED = Stored(A1.entries, A1.watermark, NEW_RUNTIME_DOMAIN)
 try:
@@ -629,7 +664,9 @@ print(f"cursor obligation checks across prefixes: {obligations_checked}")
 print(f"maximum stored logical records: {max_records}")
 print("raw repeated-mutation records: 41; compact records: 2")
 print("minimal semantic reset matrix cases: 9")
-print("reset freshness, derived hard-stale, dependency, ordering, skew, and idempotence traces: 14")
+print("reset freshness, derived hard-stale, dependency, ordering, and idempotence traces: 14")
+print("ValueRevision order assertions: 7 (including support-vector identity)")
+print("immutable issued-cursor snapshot assertions: 3")
 print("two-domain rejection assertions: 4 (including 2 foreign baselines)")
 print("same-process cutover preservation assertions: 1")
 print("new-runtime cursor-domain replacement assertions: 1")


### PR DESCRIPTION
### Motivation

- Make the supported execution model explicit: participating hosts share a synchronized real wall clock and cross-host skew/rollback is outside the supported model.  Synchronization correctness and value-selection guarantees do not apply to skewed executions.
- Eliminate contradictory weaker clock wording and unsupported skew-based examples so the specification consistently treats wall time as the primary cross-host ordering coordinate (subject only to finite-resolution equality).
- Remove ambiguity in equal-time tie-breaking by making `ValueRevision` unambiguous and consistent with `canonicalEvent`/`JournalEntryId` identity.
- Provide a safe ergonomic cursor API by making `PossibleNodeChange`/`BaselinePossibleNodeChange` nominal opaque tokens with immutable private snapshots and preserving runtime domain validation.

### Description

- Made the global synchronized-wall-clock assumption normative and replaced earlier per-host/approximate wording and supported clock-skew traces with explicit statements that cross-host skew/rollback is outside the supported model and need not be detected or repaired. (Docs updated in `docs/incremental-graph-journal.md`, `docs/specs/incremental-graph-synchronization.md`, `docs/specs/database-lifecycle.md`.)
- Replaced the previous `ValueRevision` tuple with the single canonical definition using the canonical origin suffix: `origin(x,G) = canonicalEvent(x,G)` and `ValueRevision(x,G) = [modifiedAt(x), origin(x,G).sequence, origin(x,G).author]`, i.e. lexicographic ordering (modifiedAt, sequence, author).  Aligned all equal-time canonical-event rules and examples to use sequence-first then author. (Docs updated in `docs/incremental-graph-journal.md`, `docs/specs/incremental-graph-journal-sync.md`, `docs/specs/incremental-graph-synchronization.md`.)
- Specified public cursor token types as opaque nominal types and documented the public API contract conceptually (module-private `unique symbol` branding or equivalent runtime mechanism allowed).  `PossibleNodeChange` carries visible payload `{ nodeName, bindings, action, time }` plus a non-exported private snapshot `(cursorDomainIdentity, localIndex, actionOrdinal)`; `BaselinePossibleNodeChange` is the nominal baseline snapshot.  Clarified that issued cursor snapshots are immutable and distinct from the mutable `StoredJournalEntry.localIndex`, and that `possibleMaybeChanges({ since })` uses only the hidden snapshot for continuation ordering. (Docs updated in `docs/specs/incremental-graph-journal-api.md`, `docs/specs/incremental-graph-journal-types.md`, `docs/specs/incremental-graph.md`.)
- Clarified query construction: when producing a `PossibleNodeChange` the implementation must take a fixed committed snapshot, copy the stored entry's numeric local index from that snapshot, expand the five actions, and capture `(domain,index,ordinal)` immutably into the token; visible payload fields are separate and must not be used to reconstruct continuation position.
- Extended the executable verifier (`scripts/verify-journal-spec-model.py`) with explicit assertions that: equal-time candidates are ordered by sequence then author consistent with `canonicalEvent`; different-time assertions show wall time beats sequence; and a regression asserting that touching a witness moves the stored index but does not mutate previously issued cursor tokens. Also adjusted verifier prints to report these assertions. (Script updated.)
- Explicitly preserved the architecture constraints: no HLC/vector clocks, no causal vectors/clock-adjustment machinery, sequence remains Lamport-style secondary coordinate (not a global primary clock), reset semantics preserved (fresh generation authority), and runtime domain checks retained (foreign cursor rejection). (Multiple spec pages adjusted to preserve these invariants.)

### Testing

- Ran the bounded executable verifier `python3 scripts/verify-journal-spec-model.py`; it completed its exhaustive checks (supported logical states, merge triples, compaction closure, cursor obligation checks) and reported the added assertions for `ValueRevision` ordering and immutable issued-cursor snapshots; all verifier assertions passed.
- Ran `npm run static-analysis` (TypeScript compile + `eslint`) and it completed without errors under the repository static checks.
- Successfully byte-compiled the verifier (`python3 -m py_compile scripts/verify-journal-spec-model.py`) to validate the verifier script changes.
- Ran repository checks (`git diff --check`, grep scans for former vague clock wording) to confirm the per-host-monotone/approximate clock wording and skew-based supported examples were removed or reclassified as unsupported; grep shows the synchronized-clock language now present at all inspected locations.

If you want, I can open a review-ready PR description or add a couple of negative TypeScript compile-time tests that demonstrate structural forging of `PossibleNodeChange` fails in downstream consumers (recommended for strongly-typed clients).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a79713b05c8832eb450c766c144a975)