### PR TITLE
Clarify journal lifecycle: accept retained (uncompacted) checkpoints; migration hard-invalidation rules; possibleMaybeChanges cursor-time wording

### DIFF
--- a/docs/specs/database-lifecycle.md
+++ b/docs/specs/database-lifecycle.md
@@ -80,12 +80,34 @@ When local live state is absent, Volodyslav first asks whether the synchronizati
 
 This is **absent-state self-restoration**, not reset of an existing database. It
 restores and validates the authoritative graph together with the durable local
-`HostFingerprint`, compacted stored journal entries with their receiver-local
-indexes, `localJournalClock`, and `localJournalIndexWatermark`. The restored
-author must be the branch owner, the logical clock must cover every observed
-sequence, and the index watermark must cover every retained local index. Gaps
-are harmless. Cursor-domain identity is not synchronization content and MUST
-NOT be restored from the repository.
+`HostFingerprint`, retained stored journal entries with their receiver-local
+indexes, `localJournalClock`, and `localJournalIndexWatermark`. Absent-state
+self-restoration accepts the retained journal representation published by a
+supported synchronization checkpoint whether or not canonical compaction ran
+before that checkpoint. It preserves the collection and its indexes exactly:
+restoration neither requires `J == compact(J)` nor implicitly compacts, authors,
+re-authors, merges, or migrates journal history.
+
+Before installation, restoration validates the ordinary load structure:
+
+- the durable `HostFingerprint` belongs to the selected host/writer branch;
+- retained generation references resolve correctly;
+- retained validation causal references resolve correctly and match the
+  required key, generation, and author;
+- every referenced invalidate sequence precedes its validation sequence;
+- `localJournalClock` covers every retained or otherwise observed sequence;
+- every retained `StoredJournalEntry` has exactly one valid receiver-local
+  index, and retained indexes are unique; and
+- `localJournalIndexWatermark` covers every retained index. Index gaps are
+  allowed.
+
+Canonical compacted form, surviving same-author historical monotonicity
+evidence, and complete diagnosis of unsupported history are not restoration
+preconditions. Defensive corruption checks remain optional at the supported-
+state boundary. Canonical form is storage normalization, not validity:
+canonical does not imply valid, and non-canonical does not imply invalid. A
+supported uncompacted journal remains supported state; manually forged or
+corrupted history remains unsupported even if it happens to be canonical.
 
 Restoration resumes previously emitted durable state. It MUST NOT classify the
 restored graph as an empty-to-restored transition or emit `add` for every
@@ -205,6 +227,17 @@ Normal synchronization performs these lifecycle steps:
 9. Reopen the application database and run the migration gate before exposing it again.
 
 The merge resolves state according to graph timestamps and dependency semantics, not textual repository merge rules. Locally newer state is retained, remotely newer compatible state may be taken, and affected derived state may be invalidated so that it is recomputed from the merged dependencies. A successful merge preserves graph coherence and does not make a partially constructed target active.
+
+Checkpointing serializes the stable current supported receiver state as it
+exists. Canonical compaction is optional maintenance and is not a prerequisite
+for checkpoint publication, staging, normal open/load, migration, or
+self-restoration. A checkpoint may therefore contain compacted or uncompacted
+retained journal history. In particular, a supported trace may retain
+superseded same-coordinate entries `E1`, `E2`, and `E3`, checkpoint all three,
+and later restore all three with their original local indexes, watermark,
+durable `HostFingerprint`, and `localJournalClock`. Restoration accepts that
+state without discarding the entries that a separate `compact(J)` would remove,
+then allocates a fresh runtime cursor domain.
 
 ### 7.3 Per-host failure behavior
 

--- a/docs/specs/incremental-graph-journal-api.md
+++ b/docs/specs/incremental-graph-journal-api.md
@@ -9,9 +9,14 @@ InvalidPossibleChangeCursorError
 isInvalidPossibleChangeCursorError(object)
 ```
 
-A result means that this exact closed-classifier action may have happened to the
-semantic key after the cursor. False positives and collapse into a later
-covering possibility are allowed; action-specific false negatives are forbidden.
+A returned result means that, after the supplied receiver-local cursor, this
+receiver acquired or re-established conservative evidence requiring the stated
+closed-classifier action to be considered possible for the semantic key.
+"After the cursor" refers only to receiver-local observation/relevance order. It
+does not imply that `PossibleNodeChange.time` is later than when the cursor was
+issued: a cursor is not a wall-clock timestamp. False positives and collapse
+into a later covering possibility are allowed; action-specific false negatives
+are forbidden.
 
 `possibleMaybeChanges()` eagerly materializes the complete matching result for
 its fixed query snapshot and resolves to
@@ -161,6 +166,13 @@ is the event occurrence time. For add/edit it is necessarily the semantic
 value's `modifiedAt`; a reset with an unchanged semantic value emits no value event. There is no receiver-local
 event object, action mask, cause field, or transition timestamp.
 
+Consequently, `PossibleNodeChange.time` may precede cursor issuance. This is
+expected when old remote history is newly imported, a known witness is touched
+later, or compaction moves notification coverage to a survivor. Cursor order is
+receiver-local observation/relevance order, while `PossibleNodeChange.time`
+remains the underlying logical `JournalEntry.time`; it is not a receiver-local
+delivery or transition time.
+
 The action ordinal lets a client advance record-by-record without skipping the
 remaining projections at one index:
 
@@ -177,6 +189,51 @@ remaining projections at one index:
   entry remains identical and all five possibilities cover the actual action.
 * **Settled no-op:** receiving an already-known entry with no graph or compaction
   change neither touches it nor advances the watermark.
+
+An unknown-history trace makes the two orders explicit:
+
+```text
+t1:
+    A authors add E for K
+    E.time = t1
+
+t2:
+    B issues cursor C
+    B does not know E
+
+t3:
+    B synchronizes and first stores E
+    E receives new receiver-local localIndex > C
+
+query B since C:
+    returns conservative PossibleNodeChange(action="add", time=t1)
+```
+
+The result is after C in B's receiver-local cursor order. Its time remains t1
+because that field records the underlying logical event, not B's later
+observation/import time. There is no contradiction between those facts.
+
+A touch likewise moves only receiver-local relevance:
+
+```text
+E.time = t1
+E.localIndex = 40
+
+cursor C issued after 40
+
+later transaction touches E:
+    E.localIndex = 90
+    E.time remains t1
+
+query since C:
+    may return PossibleNodeChange(..., time=t1)
+```
+
+Here 90 answers "when did this evidence become newly relevant to this
+receiver?" and t1 answers "when did the underlying logical journal event
+occur?" The public API exposes only logical `time`; private cursor authority
+contains the receiver-local index. The issued C remains immutable, and no
+receiver-local wall timestamp is exposed.
 
 ## Cursor-coverage theorem
 

--- a/docs/specs/incremental-graph-journal-emission.md
+++ b/docs/specs/incremental-graph-journal-emission.md
@@ -66,6 +66,14 @@ same invariant when they harden stale materializations. Equivalent lifecycle
 paths MUST do likewise; there is no migration- or synchronization-specific
 journal action.
 
+Conversely, passively carrying a stale materialization whose incoming proofs
+are already absent and whose obligation is already represented by an
+outstanding retained barrier neither newly establishes nor deliberately
+reasserts hard invalidation, so it authors no barrier. Thus proof removal during
+migration `keep`/`override`, explicit `invalidate()`, and
+`create(..., "potentially-outdated")` require barriers, while an already-settled
+passive carry does not.
+
 The barrier carries the materialization's exact generation G. Its sequence is reserved from `localJournalClock` after observing the transaction snapshot and is greater than all history observed by the operation. Incoming-proof removal/reassertion, graph state, the immutable barrier, receiver-local index, and watermarks commit atomically in the same darkroom batch. Each repeated explicit hard invalidation authors a fresh barrier: each call independently reasserts that the next pull must invoke the computor. Invalidation propagated by ordinary dependency mechanics may preserve complete validity proofs and continues to author only on its actual fresh→stale transition; such freshness-only propagation does not newly establish hard invalidation.
 
 ## Synchronization emission

--- a/docs/specs/incremental-graph-journal-migrations.md
+++ b/docs/specs/incremental-graph-journal-migrations.md
@@ -66,5 +66,8 @@ A migrated node already hard-invalidated with absent incoming proofs and an
 outstanding retained barrier may be carried without another entry when migration
 makes no new proof-removal or deliberate hardening decision. Thus the global
 invariant prevents missing obligations without creating barriers for settled
-state. Compaction treats migration-authored invalidates identically, including
+state. Repeating such a passive `keep` or `override` authors no barrier, assigns
+no local index, and advances no journal clock for this reason. An explicit
+`invalidate()` is instead a deliberate reassertion and MUST author a fresh
+barrier even from this settled starting state. Compaction treats migration-authored invalidates identically, including
 the fully compacted `O(nr²)` bound.

--- a/docs/specs/migration.md
+++ b/docs/specs/migration.md
@@ -83,14 +83,35 @@ Calling the same decision twice (except for `override` and `create`) is allowed 
 
 ### Operation semantics
 
-`keep` preserves the value, freshness, timestamps, and — for up-to-date nodes — compatible incoming validity. A stale node carried through `keep` loses its incoming proofs: persisted storage does not encode whether its staleness was explicit or propagated, so it is conservatively treated as a direct invalidation root.
+`keep` preserves the value, freshness, timestamps, and — for up-to-date nodes — compatible incoming validity. When a stale node carried through `keep` has incoming proofs before migration and migration drops them, the `proofs present before → proofs absent after` transition newly establishes hard invalidation. Migration MUST atomically author a normal generation-scoped causal invalidate above all observed journal history unless a barrier authored or installed by that exact migration decision already represents it. The same rule applies to `override`.
 
-Losing those proofs is a stale→stale hardening decision, not a silent
-validity-only change. Migration MUST atomically author a normal
-generation-scoped causal invalidate above all observed journal history unless a
-barrier authored by that same migration decision already represents it.
+Within a stale `keep`/`override` region whose nodes still have incoming proofs,
+those proofs may disappear. A stale B whose dependent C is also stale can lose
+both `A⇝B` and `B⇝C` during migration, and both newly hardened nodes must
+recompute.
 
-Within a **preexisting stale `keep`/`override` region**, every stale node loses incoming proofs, so validity edges inside the region may disappear. A stale B whose dependent C is also stale loses both `A⇝B` and `B⇝C` during migration, and both nodes must recompute.
+Already-settled hard invalidation is different. If a stale node's incoming
+proofs are already absent and an outstanding retained invalidate already
+represents the obligation, a `keep` or `override` that makes no new proof-
+removal or hardening decision carries that state silently. It authors no new
+invalidate, allocates no new local index, and advances no journal clock for this
+reason. Repeated passive migrations do not manufacture barriers merely because
+the node remains stale.
+
+```text
+before migration:
+    K stale
+    incoming proofs absent
+    retained invalidate I outstanding
+
+migration.keep(K)
+
+after migration:
+    K remains stale
+    proofs remain absent
+    I still represents the existing obligation
+    no new journal entry
+```
 
 **Migration-time propagated invalidation** is different: the migration callback explicitly calls `invalidate()` on a node, and the propagation runs in memory with full provenance. In that case outgoing proofs survive and freshness-only propagation preserves validity edges.
 
@@ -104,8 +125,10 @@ The intended use case is format migration: the database version changes the seri
 
 **Explicit invalidation** removes only the explicitly named node's incoming validity proofs. Its outgoing proofs remain intact because its stored semantic value has not changed.
 
-Migration explicit invalidation authors the same causal invalidate even when the
-node was already stale. `create(..., "potentially-outdated")` likewise authors a
+Migration explicit invalidation deliberately reasserts the obligation and
+authors a fresh causal invalidate even when the node was already stale, its
+incoming proofs were already absent, and an older outstanding invalidate
+exists. `create(..., "potentially-outdated")` likewise authors a
 barrier for its new add generation because it creates a must-recompute cache.
 These entries use no migration-specific action and follow normal allocation,
 atomicity, frontier, cursor, and compaction rules.


### PR DESCRIPTION
### Motivation

- Fix a correctness bug where absent-state self-restoration was described as requiring a canonical/compacted journal representation, which contradicts the optional-compaction contract and prevents restoring supported uncompacted checkpoints.  
- Make the migration hard-invalidation rules unambiguous so repeated passive migrations do not manufacture barriers while explicit reassertions still produce fresh barriers.  
- Prevent confusion about `possibleMaybeChanges()` by clarifying that "after the cursor" refers to receiver-local cursor order and not wall-clock ordering of `PossibleNodeChange.time`.

### Description

- In `docs/specs/database-lifecycle.md` replaced compaction-implying wording with retained/retained-journal terminology, documented that absent-state self-restoration accepts the retained journal published by a supported synchronization checkpoint whether or not canonical compaction ran, and explicitly stated that restoration neither requires `J == compact(J)` nor performs implicit compaction.  
- Added an explicit list of structural validation checks performed before installing a retained checkpoint (host fingerprint ownership, generation and causal reference resolution, invalidate-before-validation ordering, `localJournalClock` coverage, unique receiver-local indexes and watermark coverage, etc.) and reiterated that defensive corruption checks remain optional at the supported-state boundary.  
- In `docs/specs/migration.md`, `docs/specs/incremental-graph-journal-migrations.md`, and `docs/specs/incremental-graph-journal-emission.md` clarified the distinction between (a) stale nodes where migration newly removes incoming proofs (which MUST author a generation-scoped `InvalidateJournalEntry` unless the exact migration decision already installed one) and (b) already-settled hard-invalidated nodes whose proofs are already absent and whose obligation is already represented by an outstanding barrier (which may be carried silently); added the explicit `migration.keep(K)` trace and reiterated that an explicit `invalidate()` always authors a fresh barrier.  
- In `docs/specs/incremental-graph-journal-api.md` clarified `possibleMaybeChanges()` language so "after the cursor" is explicitly defined as receiver-local observation/relevance ordering, stated that `PossibleNodeChange.time` remains `JournalEntry.time` and may precede cursor issuance, and added the requested unknown-history and touch traces illustrating import-after-cursor and touch-without-logical-time-change cases.  
- Preserved all existing protocol/architecture choices and invariants (no new delivery-event/causeId/receiver-local wall-time layer; no protocol redesign), and limited changes to specification text and illustrative traces across the five documentation files updated.

### Testing

- Ran `npm install` to prepare the workspace and `npm run static-analysis` (TypeScript + `eslint`) which completed successfully.  
- Verified repository and diff checks with `git diff --check` and `git status --short` with no outstanding formatting issues and a clean committed change (commit `00c0687`).  
- Performed targeted grep searches for compact/restore/compaction language to confirm lifecycle references were updated across `docs/` and validated the added examples and explanatory text; these checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a79f77d8380832e848f5a8642499555)