### PR TITLE
Decouple journal contract from Git transport

### DIFF
--- a/docs/specs/incremental-graph-journal-types.md
+++ b/docs/specs/incremental-graph-journal-types.md
@@ -295,7 +295,8 @@ Each logical runtime receiver allocates one fresh private, unforgeable
 cursor-domain identity, unique from every unrelated receiver. It is runtime
 state: not part of `JournalEntry` or durable database state, not an author
 fingerprint, journal clock, or replica name, not remotely replicated, not
-serialized into Git/synchronization state, and not user-accessible. Object
+serialized into durable or replicated synchronization state, and not
+user-accessible. Object
 identity, an unexported symbol retained only inside private runtime state, or an
 equivalent private mechanism may implement it. The identity MUST NOT appear as a
 reflectable property value on a public cursor token.

--- a/docs/specs/incremental-graph-synchronization.md
+++ b/docs/specs/incremental-graph-synchronization.md
@@ -362,10 +362,10 @@ Before journal join or conflict planning, validate each source against its own
 pre-merge journal. Every source materialization MUST resolve its source presence
 generation, a current generation-scoped value event matching its `modifiedAt`,
 and a `ValueRevision` whose event belongs to that generation. Its source
-freshness and validity must agree with the effective-validation barrier for N,G and ordinary graph
-invariants. Failure is corrupt source state and rejects that host merge; it MUST
-NOT be converted into an unusable candidate, absence, or a new destructive
-entry.
+freshness and validity must agree with the effective-validation barrier for N,G
+and ordinary graph invariants. Failure is corrupt source state and rejects that
+source merge; it MUST NOT be converted into an unusable candidate, absence, or a
+new destructive entry.
 
 Different identifiers for the same semantic key are expected, not corruption.
 For a surviving selected candidate, its source identifier is preferred. If the
@@ -406,23 +406,25 @@ Before T can become active, validate all of the following:
 10. both journal watermarks and all local-index uniqueness/inertness invariants
     hold.
 
-Failure of any check aborts that host merge, leaves the active pointer unchanged,
-and exposes no partial target. Graph merge and long validation run in inactive
-storage, not by broadening the active-replica darkroom.
+Failure of any check aborts that source merge, leaves the active pointer
+unchanged, and exposes no partial target. Graph merge and long validation run in
+inactive storage, not by broadening the active-replica darkroom.
 
-### Cutover and sequential hosts
+### Cutover and sequential sources
 
 T becomes active whenever authoritative graph state, logical journal contents,
 or receiver-local entry indexes change; a journal-only import therefore still
 uses durable inactive construction and atomic pointer cutover. Cutover may be
 skipped only when all three are unchanged.
 
-Normal synchronization may process multiple host branches sequentially. Each
-host merge reads the active result of prior successful merges, validates its own
-complete result before cutover, and cleans its staging storage afterward. A
-failed host is recorded and does not roll back successful hosts; processing may
-continue and failures are reported together. This sequential lifecycle does not
-imply multi-host associativity, order independence, or all-to-all communication.
+Normal synchronization may process multiple source snapshots sequentially,
+regardless of how a transport discovers or delivers them. Each source merge
+reads the active result of prior successful merges, validates its own complete
+result before cutover, and cleans its staging storage afterward. A failed source
+is recorded and does not roll back successful sources; processing may continue
+and failures are reported together. This sequential lifecycle does not imply
+multi-source associativity, order independence, or all-to-all communication,
+and it requires no repository, branch, or other transport-specific container.
 
 Controlled reset is not this merge algorithm. Existing-live reset does not join
 the selected source journal. It atomically reconciles only source semantic


### PR DESCRIPTION
### Motivation
- Remove transport-specific vocabulary that couples the journal and synchronization contracts to Git repositories and branches so the spec applies to databases, object stores, removable media, and peer-to-peer transports. 
- Make explicit that cursor-domain identity and receiver-local indexes are runtime or durable/replicated state and must not be interpreted or serialized as repository artifacts.

### Description
- In `docs/specs/incremental-graph-journal-types.md` replaced the phrase about being "serialized into Git/synchronization state" with a transport-neutral formulation referencing durable or replicated synchronization state and clarified cursor-domain identity remains non-serializable. 
- In `docs/specs/incremental-graph-synchronization.md` renamed and reframed host/branch wording to use transport-neutral terms such as "source" and "source merge" and adjusted surrounding validation language for clarity. 
- Rewrote the sequential-processing paragraph to state normal synchronization may process multiple source snapshots sequentially regardless of how a transport delivers them and to explicitly require no repository, branch, or other transport-specific container.

### Testing
- Ran `npm install`, which completed (install warnings only) and produced installed dependencies. 
- Ran `npm run static-analysis` (which runs `tsc` and `eslint`) and it completed without errors. 
- Used `rg` to confirm the prohibited phrases (`Git/synchronization state`, `multiple host branches sequentially`) are no longer present in the edited spec files. 
- Ran `git diff --check` and `git status --short` to ensure there are no diff/whitespace or working-tree issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7c25ed9d24832ea9a8ff76f9ba272e)