### PR TITLE
Strengthen persisted NodeKey contract; make PossibleNodeChange deeply immutable; preserve process-local cursors

### DIFF
--- a/docs/specs/incremental-graph-journal-api.md
+++ b/docs/specs/incremental-graph-journal-api.md
@@ -182,7 +182,8 @@ For every qualifying stored entry E:
 
 ```text
 PossibleActions(E) = { add, edit, delete, invalidate, validate }
-PossibleNodeChange.time = E.entry.time
+PossibleNodeChange.time = fromUnixTimestamp(E.entry.time)
+toUnixTimestamp(PossibleNodeChange.time) = E.entry.time
 ```
 
 All five records use E's semantic key and immutable occurrence time. The local

--- a/docs/specs/incremental-graph-journal-api.md
+++ b/docs/specs/incremental-graph-journal-api.md
@@ -54,6 +54,25 @@ interface BaselinePossibleNodeChange {
 }
 ```
 
+Every returned `PossibleNodeChange` is reachably immutable, not merely
+compile-time `readonly`. Construction MUST isolate the visible payload from
+mutable query, journal, and caller-owned sources by a deep semantic snapshot or
+by safely sharing an already deeply immutable decoded `JournalEntry.key`. The
+token object, `bindings` array, and every array or record nested anywhere in a
+binding MUST be frozen or otherwise impossible for a caller to mutate. Its
+visible semantic key therefore remains stable permanently. A caller MUST NOT be
+able to mutate retained journal state through a returned token.
+
+Implementation tests MUST attempt at least `change.bindings.push(...)`,
+assignment to `change.bindings[0]`, assignment to a nested record property, and
+`push(...)` on a nested array. Each attempt must fail or have no effect. After
+all attempts, the change still describes its original `NodeKey`, the exact
+token remains valid with its original private cursor registration, retained
+journal history is unchanged, and later queries observe the original semantic
+key. Tests MUST also mutate nested source bindings after authoring a journal key
+and prove that decoding the retained `JournalEntry.key` returns the pre-mutation
+value.
+
 `PossibleNodeChange.time` is the application-facing `DateTime`
 `fromUnixTimestamp(E.time)` for its underlying journal entry E. The conversion
 is exact at millisecond precision, so

--- a/docs/specs/incremental-graph-journal-types.md
+++ b/docs/specs/incremental-graph-journal-types.md
@@ -71,6 +71,15 @@ InvalidationContext = Map<DatabaseFingerprint, JournalEntryId>
 JournalEntryId(E) = (E.sequence, E.author)
 ```
 
+`JournalEntry.key` remains exactly the existing `NodeKey` semantic-key type; no
+journal-specific key type or duplicated `{nodeName, bindings}` payload exists.
+The canonical, reversible, and durable key contract is specified in
+[`keys-design.md`](keys-design.md#canonical-reversible-semantic-identity).
+Authoring deeply snapshots the key's semantic contents (or provides equivalent
+alias isolation) and makes the key and every nested array/record immutable for
+the lifetime of the entry. Later mutation of source bindings cannot alter the
+entry. Import preserves the same immutable logical key unchanged.
+
 Entry IDs are ordered lexicographically, sequence first and author second.
 `JournalEntry.time` is always the real wall-clock time at which that journal
 event occurred. For add/edit, that occurrence is the semantic value creation or

--- a/docs/specs/incremental-graph-journal-types.md
+++ b/docs/specs/incremental-graph-journal-types.md
@@ -79,6 +79,9 @@ Authoring deeply snapshots the key's semantic contents (or provides equivalent
 alias isolation) and makes the key and every nested array/record immutable for
 the lifetime of the entry. Later mutation of source bindings cannot alter the
 entry. Import preserves the same immutable logical key unchanged.
+Restored or imported entries MUST establish this immutable representation before
+decoded key contents can be shared with public results; already-immutable data
+may be safely shared without an unnecessary additional copy.
 
 Entry IDs are ordered lexicographically, sequence first and author second.
 `JournalEntry.time` is always the real wall-clock time at which that journal

--- a/docs/specs/incremental-graph.md
+++ b/docs/specs/incremental-graph.md
@@ -24,7 +24,14 @@ This document provides a formal specification for the incremental graph's operat
 
 **TERM-07 (NodeInstance):** A specific node identified by a `NodeName` and `BindingEnvironment`. Conceptually: `{ nodeName: NodeName, bindings: BindingEnvironment }`. Notation: `nodeName@bindings`.
 
-**TERM-08 (NodeKey):** A string key used for storage, derived from `(nodeName, bindings)`.
+**TERM-08 (NodeKey):** The canonical semantic identity of one concrete node
+instance, derived from its `NodeName` and `BindingEnvironment`. Two valid node
+instances have equal `NodeKey` values if and only if their `NodeName` values are
+equal and their bindings are position-wise equal under `isEqual`. A `NodeKey`
+is self-contained and reversibly determines that same `NodeName` and
+`BindingEnvironment`. `NodeKeyString` names its serialized string
+representation where persistence or indexing requires one; `NodeIdentifier`
+is instead the persisted storage identity of one materialization.
 
 **TERM-09 (NodeValue):** Computed value at a node (always a `ComputedValue`). The term `NodeValue` is an alias for `ComputedValue` in the context of stored node values.
 
@@ -41,7 +48,7 @@ A materialization persists across restarts unless an explicit closure-preserving
 
 **TERM-11 (Computor):** Async function: `(inputs: Array<ComputedValue>, oldValue: ComputedValue | undefined, bindings: Array<ConstValue>) => Promise<ComputedValue | Unchanged>`.
 
-**DEF-OUTCOMES-01 (Outcomes Set):** For any schema node definition and arguments `(inputs, oldValue, bindings)`, `Outcomes(nodeName, bindings, inputs, oldValue) ⊆ ComputedValue` (equivalently `Outcomes(NodeInstance, inputs, oldValue)`) represents the set of all semantic values that could be produced by the computor in any permitted execution context. This set may be infinite. `Unchanged` is not part of `Outcomes`—it is an optimization sentinel only. `NodeKey` may be used as a storage key derived from the node instance, but it is not a semantic argument to `Outcomes`.
+**DEF-OUTCOMES-01 (Outcomes Set):** For any schema node definition and arguments `(inputs, oldValue, bindings)`, `Outcomes(nodeName, bindings, inputs, oldValue) ⊆ ComputedValue` (equivalently `Outcomes(NodeInstance, inputs, oldValue)`) represents the set of all semantic values that could be produced by the computor in any permitted execution context. This set may be infinite. `Unchanged` is not part of `Outcomes`—it is an optimization sentinel only. `NodeKey` identifies the node instance but is not a semantic argument to `Outcomes`; storage requiring a serialized key uses `NodeKeyString`.
 
 **DEF-COMP-INVOKE-01 (Computor Invocation):** When the operational semantics "invokes a computor", it nondeterministically selects `r ∈ Outcomes(...)` and treats `r` as the returned value of the Promise. In implementation, this corresponds to executing the computor function, which may produce different results on different invocations for nondeterministic computors.
 

--- a/docs/specs/keys-design.md
+++ b/docs/specs/keys-design.md
@@ -31,7 +31,16 @@ Public concrete-node operations remain `NodeKey`-addressed (`head + args` / `Nod
 
 - Public callers and HTTP routes provide semantic keys (`head + args` / `NodeKey`).
 - At public method entry, `IncrementalGraph` resolves to `NodeIdentifier` immediately.
-- All logic below that boundary (storage, recompute, invalidation propagation, migration, sync, render, scan) is identifier-native.
+- Concrete graph-state and materialization logic below that boundary is
+  identifier-native. This includes storage, recomputation, invalidation
+  propagation, graph migration payloads, synchronization of graph state, and
+  render/scan graph-state paths.
+
+The journal is a distinct semantic-history subsystem. Its logical
+`JournalEntry.key` deliberately remains `NodeKey`, allowing history to be
+grouped by semantic node and projected back to public `nodeName` and `bindings`
+after both the materialization and its `NodeIdentifier` disappear. This is not
+`NodeKey`-addressed graph state.
 
 `nodeKeyToId(nodeKey)` and `nodeIdToKey(id)` are internal/lower-level translation helpers,
 not public `IncrementalGraph` methods and not HTTP API operations.
@@ -45,7 +54,9 @@ await graph.pull(head, args);
 await graph.invalidate(head, args);
 ```
 
-Internal workflow converts once at the boundary, then stays identifier-native.
+Internal graph-state workflow converts once at the boundary, then stays
+identifier-native. Journal authoring may retain the semantic `NodeKey` as the
+entry's immutable logical key.
 
 No mixed model is allowed where storage-layer concrete-node operations remain `NodeKey`-addressed after boundary conversion.
 
@@ -167,6 +178,10 @@ metadata whose contract requires them:
 
 - `identifiers_keys_map`, as the materialized-node identity bijection; and
 - immutable `JournalEntry.key`, as retained semantic journal history.
+
+`JournalEntry.key` has logical type `NodeKey`. Its persistent representation may
+use the implementation's `NodeKeyString` serialization, without making either
+form a graph-state address.
 
 The second location does not make journal entries graph state and does not
 restore key-addressed graph records. In particular, `values[id]`,
@@ -306,19 +321,34 @@ the key, and `JournalEntry.key` is never derived from a selected identifier.
 ### Current encoding audit
 
 The current implementation serializes `{head,args}` with JSON. That byte layout
-is not normative. It round-trips ordinary finite numbers, strings, booleans,
-arrays, and records, but it does not yet satisfy the complete contract above:
+is not normative. Record property order is semantically significant because
+IncrementalGraph `isEqual` compares record keys positionally. A `NodeKey`
+encoding MUST preserve that order and MUST NOT sort record properties if doing
+so would identify records which `isEqual` considers unequal. The current JSON
+representation's preservation of object enumeration order is compatible with
+this part of the contract.
 
-- record property insertion order affects `JSON.stringify`, although
-  `isEqual` treats records with the same properties as equal, so serialization
-  is not canonical for those values; and
-- the declared `ConstValue` number domain does not exclude `NaN`, positive
-  infinity, or negative infinity. JSON converts these values to `null`, which
-  is not injective and changes semantic identity.
+The JSON representation does not yet satisfy the complete contract because the
+declared `ConstValue` number domain does not exclude `NaN`, positive
+infinity, or negative infinity. JSON converts these values to `null`, which
+is not injective and changes semantic identity. `[NaN]`, `[Infinity]`, and
+`[-Infinity]` therefore all serialize with `null` in the corresponding position
+and cannot decode as their original, semantically distinct number values. The
+target contract continues to cover the existing `ConstValue` domain; a later
+encoding must distinguish every valid value losslessly.
 
-These are implementation gaps to be closed when the target NodeKey contract is
-implemented. They do not narrow or redefine `ConstValue`, and they do not make
-today's JSON representation normative.
+There is a separate comparator mismatch in the current implementation:
+`compareConstValue` sorts record keys, and therefore `compareConstValue(a,b) ===
+0` (and potentially `compareNodeKey(a,b) === 0`) can hold for records whose
+property orders make them unequal under normative `isEqual`. `NodeKey` semantic
+equality is defined by IncrementalGraph `isEqual`, not comparator zero. A
+journal implementation MUST NOT use comparator zero as a same-key test unless
+the comparator has first been made consistent with normative semantic equality.
+
+The non-finite-number serialization and comparator-equivalence mismatches are
+implementation gaps to be closed when the target `NodeKey` contract is
+implemented. They do not narrow or redefine `ConstValue`, redefine `isEqual`,
+or make today's JSON representation normative.
 
 ### last_node_index
 

--- a/docs/specs/keys-design.md
+++ b/docs/specs/keys-design.md
@@ -16,8 +16,9 @@ node addressing. It describes the model as it is meant to be.
 
 ## Terms
 
-- **NodeKey**: the schema-derived identity of a concrete node instance, based on
-  `(head, args)`
+- **NodeKey**: the canonical semantic identity of a concrete node instance,
+  derived from `(head, args)`; in implementation documents `NodeKeyString`
+  denotes its serialized representation where a string representation is needed
 - **NodeIdentifier**: the deterministic persisted identifier attached to a materialized node
 - **graph-state sublevels**: `values`, `freshness`, `valid`,
   `timestamps`
@@ -158,7 +159,19 @@ This applies to:
 - validity sets are sorted by `NodeIdentifier` (lexicographic), never by `NodeKey`
 - render/scan paths use direct identifier path segments
 - graph-state path encoding/decoding must not reconstruct `NodeKey` values
-- `NodeKeyString` may persist only inside explicit lookup metadata (`identifiers_keys_map`)
+- `NodeKey` and `NodeKeyString` MUST NOT address graph-state sublevels or occur
+  inside graph validity/storage structures
+
+Persistent semantic keys are permitted only in explicit semantic-identity
+metadata whose contract requires them:
+
+- `identifiers_keys_map`, as the materialized-node identity bijection; and
+- immutable `JournalEntry.key`, as retained semantic journal history.
+
+The second location does not make journal entries graph state and does not
+restore key-addressed graph records. In particular, `values[id]`,
+`freshness[id]`, `timestamps[id]`, and `valid[id]` remain exclusively
+`NodeIdentifier`-addressed.
 
 ### Lookup metadata
 
@@ -171,7 +184,10 @@ persisted identity:
 These functions operate on the `/${current_replica}/global/identifiers_keys_map` database value.
 Here `${current_replica}` is the replica name of the current database instance, for example `x` or `y`.
 
-`NodeKeyString` may remain persisted only in this lookup table at `/${current_replica}/global/identifiers_keys_map`.
+Within graph storage, `NodeKeyString` may remain persisted only in this lookup
+table at `/${current_replica}/global/identifiers_keys_map`. The journal's
+separate permitted use is `JournalEntry.key`; it is semantic history rather
+than graph-state addressing.
 
 The map is the materialized-node identity table, with a strict invariant:
 
@@ -209,8 +225,100 @@ Delete removes:
 - `nodeKeyToId(nodeKey)`
 - `nodeIdToKey(id)`
 
+It does not remove retained journal entries carrying that `NodeKey`.
+
 Migration preserves identifiers for `keep`, `override`, and `invalidate`, and allocates
 fresh identifiers for `create` using the same fingerprint/index scheme.
+
+## Canonical, reversible semantic identity
+
+For every valid semantic node instance, a compliant `NodeKey` is self-contained:
+it deterministically recovers the same `NodeName` and binding environment. The
+physical encoding is implementation-defined, but an operation equivalent to
+`decodeNodeKey` MUST satisfy:
+
+```text
+decodeNodeKey(makeNodeKey(nodeName, bindings)) ==semantic
+    { nodeName, bindings }
+```
+
+Semantic equality means the same `NodeName`, equal binding lengths, and
+`isEqual(decoded.bindings[i], bindings[i])` at every position. Decoding MUST NOT
+consult `identifiers_keys_map`, a `NodeIdentifier`, or current materialization
+state.
+
+For any valid node instances A and B:
+
+```text
+A ==semantic B  iff  NodeKey(A) == NodeKey(B)
+```
+
+Thus semantically equal instances produce the same canonical key and
+semantically unequal instances produce different keys, including when bindings
+contain nested arrays or records. Equality here is key-value equality, never
+JavaScript object identity. Journal same-key grouping, per-key history,
+`presenceHead(K)`, `candidateEvents(K)`, `notificationWitness(K)`, and
+compaction coordinates rely on this equivalence.
+
+Once K is persisted in supported journal history, every later supported
+implementation and database migration MUST decode K as exactly the same
+`(nodeName, bindings)`. A migration MUST NOT silently reinterpret K or rewrite
+an immutable `JournalEntry.key` merely because an internal encoding changes.
+Supported future implementations therefore preserve decoding compatibility for
+persisted keys. Deliberately changing the encoding requires a separately
+specified compatibility/versioning mechanism.
+
+Authoring a journal entry MUST take a deep semantic snapshot of its `NodeKey`,
+or otherwise guarantee equivalent isolation, so no caller-owned array or record
+remains a mutable alias. The key and every publicly reachable nested value are
+immutable for the entry's lifetime. Remote import preserves that same logical
+key unchanged.
+
+### De-materialization trace
+
+```text
+K = NodeKey(foo, [{ id: 7 }])
+
+t1:
+    K is materialized
+    identifiers_keys_map contains K <-> N
+    the journal retains E with E.key = K
+
+t2:
+    K is de-materialized
+    graph-state records for N are deleted
+    the identifiers_keys_map entry for K/N is deleted
+    E remains retained
+
+later:
+    possibleMaybeChanges() processes E
+    decodeNodeKey(E.key)
+        -> nodeName = foo
+        -> bindings = [{ id: 7 }]
+```
+
+The last step uses no `NodeIdentifier`, `identifiers_keys_map`, or current graph
+materialization. A `NodeIdentifier` is the storage identity of a materialization
+and may disappear with it; a `NodeKey` is semantic identity and may outlive it
+in journal history. Synchronization may reconcile identifiers without changing
+the key, and `JournalEntry.key` is never derived from a selected identifier.
+
+### Current encoding audit
+
+The current implementation serializes `{head,args}` with JSON. That byte layout
+is not normative. It round-trips ordinary finite numbers, strings, booleans,
+arrays, and records, but it does not yet satisfy the complete contract above:
+
+- record property insertion order affects `JSON.stringify`, although
+  `isEqual` treats records with the same properties as equal, so serialization
+  is not canonical for those values; and
+- the declared `ConstValue` number domain does not exclude `NaN`, positive
+  infinity, or negative infinity. JSON converts these values to `null`, which
+  is not injective and changes semantic identity.
+
+These are implementation gaps to be closed when the target NodeKey contract is
+implemented. They do not narrow or redefine `ConstValue`, and they do not make
+today's JSON representation normative.
 
 ### last_node_index
 


### PR DESCRIPTION
### Motivation

- Resolve review findings to keep `JournalEntry.key` exactly `NodeKey` while making journal-retained keys durable and decodable without consulting materialized graph state.
- Clarify the distinction between semantic keys and storage identifiers so journal history can persist semantic `NodeKey` values while graph-state sublevels remain `NodeIdentifier`-addressed.
- Ensure `PossibleNodeChange` tokens are reachably immutable and preserve the existing process-local, non-serializable cursor architecture.

### Description

- Spec updates: `docs/specs/keys-design.md` now treats `NodeKey` as the canonical, reversible semantic identity, explicitly permits `NodeKey` persistence inside `JournalEntry.key`, prohibits `NodeKey`/`NodeKeyString` from addressing graph-state sublevels, documents the de-materialization trace, and records current JSON-encoding gaps (record key order; non-finite numbers) without making the JSON layout normative.
- Journal types: `docs/specs/incremental-graph-journal-types.md` now asserts `JournalEntry.key` remains exactly `NodeKey`, requires deep snapshot/alias isolation for authored keys, and clarifies immutability and import semantics.
- Journal API: `docs/specs/incremental-graph-journal-api.md` now requires every returned `PossibleNodeChange` to be reachably immutable (token object, `bindings`, and all nested arrays/records frozen or otherwise immutable) and adds required mutation/aliasing verification expectations for implementations.
- Scope and wording: updated PR wording to state this is a specification-led journal PR that also includes supporting prerequisite/runtime-invariant work and to explicitly state that `PossibleNodeChange` cursor tokens are process-local, non-serializable, same-process cutovers preserve domain, runtime recreation does not preserve authority, and computors receive no journal/bootstrap cursor.
- No new semantic key types were introduced and no duplication of `{nodeName, bindings}` in journal entries was added; graph-state addressing by `NodeIdentifier` is preserved.

### Testing

- Ran `npm install` and `npm run static-analysis` (TypeScript compile + `eslint`); these completed successfully.
- Executed the spec/verifier scripts `python3 scripts/verify-journal-spec-model.py` and `python3 scripts/verify-nighttime-locking-model.py`; their verification runs completed without failures and reported coverage/consistency checks (cursor-domain, compaction closure, projection preservation, locking checks) as passing in the local run.
- Performed repository-wide consistency sweep (`rg`) for terms and contracts (`NodeKey`, `NodeKeyString`, `NodeIdentifier`, `identifiers_keys_map`, `JournalEntry.key`, `serializeNodeKey`, `deserializeNodeKey`, `possibleMaybeChanges`, `bindings`, `immutable`, `readonly`, `process-local`, `non-serializable`, `specification-only`) and resolved the documented contradictions by the edits above.
- Ran `git diff --check` and verified no whitespace/content issues and committed the change as "Strengthen persisted NodeKey journal contract".

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7cb1244920832e8c1ce156722ffc12)