### PR TITLE
Align verifier NodeKey encoding with production and remove stale cursor authority wording

### DIFF
--- a/backend/tests/node_key_serialization_fixture.test.js
+++ b/backend/tests/node_key_serialization_fixture.test.js
@@ -1,0 +1,16 @@
+const nodeKeyVectors = require("../../scripts/fixtures/node-key-serialization.json");
+const {
+    serializeNodeKey,
+    stringToNodeName,
+} = require("../src/generators/incremental_graph/database/node_key");
+
+describe("shared NodeKey serialization vectors", () => {
+    test.each(nodeKeyVectors)("production serializes $description canonically", vector => {
+        const serialized = serializeNodeKey({
+            head: stringToNodeName(vector.nodeName),
+            args: vector.bindings,
+        });
+
+        expect(serialized).toBe(vector.serialized);
+    });
+});

--- a/docs/specs/database-lifecycle.md
+++ b/docs/specs/database-lifecycle.md
@@ -118,7 +118,7 @@ canonical does not imply valid, and non-canonical does not imply invalid. A
 supported uncompacted journal remains supported state; manually forged or
 corrupted history remains unsupported even if it happens to be canonical.
 
-Restoration resumes previously emitted durable state and MUST NOT classify the restored graph as an empty-to-restored transition. Durable encoded cursors preserve their exact immutable position and authority across restart.
+Restoration resumes previously emitted durable state and MUST NOT classify the restored graph as an empty-to-restored transition. Durable encoded cursors preserve their exact immutable position and coverage metadata across restart, so each encoded cursor remains valid wherever its issuer coverage requirement is satisfied.
 
 The supported source is the host's current synchronized state, not an arbitrary historical checkpoint. Restoring an older checkpoint under the same author/clock is unsupported unless a future recovery protocol supplies anti-rollback state or assigns a new durable database fingerprint. Any failure to query, obtain, validate, or install the expected current state is fatal; startup does not silently fall back to an empty database.
 

--- a/docs/specs/incremental-graph-journal-migrations.md
+++ b/docs/specs/incremental-graph-journal-migrations.md
@@ -29,7 +29,8 @@ A supported migration MUST accept structurally valid uncompacted history.
 Non-canonical representation is not corruption and cutover does not require
 either journal to equal its compact form. Migration never runs implicit logical
 or notification compaction and a journal-silent migration preserves all entries,
-records, coordinates, allocators, watermark, frontier, and token authority.
+records, coordinates, allocators, watermark, frontier, and cursor continuation
+validity.
 Independent maintenance compaction remains a separate operation.
 
 For example, several superseded logical entries and notification occurrences may

--- a/docs/specs/incremental-graph.md
+++ b/docs/specs/incremental-graph.md
@@ -475,7 +475,7 @@ function makeIncrementalGraph(
 
 `PossibleNodeChange` and `BaselinePossibleNodeChange` are opaque nominal public
 types branded at compile time by a module-private, unexported `unique symbol`
-(or an equivalent non-forgeable type declaration). That symbol is not a runtime snapshot carrier. Cursor authority uses the canonical versioned journal-owned codec and durable opaque metadata. The former combines visible readonly `{nodeName, bindings, action, time}` with an immutable cursor position; the latter is universal baseline authority. External TypeScript callers cannot construct either type structurally, and raw indexes, issuer metadata, watermarks, and ordinals are not ordinary public fields. The complete type,
+(or an equivalent non-forgeable type declaration). That symbol is not a runtime snapshot carrier. Cursor meaning uses the canonical versioned journal-owned codec and durable opaque metadata. A possible-change cursor combines visible readonly `{nodeName, bindings, action, time}` with an immutable cursor position; the baseline is a universal before-all sentinel. External TypeScript callers cannot construct either type structurally, and raw indexes, issuer metadata, watermarks, and ordinals are not ordinary public fields. The complete type,
 snapshot, and runtime-validation contract is in
 `incremental-graph-journal-api.md`.
 

--- a/scripts/fixtures/node-key-serialization.json
+++ b/scripts/fixtures/node-key-serialization.json
@@ -1,0 +1,76 @@
+[
+  {
+    "description": "comma in one binding",
+    "nodeName": "node",
+    "bindings": [
+      "a,b"
+    ],
+    "serialized": "{\"head\":\"node\",\"args\":[\"a,b\"]}"
+  },
+  {
+    "description": "comma across two bindings",
+    "nodeName": "node",
+    "bindings": [
+      "a",
+      "b"
+    ],
+    "serialized": "{\"head\":\"node\",\"args\":[\"a\",\"b\"]}"
+  },
+  {
+    "description": "single empty binding",
+    "nodeName": "node",
+    "bindings": [
+      ""
+    ],
+    "serialized": "{\"head\":\"node\",\"args\":[\"\"]}"
+  },
+  {
+    "description": "no bindings",
+    "nodeName": "node",
+    "bindings": [],
+    "serialized": "{\"head\":\"node\",\"args\":[]}"
+  },
+  {
+    "description": "delimiters and escapes",
+    "nodeName": "node|:,\"\\",
+    "bindings": [
+      "|",
+      ":",
+      ",",
+      "\"",
+      "\\",
+      "|:,\"\\"
+    ],
+    "serialized": "{\"head\":\"node|:,\\\"\\\\\",\"args\":[\"|\",\":\",\",\",\"\\\"\",\"\\\\\",\"|:,\\\"\\\\\"]}"
+  },
+  {
+    "description": "ordinary Unicode",
+    "nodeName": "nøde",
+    "bindings": [
+      "café"
+    ],
+    "serialized": "{\"head\":\"nøde\",\"args\":[\"café\"]}"
+  },
+  {
+    "description": "lone high surrogate",
+    "nodeName": "node",
+    "bindings": [
+      "\ud800"
+    ],
+    "serialized": "{\"head\":\"node\",\"args\":[\"\\ud800\"]}"
+  },
+  {
+    "description": "lone low surrogate",
+    "nodeName": "\udfff",
+    "bindings": [],
+    "serialized": "{\"head\":\"\\udfff\",\"args\":[]}"
+  },
+  {
+    "description": "UTF-16 surrogate pair",
+    "nodeName": "node",
+    "bindings": [
+      "😀"
+    ],
+    "serialized": "{\"head\":\"node\",\"args\":[\"😀\"]}"
+  }
+]

--- a/scripts/verify-journal-spec-model.py
+++ b/scripts/verify-journal-spec-model.py
@@ -7,6 +7,7 @@ UnixTimestamp values, not arbitrary signed 64-bit persistence values.
 from dataclasses import dataclass
 from itertools import product
 import json
+from pathlib import Path
 
 ACTIONS = ("add", "edit", "delete", "invalidate", "validate")
 
@@ -569,11 +570,35 @@ class InvalidPossibleChangeCursorError(Exception):
 def valid_fingerprint(value):
     return len(value) == 16 and value.isascii() and value.isalpha() and value.islower()
 
+def js_compatible_string(value):
+    """Combine UTF-16 surrogate pairs as JavaScript does before serialization."""
+    result = []
+    index = 0
+    while index < len(value):
+        codepoint = ord(value[index])
+        if 0xD800 <= codepoint <= 0xDBFF and index + 1 < len(value):
+            following = ord(value[index + 1])
+            if 0xDC00 <= following <= 0xDFFF:
+                result.append(chr(0x10000 + ((codepoint - 0xD800) << 10) + following - 0xDC00))
+                index += 2
+                continue
+        result.append(value[index])
+        index += 1
+    return "".join(result)
+
 def node_key(node_name, bindings):
     # Mirrors production serializeNodeKey(): property order is head then args,
-    # and JSON.stringify emits compact JSON while preserving Unicode text.
-    return json.dumps({"head": node_name, "args": list(bindings)},
-                      separators=(",", ":"), ensure_ascii=False)
+    # JSON.stringify emits compact JSON, preserves Unicode text, and escapes
+    # lone UTF-16 surrogates using lowercase hexadecimal escape sequences.
+    serialized = json.dumps({
+        "head": js_compatible_string(node_name),
+        "args": [js_compatible_string(binding) for binding in bindings],
+    }, separators=(",", ":"), ensure_ascii=False)
+    return "".join(
+        "\\u" + format(ord(character), "04x")
+        if 0xD800 <= ord(character) <= 0xDFFF else character
+        for character in serialized
+    )
 
 # Semantic addresses that delimiter-based encodings conflate remain distinct.
 assert node_key("node", ("a,b",)) != node_key("node", ("a", "b"))
@@ -584,6 +609,13 @@ assert node_key("node|:,\"\\", delimiter_bindings) == (
     '{"head":"node|:,\\"\\\\","args":["|",":",",","\\"","\\\\","|:,\\"\\\\"]}'
 )
 assert node_key("nøde", ("café",)) == '{"head":"nøde","args":["café"]}'
+node_key_vectors = json.loads(
+    (Path(__file__).parent / "fixtures" / "node-key-serialization.json").read_text(encoding="utf-8")
+)
+assert all(
+    node_key(vector["nodeName"], tuple(vector["bindings"])) == vector["serialized"]
+    for vector in node_key_vectors
+)
 
 def valid_record(record):
     return record.key == node_key(record.node_name, record.bindings)

--- a/scripts/verify-journal-spec-model.py
+++ b/scripts/verify-journal-spec-model.py
@@ -570,7 +570,20 @@ def valid_fingerprint(value):
     return len(value) == 16 and value.isascii() and value.isalpha() and value.islower()
 
 def node_key(node_name, bindings):
-    return node_name + ":" + ",".join(bindings)
+    # Mirrors production serializeNodeKey(): property order is head then args,
+    # and JSON.stringify emits compact JSON while preserving Unicode text.
+    return json.dumps({"head": node_name, "args": list(bindings)},
+                      separators=(",", ":"), ensure_ascii=False)
+
+# Semantic addresses that delimiter-based encodings conflate remain distinct.
+assert node_key("node", ("a,b",)) != node_key("node", ("a", "b"))
+assert node_key("node", ("",)) != node_key("node", ())
+delimiter_bindings = ("|", ":", ",", '"', "\\", "|:,\"\\")
+assert len({node_key("node", (binding,)) for binding in delimiter_bindings}) == len(delimiter_bindings)
+assert node_key("node|:,\"\\", delimiter_bindings) == (
+    '{"head":"node|:,\\"\\\\","args":["|",":",",","\\"","\\\\","|:,\\"\\\\"]}'
+)
+assert node_key("nøde", ("café",)) == '{"head":"nøde","args":["café"]}'
 
 def valid_record(record):
     return record.key == node_key(record.node_name, record.bindings)


### PR DESCRIPTION
### Motivation

- Ensure the bounded Python verifier's NodeKey encoding is bit-for-bit compatible with production `serializeNodeKey()` to avoid collisions and behavioral divergence. 
- Remove leftover security-flavored terminology (e.g. “token authority”, “cursor authority”) and replace it with precise cursor/continuation/coverage language to reflect the intended non-authenticating semantics.

### Description

- Replace the ad-hoc Python `node_key()` with a JSON encoding that mirrors production `serializeNodeKey()` exactly using `json.dumps({...}, separators=(",",":"), ensure_ascii=False)` and add a nearby comment stating it mirrors the production representation. 
- Add explicit verifier assertions that prove collision-safety for cases including `("a,b",)` vs `("a","b")`, empty-binding vs no-binding, various delimiter characters (pipe, colon, comma, quotes, backslash and combinations), and representative Unicode/escaping examples. 
- Update specification text to remove stale authority phrasing and replace with precise language such as cursor meaning, cursor continuation validity, coverage metadata, and baseline sentinel in `docs/specs/incremental-graph-journal-migrations.md`, `docs/specs/database-lifecycle.md`, and `docs/specs/incremental-graph.md`. 
- Add tests/comments so the verifier documents that its `node_key()` semantics correspond to the canonical production serializer rather than inventing a second representation. 

### Testing

- Ran `scripts/verify-journal-spec-model.py` and observed that the exhaustive bounded journal checks passed successfully. 
- Ran `scripts/verify-nighttime-locking-model.py` and observed that nighttime locking/dependency-stability checks passed successfully. 
- Ran `npm run static-analysis` and `npm install`; static analysis completed (the environment produced dependency warnings but no lint/type errors). 
- Performed repository grep for stale phrases with `rg -n -i "(cursor|token|baseline).*authorit"` and inspected matches to confirm removed/updated occurrences; no remaining security-flavored cursor/token authority phrases remain in spec locations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a80256b7c88832e80c335344aae83e0)