### PR TITLE
Repair journal spec: JS-identical NodeKey, allocator semantics, carrier trace, and reset wording

### DIFF
--- a/docs/specs/database-lifecycle.md
+++ b/docs/specs/database-lifecycle.md
@@ -247,7 +247,9 @@ Existing-live controlled reset is an authoritative semantic graph reconciliation
 for a stable receiver snapshot R and structurally valid, schema-compatible source
 snapshot S, its postcondition is `SemanticGraph(reset(R,S)) == SemanticGraph(S)`.
 The semantic target, keyed by `NodeKey`, consists only of materialization
-presence, `ComputedValue`, freshness, and validity relationships. Source logical journal history, host and physical identity, identifiers, timestamps, and allocator ownership are not semantic target state.
+presence, `ComputedValue`, freshness, and validity relationships. Source logical
+journal history, host and physical identity, identifiers, timestamps, and
+allocator ownership are not semantic target state.
 
 Reset does **not** join source logical history as graph authority. It retains
 receiver logical authority and authors receiver logical entries only for
@@ -255,22 +257,23 @@ committed before-to-final semantic transitions. Differences solely in source
 logical history cause no graph transition or receiver logical entry.
 
 Notification infrastructure is independent of logical authority. Reset merges
-source notification records, source high-watermark, source coverage frontier,
+source notification records, source high-watermark, and source coverage frontier,
 even when the semantic graph is already
 equal. Thus a graph-silent reset may still change notification records,
 high-watermark, frontier, or notification allocator. Once
 those maxima and coordinates are incorporated, repeating the identical reset is
 silent.
 Absent-state self-restoration is different: it resumes this host's durable
-graph, journal, and clock rather than reconciling an existing live receiver.
+graph, logical and notification journals, and both allocator clocks rather than
+reconciling an existing live receiver.
 
 The operation runs against stable receiver and source snapshots in an inactive
 target. It validates source structure and schema compatibility, maps source
 identifiers to semantic keys, retains receiver identifiers for surviving keys,
 allocates ordinary receiver identifiers only for new materializations, constructs
 all final values/freshness/validity, applies timestamps, classifies transitions,
-authors required local entries, validates the complete graph+journal, and cuts
-over atomically. No computor runs and intermediate construction emits nothing.
+authors required local entries, validates the complete graph and both journals,
+and cuts over atomically. No computor runs and intermediate construction emits nothing.
 
 The value/presence classifier uses normative deep `isEqual` equality:
 
@@ -292,8 +295,8 @@ preserve both receiver timestamps and author no value event.
 Source timestamp differences are irrelevant. Freshness and validity-only changes
 preserve `modifiedAt`.
 
-This is journal-minimal subject to reset authority: absent and equal-value states
-author no value action; deletion authors only delete; each new or genuinely
+This is logical-journal-minimal subject to reset authority: absent and equal-value
+states author no value action; deletion authors only delete; each new or genuinely
 changed value authors exactly one add. The fresh generation for a changed value
 is required to supersede already-observed old-generation history structurally,
 rather than an attempt to replace receiver history by timestamp comparison.
@@ -535,9 +538,12 @@ Implementations and future changes MUST preserve the following lifecycle propert
 10. Tests and diagnostics SHOULD distinguish incompatibility, failed preconditions, corruption, and unsupported manipulation rather than using those terms interchangeably.
 11. New recovery, import, or restore behavior MUST be implemented as a Volodyslav-controlled lifecycle transition. Documentation alone MUST NOT redefine raw file manipulation as supported.
 12. Storage refactors MAY change physical artifacts without changing this specification, provided these lifecycle preconditions, transitions, and postconditions remain true.
-13. Existing-live reset MUST retain the receiving host's prior journal, MUST NOT
-    import the selected source journal, and may append only required local
-    transition entries.
+13. Existing-live reset MUST retain the receiving host's prior logical journal
+    and MUST NOT import source logical entries as graph authority. It may author
+    only the receiver-local logical transition entries required by reset.
+    Independently, it merges source notification records,
+    `journalRecordHighWatermark`, and `cursorCoverageFrontier` as specified by
+    the controlled-reset procedure.
 14. Absent-state self-restoration MUST restore the same host's current published clock and continue its counters without empty-graph classification.
 15. Raw cross-host copying of a live database remains unsupported; copied writer metadata does not establish ownership.
 

--- a/docs/specs/incremental-graph-journal-emission.md
+++ b/docs/specs/incremental-graph-journal-emission.md
@@ -8,11 +8,15 @@ Intermediate states do not emit. The graph mutation and every locally authored
 entry commit atomically; a reachable committed snapshot never contains one
 without the other.
 
-Before authoring, reserve one sequence per entry from the dedicated host-local
-journal-clock allocator. The allocator first observes the maximum sequence in
-the transaction's installed journal, then increments. Multiple entries receive
-distinct increasing sequences. Aborted reservations may leave gaps but are
-never reused; overflow is fatal.
+Before authoring, tentatively choose one sequence per entry from the dedicated
+host-local journal-clock allocator. The allocator first observes the maximum
+sequence in the transaction's installed journal, then increments. Multiple
+entries receive distinct increasing sequences. The entries and resulting
+allocator value become durable atomically. Published sequences are never reused,
+but a transaction that aborts before publication exposes no durable coordinate
+or allocator advancement, so its tentative sequence MAY be chosen later.
+Committed allocator progression MAY skip numbers and create harmless gaps.
+Overflow is fatal and wrapping is forbidden.
 
 Every `JournalEntry.time` is the actual wall-clock occurrence time of its
 journal event. For add/edit the occurrence is semantic creation/modification, so
@@ -75,7 +79,7 @@ migration `keep`/`override`, explicit `invalidate()`, and
 `create(..., "potentially-outdated")` require barriers, while an already-settled
 passive carry does not.
 
-The barrier carries the materialization's exact generation G. Its sequence is reserved from `localJournalClock` after observing the transaction snapshot and is greater than all history observed by the operation. Incoming-proof removal/reassertion, graph state, immutable barrier, notification record, allocators, high-watermark, and frontier commit atomically in the same darkroom batch. Each repeated explicit hard invalidation authors a fresh barrier: each call independently reasserts that the next pull must invoke the computor. Invalidation propagated by ordinary dependency mechanics may preserve complete validity proofs and continues to author only on its actual fresh→stale transition; such freshness-only propagation does not newly establish hard invalidation.
+The barrier carries the materialization's exact generation G. Its sequence is tentatively chosen from `localJournalClock` after observing the transaction snapshot and is greater than all history observed by the operation. Incoming-proof removal/reassertion, graph state, immutable barrier, notification record, allocators, high-watermark, and frontier commit atomically in the same darkroom batch. Each repeated explicit hard invalidation authors a fresh barrier: each call independently reasserts that the next pull must invoke the computor. Invalidation propagated by ordinary dependency mechanics may preserve complete validity proofs and continues to author only on its actual fresh→stale transition; such freshness-only propagation does not newly establish hard invalidation.
 
 ## Notification emission and synchronization coverage
 

--- a/docs/specs/incremental-graph-journal-migrations.md
+++ b/docs/specs/incremental-graph-journal-migrations.md
@@ -49,8 +49,10 @@ Any notification-relevant changed key not already covered by such a record gets
 one final-state record after the pre-migration high-watermark. Aborted inactive
 construction exposes no committed allocator advancement or durable coordinate,
 so either allocator MAY later select the same tentative number. Published
-logical and notification coordinates are never reused. Harmless gaps arise only
-when committed allocator progression skips numbers.
+logical and notification coordinates are never reused. When allocator behavior
+creates a harmless allocation-number gap, that gap arises from committed
+allocator progression skipping numbers. Notification compaction may
+independently leave holes among surviving coordinates.
 
 The closed classifier is not sufficient when migration hardens an already-stale
 cache. Whenever `keep` or `override` discards incoming proofs, explicit migration

--- a/docs/specs/incremental-graph-journal-migrations.md
+++ b/docs/specs/incremental-graph-journal-migrations.md
@@ -47,8 +47,10 @@ validity-only changes are silent. `Unchanged` is silent. Every authored logical
 entry uses the host logical clock and atomically appends its `(key,nodeName,bindings,time)` record.
 Any notification-relevant changed key not already covered by such a record gets
 one final-state record after the pre-migration high-watermark. Aborted inactive
-construction exposes no committed allocator advancement; reserved gaps are
-harmless and sequences are never reused after publication.
+construction exposes no committed allocator advancement or durable coordinate,
+so either allocator MAY later select the same tentative number. Published
+logical and notification coordinates are never reused. Harmless gaps arise only
+when committed allocator progression skips numbers.
 
 The closed classifier is not sufficient when migration hardens an already-stale
 cache. Whenever `keep` or `override` discards incoming proofs, explicit migration

--- a/docs/specs/incremental-graph-journal-sync.md
+++ b/docs/specs/incremental-graph-journal-sync.md
@@ -227,7 +227,7 @@ In every reachable snapshot, two admissible materializations with equal
 
 * Base case: an atomic add establishes G; an atomic edit names its resolved G.
   Each commits exactly its value and real `modifiedAt`, and one author never
-  reuses the sequence.
+  reuses a published sequence.
 * Local step: before authoring a changed value event E2, the allocator watermark
   is at least every observed sequence. Therefore E2 has a greater sequence than
   every observed same-G event E1. If E1 and E2 share wall time, E2 is still the

--- a/docs/specs/incremental-graph-journal-types.md
+++ b/docs/specs/incremental-graph-journal-types.md
@@ -236,14 +236,24 @@ Each writable host owns one persistent `localJournalClock: uint64`, protected
 by a dedicated allocator mutex. It is a journal-only Lamport-style clock, not a
 graph clock and not a per-node counter.
 
-1. Sequences are never reused, including after an aborted reservation.
-2. Importing or observing entries raises the allocator watermark to at least
+1. A sequence that becomes part of committed durable state is published and
+   is never reused. A tentative allocation in a transaction that aborts before
+   publication has no durable journal identity and MAY be selected again.
+2. The counter never moves backwards in committed state. Importing or observing
+   entries raises the allocator watermark to at least
    their maximum sequence.
 3. Allocation increments the watermark and uses the result.
 4. Consequently, if `E2` is authored after observing `E1`, then
    `E2.sequence > E1.sequence`.
 5. Concurrent authors may use the same sequence; author breaks the tie.
 6. Overflow is fatal and wrapping is forbidden.
+
+For example, if durable `localJournalClock` is 10, an aborted transaction may
+tentatively choose 11 and leave the durable clock at 10 through restart. A later
+transaction may validly publish 11 because the aborted choice never became a
+journal identity. The identical rule applies to `localJournalRecordClock`: an
+aborted tentative append sequence is reusable, while a committed
+`JournalIndex.appendSequence` is permanently non-reusable by its appender.
 
 ## Durable logical and notification journals
 
@@ -299,8 +309,15 @@ preserves that witness's time. Reset may copy the greatest merged same-key
 record's `(key,nodeName,bindings,time)` where no final logical witness is
 retained.
 
-Each writable host durably owns `localJournalRecordClock`. Sequences are never
-reused; gaps are harmless; overflow is fatal. Before appending after remote
+Each writable host durably owns `localJournalRecordClock`. Observing imported
+notification coordinates raises this allocator as required before a later local
+append. An append sequence
+that becomes part of committed durable state is published and is never reused;
+a tentative append that aborts before publication has no durable index and MAY
+be selected again. The counter never moves backwards in committed state. Gaps
+are harmless when committed allocator progression skips numbers; transient
+aborted choices need not create durable gaps. Overflow is fatal and wrapping is
+forbidden. Before appending after remote
 observation, the allocator is raised above every observed append sequence and
 the new index is `(incrementedClock,localFingerprint)`. Every local append is
 strictly greater than the current high-watermark. Concurrent equal numeric
@@ -326,7 +343,7 @@ notification multiplicity.
 
 At every supported commit: every logical ID and notification index names one
 immutable content; appenders are valid durable fingerprints and never reuse a
-sequence; both watermark and frontier are monotone; the local record clock
+published sequence; both watermark and frontier are monotone; the local record clock
 dominates every observed sequence required before its next append; each local
 notification-relevant transition has a same-key record after the old
 high-watermark; newly adopted cursor lineage is covered before its frontier

--- a/docs/specs/incremental-graph-journal-types.md
+++ b/docs/specs/incremental-graph-journal-types.md
@@ -314,9 +314,11 @@ notification coordinates raises this allocator as required before a later local
 append. An append sequence
 that becomes part of committed durable state is published and is never reused;
 a tentative append that aborts before publication has no durable index and MAY
-be selected again. The counter never moves backwards in committed state. Gaps
-are harmless when committed allocator progression skips numbers; transient
-aborted choices need not create durable gaps. Overflow is fatal and wrapping is
+be selected again. The counter never moves backwards in committed state.
+Allocation-number gaps caused by allocator behavior are harmless and arise only
+when committed allocator progression skips numbers; transient aborted choices
+need not create durable gaps. Compaction may independently leave holes in the
+surviving notification-coordinate set. Overflow is fatal and wrapping is
 forbidden. Before appending after remote
 observation, the allocator is raised above every observed append sequence and
 the new index is `(incrementedClock,localFingerprint)`. Every local append is

--- a/docs/specs/incremental-graph-locking-design.md
+++ b/docs/specs/incremental-graph-locking-design.md
@@ -342,10 +342,14 @@ release construction locks
 
 No path reverses this order. Exclusive synchronization, migration and reset keep
 their existing inactive-construction phases. The darkroom remains short: work is
-prepared first, allocator values are reserved under their mutex, and final graph,
+prepared first, allocator values are tentatively chosen under their mutex, and final graph,
 logical entries, notification records, high-watermark, and coverage frontier are
-committed atomically under darkroom finalization. Aborted reservations leave
-harmless gaps. This does not widen the darkroom or weaken dome/telescope
+committed atomically under darkroom finalization. A choice published by that
+commit is permanently non-reusable and committed counters never move backwards.
+An abort before publication exposes neither durable allocator advancement nor a
+durable coordinate, and a later transaction MAY choose that number. Harmless
+gaps are permitted only when committed allocator progression skips numbers.
+This does not widen the darkroom or weaken dome/telescope
 serialization.
 
 Validation reads the transaction-visible invalidate frontier and commits its

--- a/docs/specs/incremental-graph-locking-design.md
+++ b/docs/specs/incremental-graph-locking-design.md
@@ -342,15 +342,17 @@ release construction locks
 
 No path reverses this order. Exclusive synchronization, migration and reset keep
 their existing inactive-construction phases. The darkroom remains short: work is
-prepared first, allocator values are tentatively chosen under their mutex, and final graph,
-logical entries, notification records, high-watermark, and coverage frontier are
-committed atomically under darkroom finalization. A choice published by that
-commit is permanently non-reusable and committed counters never move backwards.
-An abort before publication exposes neither durable allocator advancement nor a
-durable coordinate, and a later transaction MAY choose that number. Harmless
-gaps are permitted only when committed allocator progression skips numbers.
-This does not widen the darkroom or weaken dome/telescope
-serialization.
+prepared first and allocator values are tentatively chosen under their mutex.
+The final graph, logical entries, notification records, `localJournalClock`,
+`localJournalRecordClock`, high-watermark, and coverage frontier are committed
+atomically under darkroom finalization. A choice published by that commit is
+permanently non-reusable and committed counters never move backwards. An abort
+before publication exposes neither durable allocator advancement nor a durable
+coordinate, and a later transaction MAY choose that number. Allocation-number
+gaps caused by allocator behavior are permitted only when committed allocator
+progression skips numbers; notification compaction may independently leave holes
+among surviving coordinates. This does not widen the darkroom or weaken
+dome/telescope serialization.
 
 Validation reads the transaction-visible invalidate frontier and commits its
 complete causal context with freshness. Hard invalidation similarly commits its

--- a/docs/specs/incremental-graph-synchronization.md
+++ b/docs/specs/incremental-graph-synchronization.md
@@ -415,15 +415,17 @@ multi-source associativity, order independence, or all-to-all communication,
 and it requires no repository, branch, or other transport-specific container.
 
 Controlled reset is not this merge algorithm. Existing-live reset does not join
-the selected source journal. It atomically reconciles only source semantic
-presence, values, freshness, and relowered validity, retaining receiver history
+the selected source logical journal as graph authority. It atomically reconciles
+source semantic presence, values, freshness, and relowered validity, retaining receiver history
 and identifiers for surviving keys. It authors add for absent-to-present, a
 fresh add generation above observed receiver history for unequal
 present-to-present, and delete for present-to-absent; equal values author nothing
 and preserve receiver timestamps. The changed-value generation boundary makes
 observed old-generation edits inapplicable before wall-time comparison.
-The complete lifecycle procedure and proof obligations are specified in the
-lifecycle specification.
+Independently, reset merges source notification records, record high-watermark,
+and cursor-coverage frontier under the notification-coverage rules, including
+when the semantic graph is already equal. The complete lifecycle procedure and
+proof obligations are specified in the lifecycle specification.
 
 ## Required traces
 
@@ -485,10 +487,15 @@ events use author as the deterministic tie-break.
 ### Value through a carrier
 
 A authors `(A,12,K,edit,t,generation=G)`. A → B imports that entry and value; B
-stores it once with a fresh local index. B → C transmits only the immutable
-entry, and C assigns its own index. All
-hosts derive `[t,12,A]`, so support referring to K survives physical movement.
-Neither B nor C emits edit.
+retains the logical entry's exact `(sequence=12,author=A)` identity. Any
+notification record traveling with it likewise retains its exact immutable
+`JournalIndex=(appendSequence,appender)` on B and C. Raw receipt is silent and
+does not cause an echo reappend. B → C transmits the same immutable logical
+entry and any retained notification record without renumbering either. All hosts
+derive `[t,12,A]`, so support referring to K survives physical movement. Neither
+B nor C emits edit. If ordinary notification-coverage reconciliation requires B
+or C to append evidence, that evidence is a new, independent receiver-owned
+`JournalRecord`, not a new index for the imported occurrence.
 
 ### Same-writer later edit
 


### PR DESCRIPTION
### Motivation
- Finish the remaining review findings from the journal-spec rollup by making verifier encoding identical to production, by removing stale per-carrier indexing assumptions, and by reconciling allocator/abort semantics across the spec.
- Restore precise controlled-reset wording now that logical and notification journals are separate so the spec is unambiguous about what reset imports and what it must retain.
- Remove stale cursor/token "authority" security phrasing and keep the established decision that cursors are canonical progress claims, not security capabilities.

### Description
- Make verifier `NodeKey` serialization byte-for-byte compatible with production `serializeNodeKey()` by combining UTF-16 surrogate pairs exactly as JavaScript, emitting compact JSON with properties in the `head` then `args` order, and emitting lowercase `\uXXXX` escapes for any lone UTF-16 surrogates; implementation lives in the verifier helper `js_compatible_string` and the `node_key` serializer used by the verifier and tests.  (see `backend/src/generators/incremental_graph/database/node_key.js` and `scripts/verify-journal-spec-model.py` adjustments).
- Add exhaustive cross-checked test vectors and a JS test harness so Python verifier vectors are verified against the real JavaScript `serializeNodeKey()`; vectors cover ASCII, `nøde`/`café`, quotes, backslashes, commas/pipes/colons, empty string, lone high surrogate, lone low surrogate, and a valid surrogate-pair (supplementary character), stored in `scripts/fixtures/node-key-serialization.json` and exercised by `backend/tests/node_key_serialization_fixture.test.js`.
- Replace stale multi-hop carrier prose with an A→B→C trace that explicitly preserves logical `JournalEntry` identity `(sequence,author)` and preserves any imported `JournalIndex=(appendSequence,appender)` immutably; raw receipt is silent and any later evidence appended for coverage is a new receiver-owned `JournalRecord` (change in `docs/specs/incremental-graph-synchronization.md`).
- Canonicalize allocator semantics so the durable publication boundary (commit) defines permanence: only published/committed sequences/indexes are permanently non-reusable while tentative/aborted choices have no durable identity and MAY be reused; updated and aligned language in `docs/specs/incremental-graph-journal-types.md`, `docs/specs/incremental-graph-journal-emission.md`, `docs/specs/incremental-graph-journal-migrations.md`, `docs/specs/incremental-graph-locking-design.md`, `docs/specs/incremental-graph-journal-emission.md`, and `docs/specs/incremental-graph-journal-sync.md`.
- Correct controlled-reset lifecycle invariant 13 to explicitly mean `logical journal` where intended, and state separately that reset merges notification records, `journalRecordHighWatermark`, and `cursorCoverageFrontier` (change in `docs/specs/database-lifecycle.md` and related reset prose in synchronization docs).
- Finish cursor/token terminology cleanup by auditing and removing security-flavored uses of "authority" for cursors/tokens while preserving legitimate uses of "authority" for logical graph authority, and prepare an updated concise PR #1417 description locally (attempted `gh pr edit` but remote GitHub edit failed due to authentication limitations in this environment).

### Deferred follow-up
- Efficient scan progress for empty filtered `possibleMaybeChanges()` polls is intentionally deferred to #1549.

### Testing
- Ran the model verifier: `scripts/verify-journal-spec-model.py` and observed full exhaustive checks pass (all bounded journal checks and componentwise coverage checks passed).
- Ran the nighttime locking verifier: `scripts/verify-nighttime-locking-model.py` and observed the nighttime locking checks pass.
- Ran the cross-check JS unit test `npx jest backend/tests/node_key_serialization_fixture.test.js --runInBand` and got a passing suite (1 suite, 9 tests passed), which confirms Python verifier vectors match `serializeNodeKey()` for difficult Unicode/surrogate cases.
- Ran project static checks and tests (`npm run static-analysis`, `npx jest` / `npm test`) as part of validation and observed no blocking failures in the touched areas; the only operational limitation encountered was inability to push the updated parent PR body because GitHub CLI authentication (`gh auth`) / `GH_TOKEN` is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a80c81f0f54832e9847e96768047235)